### PR TITLE
PressableBox is animated by default

### DIFF
--- a/lib/src/widgets/pressable/gesture_widget.dart
+++ b/lib/src/widgets/pressable/gesture_widget.dart
@@ -11,12 +11,12 @@ class PressableBox extends StatelessWidget {
     this.onLongPress,
     this.focusNode,
     this.autofocus = false,
-    this.unpressDelay = const Duration(milliseconds: 0),
+    this.unpressDelay = const Duration(milliseconds: 150),
     this.onFocusChange,
     this.behavior,
     required this.child,
     this.style,
-    this.animationDuration = const Duration(milliseconds: 0),
+    this.animationDuration = const Duration(milliseconds: 125),
     this.animationCurve = Curves.linear,
   });
 


### PR DESCRIPTION
## Describe your changes
- By default PressableBox is already animated

## Type of change
- **New feature** (non-breaking change which adds functionality)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works