### PR TITLE
Deprecate elevation helpers

### DIFF
--- a/lib/src/attributes/shadow/shadow_util.dart
+++ b/lib/src/attributes/shadow/shadow_util.dart
@@ -247,15 +247,37 @@ class ElevationUtility<T extends StyleAttribute>
   }
 
   // Convenience methods for common elevation values.
+
+  @Deprecated('Use pass int value to call() instead')
   T none() => call(0);
+
+  @Deprecated('Use pass int value to call() instead')
   T one() => call(1);
+
+  @Deprecated('Use pass int value to call() instead')
   T two() => call(2);
+
+  @Deprecated('Use pass int value to call() instead')
   T three() => call(3);
+
+  @Deprecated('Use pass int value to call() instead')
   T four() => call(4);
+
+  @Deprecated('Use pass int value to call() instead')
   T six() => call(6);
+
+  @Deprecated('Use pass int value to call() instead')
   T eight() => call(8);
+
+  @Deprecated('Use pass int value to call() instead')
   T nine() => call(9);
+
+  @Deprecated('Use pass int value to call() instead')
   T twelve() => call(12);
+
+  @Deprecated('Use pass int value to call() instead')
   T sixteen() => call(16);
+
+  @Deprecated('Use pass int value to call() instead')
   T twentyFour() => call(24);
 }


### PR DESCRIPTION
## Describe your changes

Deprecate helper utilities for elevations; this option is a bit redundant. The initial purpose was meant to offer some type safety, but the syntax is too verbose.

## Type of change
- **Chore** (updating grunt tasks etc; no production code change)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works