### PR TITLE
Removed type of FlexWidgetDecorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+- Improvements on border, and borderRadius utitlies.
+- Fixes issue [#179](https://github.com/conceptadev/mix/issues/179)
+
 ## 1.0.0-beta.3
 
 - Revamped Mix API for improved functionality and developer experience.

--- a/lib/src/core/decorator.dart
+++ b/lib/src/core/decorator.dart
@@ -23,8 +23,3 @@ abstract class WidgetDecorator<Self extends WidgetDecorator<Self>>
     extends Decorator<Self> {
   const WidgetDecorator({super.key});
 }
-
-abstract class FlexWidgetDecorator<Self extends FlexWidgetDecorator<Self>>
-    extends Decorator<Self> {
-  const FlexWidgetDecorator({super.key});
-}

--- a/lib/src/decorators/widget_decorators.dart
+++ b/lib/src/decorators/widget_decorators.dart
@@ -45,7 +45,7 @@ class VisibilityDecorator extends WidgetDecorator<VisibilityDecorator> {
       Visibility(key: key, visible: visible, child: child);
 }
 
-class FlexibleDecorator extends FlexWidgetDecorator<FlexibleDecorator>
+class FlexibleDecorator extends WidgetDecorator<FlexibleDecorator>
     with Mergeable<FlexibleDecorator> {
   final int? flex;
   final FlexFit? fit;


### PR DESCRIPTION
Closes #179 

## Describe your changes
Removed type of FlexWidgetDecorator as this is not needed, and Flexible can wrap different types of widgets

## Type of change
- **Bug fix** (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works