### PR TITLE
Removed SpacingDto all method

### DIFF
--- a/lib/src/attributes/spacing/spacing_dto.dart
+++ b/lib/src/attributes/spacing/spacing_dto.dart
@@ -30,8 +30,6 @@ class SpacingDto extends EdgeInsetsGeometryDto<SpacingDto> {
           end: end,
         );
 
-  const SpacingDto.all(double value);
-
   static SpacingDto from(EdgeInsetsGeometry edgeInsets) {
     if (edgeInsets is EdgeInsetsDirectional) {
       return SpacingDto._(

--- a/test/src/specs/container/box_util_test.dart
+++ b/test/src/specs/container/box_util_test.dart
@@ -13,7 +13,7 @@ void main() {
         maxHeight: 100,
       );
 
-      const spacing = SpacingDto.all(10);
+      const spacing = SpacingDto.only(top: 10, bottom: 10, left: 10, right: 10);
 
       final container = boxUtility.only(
         alignment: Alignment.center,


### PR DESCRIPTION
We cannot have the all method due to the directional comparison. Also all method was not setup correctly, and not been used by any utility.

## Type of change
- **Chore** (updating CI, tooling; no production code change)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
