### PR TITLE
Fix more than one decorator on Flex widgets when decorators are used

### DIFF
--- a/lib/src/specs/flex/flex_widget.dart
+++ b/lib/src/specs/flex/flex_widget.dart
@@ -184,7 +184,13 @@ class FlexBox extends StyledWidget {
     return withMix(context, (mix) {
       return MixedBox(
         mix: mix,
-        child: MixedFlex(mix: mix, direction: direction, children: children),
+        child: Builder(
+          builder: (BuildContext context) => MixedFlex(
+            mix: MixData.inherited(context)!,
+            direction: direction,
+            children: children,
+          ),
+        ),
       );
     });
   }

--- a/test/src/specs/flex/flex_widget_test.dart
+++ b/test/src/specs/flex/flex_widget_test.dart
@@ -134,4 +134,30 @@ void main() {
       }
     },
   );
+
+  testWidgets(
+    'VBox should apply decorators only once',
+    (tester) async {
+      await tester.pumpMaterialApp(
+        HBox(
+          children: [
+            VBox(
+              style: Style(
+                flex.gap(10),
+                flexible.expanded(),
+              ),
+              children: const [
+                SizedBox(
+                  height: 10,
+                  width: 20,
+                ),
+              ],
+            ),
+          ],
+        ),
+      );
+
+      expect(find.byType(Flexible), findsOneWidget);
+    },
+  );
 }


### PR DESCRIPTION

## Describe your changes
- FlexBox doesn't duplicate the decorator anymore.

## Type of change

- **Bug fix** (non-breaking change which fixes an issue)
- **Test** (adding missing tests, refactoring tests; no production code change)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
