### PR TITLE
Chore/consolidated spec widgets

### DIFF
--- a/.fvmrc
+++ b/.fvmrc
@@ -1,5 +1,5 @@
 {
-  "flutter": "stable",
+  "flutter": "3.10.6",
   "flavors": {
     "production": "stable",
     "beta": "beta",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,7 @@
     "source.fixAll": "explicit",
     "source.dcm.fixAll": "explicit"
   },
-  "dart.flutterSdkPath": ".fvm/versions/stable",
+  "dart.flutterSdkPath": ".fvm/versions/3.10.6",
   "search.exclude": {
     "**/.fvm/versions": true
   },

--- a/lib/src/core/styled_widget.dart
+++ b/lib/src/core/styled_widget.dart
@@ -39,20 +39,20 @@ abstract class StyledWidget extends StatelessWidget {
 
   /// Applies a mix of inherited and local styles to the widget.
   ///
-  /// Accepts a [BuildContext] and a [MixBuilder]. It computes the final style by
+  /// Accepts a [BuildContext] and a [MixData] builder. It computes the final style by
   /// merging the inherited style with the local style, then applies it to the widget.
   /// This method is typically used in the `build` method of widgets extending
   /// [StyledWidget] to provide the actual styled widget.
   Widget withMix(BuildContext context, Widget Function(MixData mix) builder) {
-    final inheritedMix = inherit ? MixData.inherited(context) : null;
+    final inheritedMix = inherit ? MixProvider.maybeOfInherited(context) : null;
 
-    final mixData = MixData.create(context, style);
+    final mix = style.of(context);
 
-    final mergedMixData = inheritedMix?.merge(mixData) ?? mixData;
+    final mergedMix = inheritedMix?.merge(mix) ?? mix;
 
     return MixProvider(
-      data: mergedMixData,
-      child: applyDecorators(mergedMixData, builder(mergedMixData)),
+      data: mergedMix,
+      child: applyDecorators(mergedMix, builder(mergedMix)),
     );
   }
 
@@ -98,61 +98,17 @@ class StyledWidgetBuilder extends StyledWidget {
   }
 }
 
-/// An abstract widget that applies custom styles with animations.
-///
-/// `AnimatedStyledWidget` extends [StyledWidget] to include animations in the
-/// style application process. This widget is designed to create animated effects
-/// on styles applied to Flutter widgets. It should be extended by more concrete
-/// widgets that implement specific animated styled behaviors.
-@Deprecated('Now you can just use an AnimatedStyle instead')
-abstract class AnimatedStyledWidget extends StyledWidget {
-  /// Creates an animated styled widget.
-  ///
-  /// This constructor initializes the widget with an optional [style], [inherit] flag,
-  /// animation [curve], and a required animation [duration]. The [curve] defines the
-  /// nature of the animation's progression and [duration] specifies the length of time
-  /// the animation will run.
-  ///
-  /// The [style] and [inherit] parameters are passed to the superclass [StyledWidget].
-  /// If [inherit] is true, the widget will merge its style with its nearest [StyledWidget]
-  /// ancestor's style.
-  ///
-  /// The [curve] parameter defaults to [Curves.linear], representing a steady animation
-  /// pace. The [duration] parameter is required and determines how long the animation
-  /// takes to complete.
-  const AnimatedStyledWidget({
+class MixBuilder extends StyledWidget {
+  const MixBuilder({
     super.key,
     super.inherit,
     super.style,
-    this.curve = Curves.linear,
-    required this.duration,
+    required this.builder,
     super.orderOfDecorators = const [],
   });
 
-  /// The curve used for the animation.
-  ///
-  /// Specifies how the animation speed transitions over the course of the [duration].
-  /// By default, it's set to [Curves.linear], indicating a uniform animation speed.
-  /// Custom curves can be provided to create different animation effects.
-  final Curve curve;
-
-  /// The duration of the animation.
-  ///
-  /// Determines the total time it takes for the animation to complete from start to end.
-  /// This duration is essential to control the speed and responsiveness of the animation.
-  final Duration duration;
-
-  // Note: The build method will be implemented in subclasses, where the animation logic
-  // will be applied based on the provided style, curve, and duration.
+  final Widget Function(MixData) builder;
 
   @override
-  Widget applyDecorators(MixData mix, Widget child) {
-    return RenderAnimatedDecorators(
-      mix: mix,
-      orderOfDecorators: orderOfDecorators,
-      duration: duration,
-      curve: curve,
-      child: child,
-    );
-  }
+  Widget build(BuildContext context) => withMix(context, builder);
 }

--- a/lib/src/deprecations.dart
+++ b/lib/src/deprecations.dart
@@ -548,8 +548,6 @@ final textBaseline = text.style.textBaseline;
 @Deprecated('Use borderRadius.circular instead')
 final squared = borderRadius.zero;
 
-
-
 // flexDirection
 @Deprecated('Use flexDirection instead')
 final flexDirection = flex.direction;

--- a/lib/src/factory/mix_provider.dart
+++ b/lib/src/factory/mix_provider.dart
@@ -3,8 +3,6 @@ import 'package:flutter/material.dart';
 import 'mix_provider_data.dart';
 import 'style_mix.dart';
 
-typedef MixBuilder = Widget Function(MixData mix);
-
 /// Provides [MixData] to the widget tree.
 class MixProvider extends InheritedWidget {
   /// Stores [MixData] and wraps a [child] widget.
@@ -13,6 +11,10 @@ class MixProvider extends InheritedWidget {
   /// Retrieves the nearest [MixData] from the widget tree. Returns null if not found.
   static MixData? maybeOf(BuildContext context) {
     return context.dependOnInheritedWidgetOfExactType<MixProvider>()?.data;
+  }
+
+  static MixData? maybeOfInherited(BuildContext context) {
+    return maybeOf(context)?.toInheritable();
   }
 
   /// Retrieves the nearest [MixData] from the widget tree. Throws if not found.

--- a/lib/src/factory/mix_provider_data.dart
+++ b/lib/src/factory/mix_provider_data.dart
@@ -7,7 +7,6 @@ import '../core/attributes_map.dart';
 import '../helpers/compare_mixin.dart';
 import '../theme/token_resolver.dart';
 import '../widgets/pressable/pressable_util.dart';
-import 'mix_provider.dart';
 import 'style_mix.dart';
 
 /// This class is used for encapsulating all [MixData] related operations.
@@ -44,13 +43,6 @@ class MixData with Comparable {
     );
   }
 
-  @internal
-  static MixData? inherited(BuildContext context) {
-    final inheritedMix = MixProvider.maybeOf(context);
-
-    return inheritedMix?.toInheritable();
-  }
-
   /// Alias for animation.isAnimated
   bool get isAnimated => animation != null;
 
@@ -71,11 +63,7 @@ class MixData with Comparable {
       (attr) => attr.isInheritable,
     );
 
-    return MixData._(
-      resolver: _tokenResolver,
-      attributes: AttributeMap(inheritableAttributes),
-      animation: animation,
-    );
+    return copyWith(attributes: AttributeMap(inheritableAttributes));
   }
 
   /// Finds and returns an [VisualAttribute] of type [A], or null if not found.
@@ -106,6 +94,18 @@ class MixData with Comparable {
       resolver: _tokenResolver,
       attributes: _attributes.merge(other._attributes),
       animation: other.animation ?? animation,
+    );
+  }
+
+  MixData copyWith({
+    AttributeMap? attributes,
+    AnimatedData? animation,
+    MixTokenResolver? resolver,
+  }) {
+    return MixData._(
+      resolver: resolver ?? _tokenResolver,
+      attributes: attributes ?? _attributes,
+      animation: animation ?? this.animation,
     );
   }
 

--- a/lib/src/factory/style_mix.dart
+++ b/lib/src/factory/style_mix.dart
@@ -243,6 +243,8 @@ class Style with Comparable {
   SpreadFunctionParams<Attribute, Style> get mix =>
       SpreadFunctionParams(addAttributes);
 
+  MixData of(BuildContext context) => MixData.create(context, this);
+
   /// Returns a `AnimatedStyle` from this `Style` with the provided [duration] and [curve].
   AnimatedStyle animate({Duration? duration, Curve? curve}) {
     return AnimatedStyle._(

--- a/lib/src/specs/container/box_widget.dart
+++ b/lib/src/specs/container/box_widget.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import '../../core/styled_widget.dart';
 import '../../deprecations.dart';
 import '../../factory/mix_provider.dart';
-import '../../factory/mix_provider_data.dart';
 import 'box_spec.dart';
 
 typedef StyledContainer = Box;
@@ -56,62 +55,22 @@ class Box extends StyledWidget {
     // This method uses `withMix` to get the `MixData` and then applies it to `MixedBox`,
     // effectively styling the [child].
     return withMix(context, (mix) {
+      final style = BoxSpec.of(mix);
+
       return mix.isAnimated
           ? AnimatedMixedBox(
-              mix: mix,
-              curve: mix.animation!.curve,
+              style: style,
               duration: mix.animation!.duration,
+              curve: mix.animation!.curve,
               child: child,
             )
-          : MixedBox(mix: mix, child: child);
+          : MixedBox(spec: style, child: child);
     });
   }
 }
 
-/// A widget that is responsible for rendering a [Container] with styling defined in `MixData`.
-///
-/// `MixedBox` is a critical component in the Mix, acting as the interpreter
-/// between abstract styling rules in `MixData` and concrete visual properties on a `Container`.
-/// It allows dynamic and flexible styling of child widgets based on the rules defined in the
-/// provided `MixData`. This widget is particularly useful in scenarios where the styling needs
-/// to adapt based on different conditions or contexts.
-///
-/// The [mix] parameter is the cornerstone of `MixedBox`. It encapsulates the styling rules
-/// that dictate how the child widget should be visually represented. If [mix] is null,
-/// `MixedBox` attempts to retrieve styling information from the nearest `MixProvider` in
-/// the widget tree, enabling style inheritance and theming capabilities.
-///
-/// The [child] parameter is the widget that will be styled by `MixedBox`. This child widget
-/// can be any Flutter widget, making `MixedBox` a way to add composable visual and layout widgets
-/// to the widget tree.
-///
-/// The [decoratorOrder] parameter provides a way to control the order in which [Decorators] are applied.
-/// This can be crucial when certain styling effects need to be prioritized over others.
-/// It defaults to an empty list, which implies a standard
-/// order of decoration.
-///
-/// See also:
-/// * [MixData], which holds the styling rules used by `MixedBox`.
-/// * [Container], the underlying widget that is used to apply the actual styling.
-/// * [MixProvider], which can provide inherited `MixData`.
 class MixedBox extends StatelessWidget {
-  /// Creates a `MixedBox` widget.
-  ///
-  /// The [mix] parameter holds styling rules. If null, styling is obtained from
-  /// the closest `MixProvider`. The [child] is the widget to be styled. The optional
-  /// [decoratorOrder] determines the order of style decorators on the child.
-  const MixedBox({required this.mix, super.key, this.child});
-
-  final Widget? child;
-  final MixData mix;
-  @override
-  Widget build(BuildContext context) {
-    return BoxSpecWidget(spec: BoxSpec.of(mix), child: child);
-  }
-}
-
-class BoxSpecWidget extends StatelessWidget {
-  const BoxSpecWidget({required this.spec, super.key, this.child});
+  const MixedBox({required this.spec, super.key, this.child});
 
   final Widget? child;
   final BoxSpec spec;
@@ -135,101 +94,56 @@ class BoxSpecWidget extends StatelessWidget {
   }
 }
 
-/// Animated version of [MixedBox] that gradually changes its values over a period of time.
-///
-/// The [AnimatedMixedBox] will automatically animate between the old and
-/// new `MixData` values of properties when they change using the provided curve and
-/// duration. Attributes that are null are not animated. Its child and
-/// descendants are not animated.
-///
-/// This class is useful for generating simple implicit transitions between
-/// different in a [MixedBox] with its internal [AnimatedContainer].
-///
-/// See also:
-/// * [MixData], which holds the styling and animation rules used by `AnimatedMixedBox`.
-/// * [AnimatedContainer], the Flutter equivalent widget.
-class AnimatedMixedBox extends StatelessWidget {
+class AnimatedMixedBox extends ImplicitlyAnimatedWidget {
   const AnimatedMixedBox({
-    required this.mix,
+    required this.style,
     super.key,
     this.child,
-    this.curve = Curves.linear,
-    required this.duration,
+    required super.duration,
+    super.curve = Curves.linear,
+    super.onEnd,
   });
 
   final Widget? child;
-  final Curve curve;
-  final Duration duration;
-  final MixData mix;
+  final BoxSpec style;
 
   @override
-  Widget build(BuildContext context) {
-    final spec = BoxSpec.of(mix);
-
-    // AnimatedContainer is utilized here to animate the transition of BoxSpec properties.
-    // Each property from the BoxSpec is applied to the AnimatedContainer, allowing the
-    // widget to animate changes smoothly over the specified duration and curve.
-    return AnimatedContainer(
-      alignment: spec.alignment,
-      padding: spec.padding,
-      decoration: spec.decoration,
-      foregroundDecoration: spec.foregroundDecoration,
-      width: spec.width,
-      height: spec.height,
-      constraints: spec.constraints,
-      margin: spec.margin,
-      transform: spec.transform,
-      transformAlignment: spec.transformAlignment,
-      clipBehavior: spec.clipBehavior ?? Clip.none,
-      curve: curve,
-      duration: duration,
-      child: child,
-    );
-  }
+  AnimatedWidgetBaseState<AnimatedMixedBox> createState() =>
+      _AnimatedBoxSpecWidgetState();
 }
 
-/// Animated version of [Box] that gradually changes its values over a period of time.
-///
-/// The [AnimatedBox] will automatically animate between the old and
-/// new style values of properties when they change using the provided curve and
-/// duration. Attributes that are null are not animated. Its child and
-/// descendants are not animated.
-///
-/// This class is useful for generating simple implicit transitions between
-/// different in a [Box] with by applying the [AnimatedMixedBox] to the child.
-///
-/// See also:
-/// * [MixData], which holds the styling and animation rules used by `AnimatedBox`.
-/// * [AnimatedMixedBox], which is responsible for applying the animated transitions to
-///   the styling properties.
-@Deprecated('Use Box now accepts an AnimatedStyle instead')
-class AnimatedBox extends AnimatedStyledWidget {
-  const AnimatedBox({
-    super.style,
-    super.key,
-    super.inherit,
-    this.child,
-    super.curve,
-    required super.duration,
-    super.orderOfDecorators = const [],
-  });
+class _AnimatedBoxSpecWidgetState
+    extends AnimatedWidgetBaseState<AnimatedMixedBox> {
+  BoxSpecTween? _boxSpec;
 
-  final Widget? child;
+  @override
+  // ignore: avoid-dynamic
+  void forEachTween(TweenVisitor<dynamic> visitor) {
+    _boxSpec = visitor(
+      _boxSpec,
+      widget.style,
+      // ignore: avoid-dynamic
+      (dynamic value) => BoxSpecTween(begin: value as BoxSpec),
+    ) as BoxSpecTween?;
+  }
 
   @override
   Widget build(BuildContext context) {
-    // The withMix method is used to apply the current styling context, retrieving
-    // the BoxSpecAttribute from the given Style. If no BoxSpecAttribute is found,
-    // a default, empty BoxSpec is used.
-    return withMix(context, (mix) {
-      // AnimatedMixedBox is responsible for applying the animated transition
-      // to the BoxSpec properties, providing a seamless and dynamic styling experience.
-      return AnimatedMixedBox(
-        mix: mix,
-        curve: curve,
-        duration: duration,
-        child: child,
-      );
-    });
+    final spec = _boxSpec?.evaluate(animation);
+
+    return Container(
+      alignment: spec?.alignment,
+      padding: spec?.padding,
+      decoration: spec?.decoration,
+      foregroundDecoration: spec?.foregroundDecoration,
+      width: spec?.width,
+      height: spec?.height,
+      constraints: spec?.constraints,
+      margin: spec?.margin,
+      transform: spec?.transform,
+      transformAlignment: spec?.transformAlignment,
+      clipBehavior: spec?.clipBehavior ?? Clip.none,
+      child: widget.child,
+    );
   }
 }

--- a/lib/src/specs/flex/flex_util.dart
+++ b/lib/src/specs/flex/flex_util.dart
@@ -96,7 +96,14 @@ class FlexSpecUtility<T extends SpecAttribute>
     return SpacingSideUtility((gap) => only(gap: gap));
   }
 
+  /// Shorthand for setting the direction to horizontal.
+  T row() => direction.horizontal();
+
+  /// Shorthand for setting the direction to vertical.
+  T column() => direction.vertical();
+
   /// Creates a `FlexSpecAttribute` with the specified properties.
+  @override
   T only({
     Axis? direction,
     MainAxisAlignment? mainAxisAlignment,
@@ -120,10 +127,4 @@ class FlexSpecUtility<T extends SpecAttribute>
       gap: gap,
     ));
   }
-
-  /// Shorthand for setting the direction to horizontal.
-  T row() => direction.horizontal();
-
-  /// Shorthand for setting the direction to vertical.
-  T column() => direction.vertical();
 }

--- a/lib/src/specs/flex/flex_widget.dart
+++ b/lib/src/specs/flex/flex_widget.dart
@@ -4,8 +4,8 @@ import 'package:flutter/widgets.dart';
 
 import '../../core/styled_widget.dart';
 import '../../deprecations.dart';
-import '../../factory/mix_provider_data.dart';
 import '../../factory/style_mix.dart';
+import '../container/box_spec.dart';
 import '../container/box_widget.dart';
 import 'flex_spec.dart';
 
@@ -43,7 +43,9 @@ class StyledFlex extends StyledWidget {
   @override
   Widget build(BuildContext context) {
     return withMix(context, (mix) {
-      return MixedFlex(mix: mix, direction: direction, children: children);
+      final spec = FlexSpec.of(mix);
+
+      return MixedFlex(spec: spec, direction: direction, children: children);
     });
   }
 }
@@ -51,14 +53,14 @@ class StyledFlex extends StyledWidget {
 class MixedFlex extends StatelessWidget {
   const MixedFlex({
     super.key,
-    required this.mix,
+    required this.spec,
     required this.children,
     required this.direction,
   });
 
   final List<Widget> children;
   final Axis direction;
-  final MixData mix;
+  final FlexSpec spec;
 
   List<Widget> _buildChildren(double? gap) {
     if (gap == null) return children;
@@ -74,7 +76,6 @@ class MixedFlex extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final spec = FlexSpec.of(mix);
     final gap = spec.gap;
 
     return Flex(
@@ -175,13 +176,12 @@ class FlexBox extends StyledWidget {
   @override
   Widget build(BuildContext context) {
     return withMix(context, (mix) {
+      final box = BoxSpec.of(mix);
+      final flex = FlexSpec.of(mix);
+
       return MixedBox(
-        mix: mix,
-        child: MixedFlex(
-          mix: mix.toInheritable(),
-          direction: direction,
-          children: children,
-        ),
+        spec: box,
+        child: MixedFlex(spec: flex, direction: direction, children: children),
       );
     });
   }

--- a/lib/src/specs/stack/stack_widget.dart
+++ b/lib/src/specs/stack/stack_widget.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/widgets.dart';
 
 import '../../core/styled_widget.dart';
-import '../../factory/mix_provider_data.dart';
+import '../container/box_spec.dart';
 import '../container/box_widget.dart';
 import 'stack_spec.dart';
 
@@ -32,32 +32,21 @@ class StyledStack extends StyledWidget {
   Widget build(BuildContext context) {
     // The withMix method applies the current styling context and creates a MixedStack.
     return withMix(context, (mix) {
-      return MixedStack(mix: mix, children: children);
+      final spec = StackSpec.of(mix);
+
+      return MixedStack(spec: spec, children: children);
     });
   }
 }
 
-/// [MixedStack] - A StatelessWidget that applies a given [MixData] to a Stack.
-///
-/// This widget is used to render a stack layout with the styling attributes defined in the `MixData`.
-/// It is particularly useful for creating layered UIs where each layer's position and styling
-/// can be controlled through a `Style`.
-///
-/// Parameters:
-///   - [mix]: The `MixData` representing the current styling context.
-///   - [key]: The key for the widget.
-///   - [children]: The list of widgets to stack.
 class MixedStack extends StatelessWidget {
-  const MixedStack({required this.mix, super.key, this.children});
+  const MixedStack({required this.spec, super.key, this.children});
 
   final List<Widget>? children;
-  final MixData mix;
+  final StackSpec spec;
 
   @override
   Widget build(BuildContext context) {
-    // Resolve the StackSpecAttribute from the mix to apply specific stack-related styles.
-    final spec = StackSpec.of(mix);
-
     // The Stack widget is used here, applying the resolved styles from StackSpec.
     return Stack(
       alignment: spec.alignment ?? _defaultStack.alignment,
@@ -96,9 +85,12 @@ class ZBox extends StyledWidget {
   Widget build(BuildContext context) {
     // The withMix method is used to apply the styling context to both the box and the stack.
     return withMix(context, (mix) {
+      final boxSpec = BoxSpec.of(mix);
+      final stackSpec = StackSpec.of(mix);
+
       return MixedBox(
-        mix: mix,
-        child: MixedStack(mix: mix.toInheritable(), children: children),
+        spec: boxSpec,
+        child: MixedStack(spec: stackSpec, children: children),
       );
     });
   }

--- a/lib/src/specs/text/text_spec.dart
+++ b/lib/src/specs/text/text_spec.dart
@@ -118,3 +118,11 @@ class TextSpec extends Spec<TextSpec> {
         directive,
       ];
 }
+
+class TextSpecTween extends Tween<TextSpec> {
+  TextSpecTween({TextSpec? begin, TextSpec? end})
+      : super(begin: begin, end: end);
+
+  @override
+  TextSpec lerp(double t) => begin!.lerp(end, t);
+}

--- a/lib/src/specs/text/text_widget.dart
+++ b/lib/src/specs/text/text_widget.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 
 import '../../core/styled_widget.dart';
-import '../../factory/mix_provider_data.dart';
 import 'text_spec.dart';
 
 /// [StyledText] - A styled widget for displaying text with a mix of styles.
@@ -51,18 +50,20 @@ class StyledText extends StyledWidget {
   @override
   Widget build(BuildContext context) {
     return withMix(context, (mix) {
+      final spec = TextSpec.of(mix);
+
       return mix.isAnimated
           ? AnimatedMixedText(
               text: text,
-              mix: mix,
-              curve: mix.animation!.curve,
-              duration: mix.animation!.duration,
+              spec: spec,
               semanticsLabel: semanticsLabel,
               locale: locale,
+              duration: mix.animation!.duration,
+              curve: mix.animation!.curve,
             )
           : MixedText(
               text: text,
-              mix: mix,
+              spec: spec,
               semanticsLabel: semanticsLabel,
               locale: locale,
             );
@@ -70,23 +71,10 @@ class StyledText extends StyledWidget {
   }
 }
 
-/// [MixedText] - A StatelessWidget for rendering text with styling defined in [MixData].
-///
-/// This widget applies the styling rules from `MixData` to a [Text] widget. It is
-/// used internally by [StyledText] to render text according to the specified styles.
-/// It offers granular control over various text properties like style, alignment,
-/// direction, and more, based on the attributes defined in the `MixData`.
-///
-/// Parameters:
-///   - [text]: The text string to display.
-///   - [mix]: The `MixData` representing the current styling context.
-///   - [semanticsLabel]: An optional semantics label for the text.
-///   - [locale]: The locale used for the text.
-///   - [key]: The key for the widget.
 class MixedText extends StatelessWidget {
   const MixedText({
     required this.text,
-    required this.mix,
+    required this.spec,
     this.semanticsLabel,
     this.locale,
     super.key,
@@ -95,13 +83,10 @@ class MixedText extends StatelessWidget {
   final String text;
   final String? semanticsLabel;
   final Locale? locale;
-  final MixData mix;
+  final TextSpec spec;
 
   @override
   Widget build(BuildContext context) {
-    // Resolve the TextSpec for styling properties.
-    final spec = TextSpec.of(mix);
-
     // The Text widget is used here, applying the resolved styles and properties from TextSpec.
     return Text(
       spec.directive?.apply(text) ?? text,
@@ -121,39 +106,8 @@ class MixedText extends StatelessWidget {
   }
 }
 
-class AnimatedMixedText extends StatelessWidget {
+class AnimatedMixedText extends ImplicitlyAnimatedWidget {
   const AnimatedMixedText({
-    required this.text,
-    required this.mix,
-    required this.curve,
-    required this.duration,
-    this.semanticsLabel,
-    this.locale,
-    super.key,
-  });
-
-  final String text;
-  final String? semanticsLabel;
-  final Locale? locale;
-  final MixData mix;
-  final Curve curve;
-  final Duration duration;
-
-  @override
-  Widget build(BuildContext context) {
-    final spec = TextSpec.of(mix);
-
-    return ImplicitlyMixedText(
-      text: text,
-      spec: spec,
-      semanticsLabel: semanticsLabel,
-      duration: duration,
-    );
-  }
-}
-
-class ImplicitlyMixedText extends ImplicitlyAnimatedWidget {
-  const ImplicitlyMixedText({
     required this.text,
     required this.spec,
     this.semanticsLabel,
@@ -169,12 +123,12 @@ class ImplicitlyMixedText extends ImplicitlyAnimatedWidget {
   final TextSpec spec;
 
   @override
-  AnimatedWidgetBaseState<ImplicitlyMixedText> createState() =>
-      _ImplicitlyMixedTextState();
+  AnimatedWidgetBaseState<AnimatedMixedText> createState() =>
+      _AnimatedMixedTextState();
 }
 
-class _ImplicitlyMixedTextState
-    extends AnimatedWidgetBaseState<ImplicitlyMixedText> {
+class _AnimatedMixedTextState
+    extends AnimatedWidgetBaseState<AnimatedMixedText> {
   TextSpecTween? _textSpecTween;
 
   @override
@@ -208,12 +162,4 @@ class _ImplicitlyMixedTextState
       textHeightBehavior: spec.textHeightBehavior,
     );
   }
-}
-
-class TextSpecTween extends Tween<TextSpec> {
-  TextSpecTween({TextSpec? begin, TextSpec? end})
-      : super(begin: begin, end: end);
-
-  @override
-  TextSpec lerp(double t) => begin!.lerp(end, t);
 }

--- a/lib/src/widgets/pressable/pressable_state.dart
+++ b/lib/src/widgets/pressable/pressable_state.dart
@@ -51,7 +51,7 @@ class PressableState extends InheritedModel<PressableStateAspect> {
     PressableStateAspect? aspect,
   ]) {
     final PressableState? result = maybeOf(context, aspect);
-    assert(result != null, 'Unable to find an instance of MyModel...');
+    assert(result != null, 'Unable to find an instance of PressableState...');
 
     return result!;
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.1"
   dart_code_metrics_presets:
     dependency: "direct dev"
     description:
@@ -75,30 +75,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  leak_tracker:
+  js:
     dependency: transitive
     description:
-      name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      name: js
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
-  leak_tracker_flutter_testing:
-    dependency: transitive
-    description:
-      name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.1"
-  leak_tracker_testing:
-    dependency: transitive
-    description:
-      name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.1"
+    version: "0.6.7"
   lints:
     dependency: transitive
     description:
@@ -111,34 +95,34 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.15"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.2.0"
   meta:
     dependency: "direct main"
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.9.1"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.8.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -148,26 +132,26 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.11.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
@@ -188,10 +172,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.5.1"
   vector_math:
     dependency: transitive
     description:
@@ -200,14 +184,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  vm_service:
-    dependency: transitive
-    description:
-      name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
-      url: "https://pub.dev"
-    source: hosted
-    version: "13.0.0"
 sdks:
-  dart: ">=3.2.0-0 <4.0.0"
+  dart: ">=3.0.0-0 <4.0.0"
   flutter: ">=3.10.6"

--- a/test/src/attributes/text_style/text_style_util_test.dart
+++ b/test/src/attributes/text_style/text_style_util_test.dart
@@ -10,7 +10,7 @@ import '../../../helpers/testing_utils.dart';
 void main() {
   group('TextStyleUtility', () {
     const textStyle = TextStyleUtility(UtilityTestAttribute.new);
-    test('call() creates TextStyleAttribute correctly', () {
+    test('call() creates TextStyleDto correctly', () {
       final yellowPaint = Paint()..color = Colors.yellow;
       final purplePaint = Paint()..color = Colors.purple;
       final attr = textStyle(
@@ -67,8 +67,7 @@ void main() {
       expect(resolvedValue.decoration, TextDecoration.underline);
       expect(resolvedValue.decorationColor, Colors.green);
       expect(resolvedValue.decorationStyle, TextDecorationStyle.dashed);
-      // expect(textStyleAttribute.value.foreground, yellowPaint);
-      // expect(textStyleAttribute.value.background, purplePaint);
+
       expect(resolvedValue.debugLabel, 'debugLabel');
       expect(resolvedValue.locale, const Locale('en', 'US'));
       expect(resolvedValue.height, 2.0);
@@ -76,70 +75,70 @@ void main() {
       expect(resolvedWithPaint.background, purplePaint);
     });
 
-    test('color() creates TextStyleAttribute correctly', () {
-      final textStyleAttribute = textStyle(color: Colors.red);
-      final resolvedValue = textStyleAttribute.value.resolve(EmptyMixData);
+    test('color() creates TextStyleDto correctly', () {
+      final attribute = textStyle(color: Colors.red);
+      final resolvedValue = attribute.value.resolve(EmptyMixData);
 
       expect(resolvedValue.color, Colors.red);
     });
 
-    test('backgroundColor() creates TextStyleAttribute correctly', () {
-      final textStyleAttribute = textStyle(backgroundColor: Colors.blue);
-      final resolvedValue = textStyleAttribute.value.resolve(EmptyMixData);
+    test('backgroundColor() creates TextStyleDto correctly', () {
+      final attribute = textStyle(backgroundColor: Colors.blue);
+      final resolvedValue = attribute.value.resolve(EmptyMixData);
 
       expect(resolvedValue.backgroundColor, Colors.blue);
     });
 
-    test('fontFamily() creates TextStyleAttribute correctly', () {
-      final textStyleAttribute = textStyle(fontFamily: 'Roboto');
-      final resolvedValue = textStyleAttribute.value.resolve(EmptyMixData);
+    test('fontFamily() creates TextStyleDto correctly', () {
+      final attribute = textStyle(fontFamily: 'Roboto');
+      final resolvedValue = attribute.value.resolve(EmptyMixData);
 
       expect(resolvedValue.fontFamily, 'Roboto');
     });
 
-    test('fontSize() creates TextStyleAttribute correctly', () {
-      final textStyleAttribute = textStyle(fontSize: 16.0);
-      final resolvedValue = textStyleAttribute.value.resolve(EmptyMixData);
+    test('fontSize() creates TextStyleDto correctly', () {
+      final attribute = textStyle(fontSize: 16.0);
+      final resolvedValue = attribute.value.resolve(EmptyMixData);
 
       expect(resolvedValue.fontSize, 16.0);
     });
 
-    test('fontWeight() creates TextStyleAttribute correctly', () {
-      final textStyleAttribute = textStyle.fontWeight.bold();
-      final resolvedValue = textStyleAttribute.value.resolve(EmptyMixData);
+    test('fontWeight() creates TextStyleDto correctly', () {
+      final attribute = textStyle.fontWeight.bold();
+      final resolvedValue = attribute.value.resolve(EmptyMixData);
 
       expect(resolvedValue.fontWeight, FontWeight.bold);
     });
 
-    test('fontStyle() creates TextStyleAttribute correctly', () {
-      final textStyleAttribute = textStyle.fontStyle.italic();
-      final resolvedValue = textStyleAttribute.value.resolve(EmptyMixData);
+    test('fontStyle() creates TextStyleDto correctly', () {
+      final attribute = textStyle.fontStyle.italic();
+      final resolvedValue = attribute.value.resolve(EmptyMixData);
 
       expect(resolvedValue.fontStyle, FontStyle.italic);
     });
 
-    test('letterSpacing() creates TextStyleAttribute correctly', () {
-      final textStyleAttribute = textStyle(letterSpacing: 1.0);
-      final resolvedValue = textStyleAttribute.value.resolve(EmptyMixData);
+    test('letterSpacing() creates TextStyleDto correctly', () {
+      final attribute = textStyle(letterSpacing: 1.0);
+      final resolvedValue = attribute.value.resolve(EmptyMixData);
 
       expect(resolvedValue.letterSpacing, 1.0);
     });
 
-    test('wordSpacing() creates TextStyleAttribute correctly', () {
-      final textStyleAttribute = textStyle(wordSpacing: 2.0);
-      final resolvedValue = textStyleAttribute.value.resolve(EmptyMixData);
+    test('wordSpacing() creates TextStyleDto correctly', () {
+      final attribute = textStyle(wordSpacing: 2.0);
+      final resolvedValue = attribute.value.resolve(EmptyMixData);
 
       expect(resolvedValue.wordSpacing, 2.0);
     });
 
-    test('textBaseline() creates TextStyleAttribute correctly', () {
-      final textStyleAttribute = textStyle.textBaseline.ideographic();
-      final resolvedValue = textStyleAttribute.value.resolve(EmptyMixData);
+    test('textBaseline() creates TextStyleDto correctly', () {
+      final attribute = textStyle.textBaseline.ideographic();
+      final resolvedValue = attribute.value.resolve(EmptyMixData);
 
       expect(resolvedValue.textBaseline, TextBaseline.ideographic);
     });
 
-    test('shadows() creates TextStyleAttribute correctly', () {
+    test('shadows() creates TextStyleDto correctly', () {
       const shadow = Shadow(
         color: Colors.black,
         offset: Offset(1.0, 1.0),
@@ -160,12 +159,12 @@ void main() {
       expect(resolved.shadows?.first, shadow);
     });
 
-    test('fontFeatures() creates TextStyleAttribute correctly', () {
-      final textStyleAttribute = textStyle.fontFeatures([
+    test('fontFeatures() creates TextStyleDto correctly', () {
+      final attribute = textStyle.fontFeatures([
         const FontFeature.alternative(4),
       ]);
 
-      final resolvedValue = textStyleAttribute.value.resolve(EmptyMixData);
+      final resolvedValue = attribute.value.resolve(EmptyMixData);
 
       expect(resolvedValue.fontFeatures?.length, 1);
       expect(
@@ -174,43 +173,43 @@ void main() {
       );
     });
 
-    test('decoration() creates TextStyleAttribute correctly', () {
-      final textStyleAttribute = textStyle.decoration.underline();
+    test('decoration() creates TextStyleDto correctly', () {
+      final attribute = textStyle.decoration.underline();
 
-      final resolvedValue = textStyleAttribute.value.resolve(EmptyMixData);
+      final resolvedValue = attribute.value.resolve(EmptyMixData);
 
       expect(resolvedValue.decoration, TextDecoration.underline);
     });
 
-    test('decorationColor() creates TextStyleAttribute correctly', () {
-      final textStyleAttribute = textStyle(decorationColor: Colors.green);
-      final resolvedValue = textStyleAttribute.value.resolve(EmptyMixData);
+    test('decorationColor() creates TextStyleDto correctly', () {
+      final attribute = textStyle(decorationColor: Colors.green);
+      final resolvedValue = attribute.value.resolve(EmptyMixData);
 
       expect(resolvedValue.decorationColor, Colors.green);
     });
 
-    test('decorationStyle() creates TextStyleAttribute correctly', () {
-      final textStyleAttribute = textStyle.decorationStyle.dashed();
+    test('decorationStyle() creates TextStyleDto correctly', () {
+      final attribute = textStyle.decorationStyle.dashed();
 
-      final resolvedValue = textStyleAttribute.value.resolve(EmptyMixData);
+      final resolvedValue = attribute.value.resolve(EmptyMixData);
 
       expect(resolvedValue.decorationStyle, TextDecorationStyle.dashed);
     });
 
-    test('foreground() creates TextStyleAttribute correctly', () {
+    test('foreground() creates TextStyleDto correctly', () {
       final yellowPaint = Paint()..color = Colors.yellow;
-      final textStyleAttribute = textStyle.foreground(yellowPaint);
+      final attribute = textStyle.foreground(yellowPaint);
 
-      final resolvedValue = textStyleAttribute.value.resolve(EmptyMixData);
+      final resolvedValue = attribute.value.resolve(EmptyMixData);
 
       expect(resolvedValue.foreground, yellowPaint);
     });
 
-    test('background() creates TextStyleAttribute correctly', () {
+    test('background() creates TextStyleDto correctly', () {
       final purplePaint = Paint()..color = Colors.purple;
-      final textStyleAttribute = textStyle.background(purplePaint);
+      final attribute = textStyle.background(purplePaint);
 
-      final resolvedValue = textStyleAttribute.value.resolve(EmptyMixData);
+      final resolvedValue = attribute.value.resolve(EmptyMixData);
 
       expect(resolvedValue.background, purplePaint);
     });

--- a/test/src/factory/mix_provider_data_test.dart
+++ b/test/src/factory/mix_provider_data_test.dart
@@ -115,7 +115,7 @@ void main() {
             Style(const _NonInheritableAttribute(), icon.color.black()),
           ),
           child: Builder(builder: (context) {
-            final inheritedMix = MixData.inherited(context);
+            final inheritedMix = MixProvider.maybeOfInherited(context);
             final iconSpec = IconSpec.of(inheritedMix!);
 
             expect(inheritedMix.attributes.length, 1);


### PR DESCRIPTION
Consolidated spec widgets, and removed redundant implementation. Now that the the decorators are part of the StyledWidget and StyledBuilder we can simplify the Mixed widgets to only accept the spec
## Type of change
- **Chore** (updating CI, tooling; no production code change)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
