### PR TITLE
Remove function from Widget Tree

### DIFF
--- a/lib/src/utils/style_recipe.dart
+++ b/lib/src/utils/style_recipe.dart
@@ -5,7 +5,7 @@ abstract class StyleRecipe<T extends StyleRecipe<T>> {
 
   StyleRecipe<T> merge(covariant StyleRecipe<T>? other);
 
-  StyleRecipe<T> selectVariants(List<Variant> variants);
+  StyleRecipe<T> applyVariants(List<Variant> variants);
 
   StyleRecipe<T> copyWith();
 }

--- a/lib/src/widgets/pressable/pressable_widget.dart
+++ b/lib/src/widgets/pressable/pressable_widget.dart
@@ -154,54 +154,48 @@ class PressableWidgetState extends State<Pressable> {
 
     final onEnabled = currentStatus == WidgetStatus.enabled;
 
+    final focusableDetector = FocusableActionDetector(
+      enabled: onEnabled,
+      focusNode: _node,
+      autofocus: widget.autofocus,
+      onShowFocusHighlight: (v) => updateState(() => _focus = v),
+      onShowHoverHighlight: (v) => updateState(() => _hover = v),
+      onFocusChange: widget.onFocusChange,
+      child: WidgetStateNotifier(
+        data: WidgetStateData(
+          focus: _focus,
+          status: currentStatus,
+          state: currentGesture,
+          hover: _hover,
+        ),
+        child: widget.child,
+      ),
+    );
+
     return MergeSemantics(
       child: Semantics(
         enabled: onEnabled,
         button: true,
         focusable: onEnabled && _node.canRequestFocus,
         focused: _node.hasFocus,
-        child: _buildGestureDetector(
-            isDisabled: widget.disabled,
-            child: FocusableActionDetector(
-              enabled: onEnabled,
-              focusNode: _node,
-              autofocus: widget.autofocus,
-              onShowFocusHighlight: (v) => updateState(() => _focus = v),
-              onShowHoverHighlight: (v) => updateState(() => _hover = v),
-              onFocusChange: widget.onFocusChange,
-              child: WidgetStateNotifier(
-                data: WidgetStateData(
-                  focus: _focus,
-                  status: currentStatus,
-                  state: currentGesture,
-                  hover: _hover,
-                ),
-                child: widget.child,
+        child: widget.disabled
+            ? GestureDetector(
+                child: focusableDetector,
+              )
+            : GestureDetector(
+                onTapDown: (_) => updateState(() => _pressed = true),
+                onTapUp: (_) => handleUnpress(),
+                onTap: widget.onPressed,
+                onTapCancel: () => handleUnpress(),
+                onLongPressCancel: () =>
+                    updateState(() => _longpressed = false),
+                onLongPress: widget.onLongPress,
+                onLongPressStart: (_) => updateState(() => _longpressed = true),
+                onLongPressEnd: (_) => updateState(() => _longpressed = false),
+                behavior: widget.behavior,
+                child: focusableDetector,
               ),
-            )),
       ),
     );
-  }
-
-  GestureDetector _buildGestureDetector({
-    required bool isDisabled,
-    required Widget child,
-  }) {
-    return isDisabled
-        ? GestureDetector(
-            child: child,
-          )
-        : GestureDetector(
-            onTapDown: (_) => updateState(() => _pressed = true),
-            onTapUp: (_) => handleUnpress(),
-            onTap: widget.onPressed,
-            onTapCancel: () => handleUnpress(),
-            onLongPressCancel: () => updateState(() => _longpressed = false),
-            onLongPress: widget.onLongPress,
-            onLongPressStart: (_) => updateState(() => _longpressed = true),
-            onLongPressEnd: (_) => updateState(() => _longpressed = false),
-            behavior: widget.behavior,
-            child: child,
-          );
   }
 }


### PR DESCRIPTION
##### Issue ticket number

## Describe your changes
- Remove function from widget tree;
- Rename `StyleRecipe.selectVariants()` to  `StyleRecipe.applyVariants()`

## Type of change
- **Bug fix** (non-breaking change which fixes an issue)
- **New feature** (non-breaking change which adds functionality)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
