### PR TITLE
Fix/multiconditions contextvariant

### DIFF
--- a/lib/src/attributes/variant_attribute.dart
+++ b/lib/src/attributes/variant_attribute.dart
@@ -35,17 +35,9 @@ class VariantAttribute extends StyleVariantAttribute<Variant> {
   }
 }
 
-mixin WhenVariant<T extends StyleVariant> on StyleVariantAttribute<T> {
-  bool when(BuildContext context);
-}
-
 @immutable
-class ContextVariantAttribute extends StyleVariantAttribute<ContextVariant>
-    with WhenVariant<ContextVariant> {
+class ContextVariantAttribute extends StyleVariantAttribute<ContextVariant> {
   const ContextVariantAttribute(super.variant, super.style);
-
-  @override
-  bool when(BuildContext context) => variant.when(context);
 
   @override
   ContextVariantAttribute merge(ContextVariantAttribute other) {
@@ -64,8 +56,7 @@ ArgumentError throwArgumentError<T extends StyleVariantAttribute>(T other) {
 }
 
 @immutable
-class MultiVariantAttribute extends StyleVariantAttribute<MultiVariant>
-    with WhenVariant<MultiVariant> {
+class MultiVariantAttribute extends StyleVariantAttribute<MultiVariant> {
   const MultiVariantAttribute(super.variant, super.style);
 
   // Remove all variants in given a list
@@ -84,9 +75,6 @@ class MultiVariantAttribute extends StyleVariantAttribute<MultiVariant>
       'Variant must be a Variant, ContextVariant, or MultiVariant',
     );
   }
-
-  @override
-  bool when(BuildContext context) => variant.when(context);
 
   @override
   MultiVariantAttribute merge(MultiVariantAttribute other) {

--- a/lib/src/factory/mix_provider_data.dart
+++ b/lib/src/factory/mix_provider_data.dart
@@ -122,25 +122,14 @@ List<StyleAttribute> applyContextToVisualAttributes(
 
   Style style = Style.create(builtAttributes);
 
-  final contextVariants = mix.variants.whereType<ContextVariantAttribute>();
-  final multiVariants = mix.variants.whereType<MultiVariantAttribute>();
+  final variantAttributes = mix.variants.whereType<StyleVariantAttribute>();
 
   // Once there are no more context variants to apply, return the mix
-  if (contextVariants.isEmpty && multiVariants.isEmpty) {
+  if (variantAttributes.isEmpty) {
     return style.styles.values;
   }
 
-  List<StyleVariantAttribute> contextVariantTypes = [];
-
-  for (ContextVariantAttribute attr in contextVariants) {
-    contextVariantTypes.add(attr);
-  }
-
-  for (MultiVariantAttribute attr in multiVariants) {
-    contextVariantTypes.add(attr);
-  }
-
-  for (final variant in contextVariantTypes) {
+  for (final variant in variantAttributes) {
     style = _applyVariants(context, style, variant);
   }
 

--- a/lib/src/factory/mix_provider_data.dart
+++ b/lib/src/factory/mix_provider_data.dart
@@ -118,18 +118,14 @@ List<StyleAttribute> applyContextToVisualAttributes(
   BuildContext context,
   Style mix,
 ) {
-  final builtAttributes = _applyStyleBuilder(context, mix.styles.values);
-
-  Style style = Style.create(builtAttributes);
-
-  final variantAttributes = mix.variants.whereType<StyleVariantAttribute>();
-
-  // Once there are no more context variants to apply, return the mix
-  if (variantAttributes.isEmpty) {
-    return style.styles.values;
+  if (mix.variants.isEmpty) {
+    return mix.styles.values;
   }
 
-  for (final variant in variantAttributes) {
+  final builtAttributes = _applyStyleBuilder(context, mix.styles.values);
+  Style style = Style.create(builtAttributes);
+
+  for (final variant in mix.variants.values) {
     style = _applyVariants(context, style, variant);
   }
 

--- a/lib/src/factory/mix_provider_data.dart
+++ b/lib/src/factory/mix_provider_data.dart
@@ -6,7 +6,6 @@ import '../core/attribute.dart';
 import '../core/attributes_map.dart';
 import '../helpers/compare_mixin.dart';
 import '../theme/token_resolver.dart';
-import '../widgets/pressable/pressable_util.dart';
 import 'style_mix.dart';
 
 /// This class is used for encapsulating all [MixData] related operations.
@@ -131,45 +130,31 @@ List<StyleAttribute> applyContextToVisualAttributes(
     return style.styles.values;
   }
 
-  List<WhenVariant> contextVariantTypes = [];
-  List<WhenVariant> pressableVariantTypes = [];
+  List<StyleVariantAttribute> contextVariantTypes = [];
 
   for (ContextVariantAttribute attr in contextVariants) {
-    if (attr.variant is PressableStateVariant) {
-      pressableVariantTypes.add(attr);
-    } else {
-      contextVariantTypes.add(attr);
-    }
+    contextVariantTypes.add(attr);
   }
 
   for (MultiVariantAttribute attr in multiVariants) {
-    if (attr.variant.variants
-        .any((variant) => variant is PressableStateVariant)) {
-      pressableVariantTypes.add(attr);
-    } else {
-      contextVariantTypes.add(attr);
-    }
+    contextVariantTypes.add(attr);
   }
 
-  for (WhenVariant variant in contextVariantTypes) {
-    style = _applyVariants(context, style, variant);
-  }
-
-  // Pressable Variants are applied after Context Variants
-  // As they take precedence over Context Variants from a styling perspective
-  for (WhenVariant variant in pressableVariantTypes) {
+  for (final variant in contextVariantTypes) {
     style = _applyVariants(context, style, variant);
   }
 
   return applyContextToVisualAttributes(context, style);
 }
 
-Style _applyVariants<T extends WhenVariant>(
+Style _applyVariants(
   BuildContext context,
   Style style,
-  T variant,
+  StyleVariantAttribute variantAttribute,
 ) {
-  return variant.when(context) ? style.merge(variant.value) : style;
+  return variantAttribute.variant.when(context)
+      ? style.merge(variantAttribute.value)
+      : style;
 }
 
 M? _mergeAttributes<M extends StyleAttribute>(Iterable<M> mergeables) {

--- a/lib/src/variants/variant.dart
+++ b/lib/src/variants/variant.dart
@@ -303,12 +303,23 @@ class MultiVariant extends StyleVariant {
   /// ```
   /// `isApplicable` will be true if either `contextVariantA` or `contextVariantB` is applicable in the given context.
   bool when(BuildContext context) {
-    final contextVariants = variants.whereType<ContextVariant>();
+    var resultArray = <bool>[];
+
+    for (final variant in variants) {
+      if (variant is MultiVariant) {
+        resultArray.add(variant.when(context));
+      }
+      if (variant is ContextVariant) {
+        resultArray.add(variant.when(context));
+      }
+      if (variant is Variant) {
+        resultArray.add(false);
+      }
+    }
 
     return operatorType == MultiVariantOperator.or
-        ? contextVariants.any((variant) => variant.when(context))
-        : contextVariants.length == variants.length &&
-            contextVariants.every((variant) => variant.when(context));
+        ? resultArray.fold(false, (v1, v2) => v1 || v2)
+        : resultArray.isNotEmpty && resultArray.every((e) => e);
   }
 
   /// Creates a new [MultiVariantAttribute] with the given [variant] and [style].

--- a/lib/src/variants/variant.dart
+++ b/lib/src/variants/variant.dart
@@ -347,11 +347,11 @@ class MultiVariant extends StyleVariant {
   /// `isApplicable` will be true if either `contextVariantA` or `contextVariantB` is applicable in the given context.
   @override
   bool when(BuildContext context) {
-    var resultArray = variants.map((e) => e.when(context));
+    var list = variants.map((e) => e.when(context));
 
     return operatorType == MultiVariantOperator.or
-        ? resultArray.fold(false, (v1, v2) => v1 || v2)
-        : resultArray.isNotEmpty && resultArray.every((e) => e);
+        ? list.contains(true)
+        : list.every((e) => e);
   }
 
   /// Determines if the current `MultiVariant` matches a set of provided variants.
@@ -374,9 +374,9 @@ class MultiVariant extends StyleVariant {
   bool matches(Iterable<StyleVariant> matchVariants) {
     final list = variants.map((e) => e.matches(matchVariants)).toList();
 
-    return operatorType == MultiVariantOperator.and
-        ? list.every((e) => e)
-        : list.contains(true);
+    return operatorType == MultiVariantOperator.or
+        ? list.contains(true)
+        : list.every((e) => e);
   }
 
   @override

--- a/lib/src/variants/variant.dart
+++ b/lib/src/variants/variant.dart
@@ -39,6 +39,8 @@ abstract class StyleVariant with Comparable {
   /// Returns true if this variant is present in the provided [matchVariants].
   bool matches(Iterable<StyleVariant> matchVariants) =>
       matchVariants.contains(this);
+
+  bool when(BuildContext context);
 }
 
 /// An immutable class representing a styling variant.
@@ -114,6 +116,9 @@ class Variant extends StyleVariant {
   }
 
   @override
+  bool when(BuildContext context) => false;
+
+  @override
   get props => [name];
 }
 
@@ -147,10 +152,11 @@ class ContextVariant extends StyleVariant {
   /// The [when] function takes a [BuildContext] and returns a boolean indicating whether
   /// the condition for this variant is met in the given context. This allows for dynamic
   /// styling changes based on runtime context conditions, such as theme brightness or screen size.
-  final bool Function(BuildContext context) when;
+
+  final bool Function(BuildContext context) whenBuilder;
 
   /// Constructs a `ContextVariant` with a given [name] and a context condition function [when].
-  const ContextVariant(this.when);
+  const ContextVariant(this.whenBuilder);
 
   /// Creates a new [ContextVariantAttribute] with the given [variant] and [style].
   ///
@@ -188,7 +194,10 @@ class ContextVariant extends StyleVariant {
   }
 
   @override
-  get props => [when];
+  bool when(BuildContext context) => whenBuilder(context);
+
+  @override
+  get props => [whenBuilder];
 }
 
 enum MultiVariantOperator { and, or }
@@ -287,41 +296,6 @@ class MultiVariant extends StyleVariant {
         : MultiVariant(updatedVariants, type: operatorType);
   }
 
-  /// Evaluates if the `MultiVariant` should be applied based on the build context.
-  ///
-  /// For `MultiVariantType.or`, it returns true if any of the context-aware variants (`ContextVariant`)
-  /// evaluates true in the given [context]. For `MultiVariantType.and`, it returns true only if all context-aware
-  /// variants evaluate true, and if all variants in the `MultiVariant` are context-aware.
-  ///
-  /// This method enables context-sensitive styling, allowing the application of styles based on runtime
-  /// conditions like screen size, orientation, or theme.
-  ///
-  /// Example:
-  /// ```dart
-  /// final combinedVariant = MultiVariant.or([contextVariantA, contextVariantB]);
-  /// bool isApplicable = combinedVariant.when(context);
-  /// ```
-  /// `isApplicable` will be true if either `contextVariantA` or `contextVariantB` is applicable in the given context.
-  bool when(BuildContext context) {
-    var resultArray = <bool>[];
-
-    for (final variant in variants) {
-      if (variant is MultiVariant) {
-        resultArray.add(variant.when(context));
-      }
-      if (variant is ContextVariant) {
-        resultArray.add(variant.when(context));
-      }
-      if (variant is Variant) {
-        resultArray.add(false);
-      }
-    }
-
-    return operatorType == MultiVariantOperator.or
-        ? resultArray.fold(false, (v1, v2) => v1 || v2)
-        : resultArray.isNotEmpty && resultArray.every((e) => e);
-  }
-
   /// Creates a new [MultiVariantAttribute] with the given [variant] and [style].
   ///
   /// This method is used to create a new [MultiVariantAttribute] instance with the given [variant] and [style].
@@ -354,6 +328,30 @@ class MultiVariant extends StyleVariant {
     ].whereType<Attribute>();
 
     return MultiVariantAttribute(this, Style.create(params));
+  }
+
+  /// Evaluates if the `MultiVariant` should be applied based on the build context.
+  ///
+  /// For `MultiVariantType.or`, it returns true if any of the context-aware variants (`ContextVariant`)
+  /// evaluates true in the given [context]. For `MultiVariantType.and`, it returns true only if all context-aware
+  /// variants evaluate true, and if all variants in the `MultiVariant` are context-aware.
+  ///
+  /// This method enables context-sensitive styling, allowing the application of styles based on runtime
+  /// conditions like screen size, orientation, or theme.
+  ///
+  /// Example:
+  /// ```dart
+  /// final combinedVariant = MultiVariant.or([contextVariantA, contextVariantB]);
+  /// bool isApplicable = combinedVariant.when(context);
+  /// ```
+  /// `isApplicable` will be true if either `contextVariantA` or `contextVariantB` is applicable in the given context.
+  @override
+  bool when(BuildContext context) {
+    var resultArray = variants.map((e) => e.when(context));
+
+    return operatorType == MultiVariantOperator.or
+        ? resultArray.fold(false, (v1, v2) => v1 || v2)
+        : resultArray.isNotEmpty && resultArray.every((e) => e);
   }
 
   /// Determines if the current `MultiVariant` matches a set of provided variants.

--- a/lib/src/widgets/pressable/pressable_util.dart
+++ b/lib/src/widgets/pressable/pressable_util.dart
@@ -10,22 +10,22 @@ import 'pressable_state.dart';
 /// Global context variants for handling common widget states and gestures.
 
 /// Applies styles when the widget is pressed.
-final onPressed = PressableStateVariant(
+final onPressed = ContextVariant(
   (context) => PressableState.pressedOf(context),
 );
 
 /// Applies styles when the widget is long pressed.
-final onLongPressed = PressableStateVariant(
+final onLongPressed = ContextVariant(
   (context) => PressableState.longPressedOf(context),
 );
 
 /// Applies styles when widget is hovered over.
-final onHover = PressableStateVariant(
+final onHover = ContextVariant(
   (context) => PressableState.hoveredOf(context),
 );
 
 /// Applies styles when the widget is disabled.
-final onEnabled = PressableStateVariant(
+final onEnabled = ContextVariant(
   (context) => PressableState.enabledOf(context),
 );
 
@@ -35,7 +35,7 @@ final onDisabled = onNot(onEnabled);
 const onMouseHover = OnMouseHoverBuilder.new;
 
 /// Applies styles when the widget has focus.dar
-const onFocused = PressableStateVariant(PressableState.focusedOf);
+const onFocused = ContextVariant(PressableState.focusedOf);
 
 const onPressedEvent = OnPressedEventBuilder.new;
 const onLongPressedEvent = OnLongPressedEventBuilder.new;
@@ -43,12 +43,6 @@ const onHoverEvent = OnHoverEventBuilder.new;
 const onEnabledEvent = OnEnabledEventBuilder.new;
 const onDisabledEvent = OnDisabledEventBuilder.new;
 const onFocusedEvent = OnFocusedEventBuilder.new;
-
-/// Helper class for creating widget state-based context variants.
-@immutable
-class PressableStateVariant extends ContextVariant {
-  const PressableStateVariant(super.when);
-}
 
 @immutable
 class OnDisabledEventBuilder

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.1"
+    version: "1.18.0"
   dart_code_metrics_presets:
     dependency: "direct dev"
     description:
@@ -75,14 +75,30 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  js:
+  leak_tracker:
     dependency: transitive
     description:
-      name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      name: leak_tracker
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.7"
+    version: "10.0.0"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   lints:
     dependency: transitive
     description:
@@ -95,34 +111,34 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.15"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.8.0"
   meta:
     dependency: "direct main"
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.11.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -132,26 +148,26 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
@@ -172,10 +188,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.6.1"
   vector_math:
     dependency: transitive
     description:
@@ -184,6 +200,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  vm_service:
+    dependency: transitive
+    description:
+      name: vm_service
+      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      url: "https://pub.dev"
+    source: hosted
+    version: "13.0.0"
 sdks:
-  dart: ">=3.0.0-0 <4.0.0"
+  dart: ">=3.2.0-0 <4.0.0"
   flutter: ">=3.10.6"

--- a/test/src/attributes/variant_attribute_test.dart
+++ b/test/src/attributes/variant_attribute_test.dart
@@ -98,7 +98,7 @@ void main() {
     test('when() returns correct instance', () {
       final variantAttribute = ContextVariantAttribute(variant, style);
 
-      final result = variantAttribute.when(MockBuildContext());
+      final result = variantAttribute.variant.when(MockBuildContext());
 
       expect(result, isTrue);
     });

--- a/test/src/factory/mix_provider_data_test.dart
+++ b/test/src/factory/mix_provider_data_test.dart
@@ -534,6 +534,7 @@ void _testApplyContextToVisualAttributes({
   required bool isExpectedToApply,
 }) {
   final style = Style(
+    box.color.black(),
     condition(
       icon.color.black(),
     ),
@@ -544,11 +545,12 @@ void _testApplyContextToVisualAttributes({
     style,
   );
 
-  final expectedStyle = Style(
-    icon.color.black(),
-  );
+  final expectedStyle = Style.create([
+    box.color.black(),
+    if (isExpectedToApply) icon.color.black(),
+  ]);
 
-  expect(attributeList, isExpectedToApply ? expectedStyle.styles.values : []);
+  expect(attributeList, expectedStyle.styles.values);
 }
 
 class _NonInheritableAttribute

--- a/test/src/factory/mix_provider_data_test.dart
+++ b/test/src/factory/mix_provider_data_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: non_constant_identifier_names
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mix/mix.dart';
@@ -5,128 +7,548 @@ import 'package:mix/mix.dart';
 import '../../helpers/testing_utils.dart';
 
 void main() {
-  final autoApplyVariant = ContextVariant((context) => true);
-  test('MixData create', () {
-    final mixData = MixData.create(
-      MockBuildContext(),
-      Style(
-        const MockIntScalarAttribute(1),
-        const MockStringScalarAttribute('test'),
-        const MockDoubleScalarAttribute(3.0),
-        const MockBooleanScalarAttribute(false),
-        autoApplyVariant(const MockDoubleScalarAttribute(2.0)),
-      ),
-    );
-
-    // Test that the `MixData` object is created with the correct properties.
-    expect(mixData, isInstanceOf<MixData>());
-
-    // Add any other additional assertions that are specific to your use case.
-    // If you become able to access properties _attributes and _resolver you would assert:
-    expect(mixData.attributes, isInstanceOf<AttributeMap>());
-    expect(mixData.tokens, isInstanceOf<MixTokenResolver>());
-    expect(mixData.attributes.length, 4);
-    expect(
-      mixData.attributeOf<MockIntScalarAttribute>(),
-      isInstanceOf<MockIntScalarAttribute>(),
-    );
-    expect(
-      mixData.attributeOf<MockStringScalarAttribute>(),
-      const MockStringScalarAttribute('test'),
-    );
-    expect(
-      mixData.attributeOf<MockStringScalarAttribute>(),
-      isInstanceOf<MockStringScalarAttribute>(),
-    );
-    expect(
-      mixData.attributeOf<MockDoubleScalarAttribute>(),
-      const MockDoubleScalarAttribute(2.0),
-    );
-
-    expect(
-      mixData.attributeOf<MockBooleanScalarAttribute>(),
-      const MockBooleanScalarAttribute(false),
-    );
-  });
-
-  test('MixData merge', () {
-    final mixData = MixData.create(
-      MockBuildContext(),
-      Style(
-        const MockIntScalarAttribute(1),
-        const MockStringScalarAttribute('test'),
-        const MockDoubleScalarAttribute(3.0),
-        const MockBooleanScalarAttribute(true),
-        autoApplyVariant(const MockDoubleScalarAttribute(2.0)),
-      ),
-    );
-
-    final mixData2 = MixData.create(
-      MockBuildContext(),
-      Style(
-        const MockDoubleScalarAttribute(5.0),
-        autoApplyVariant(const MockDoubleScalarAttribute(4.0)),
-      ),
-    );
-
-    final mergedMixData = mixData.merge(mixData2);
-
-    expect(mergedMixData, isInstanceOf<MixData>());
-    expect(mergedMixData.attributes.length, 4);
-    expect(
-      mergedMixData.attributeOf<MockIntScalarAttribute>(),
-      isInstanceOf<MockIntScalarAttribute>(),
-    );
-    expect(
-      mergedMixData.attributeOf<MockStringScalarAttribute>(),
-      isInstanceOf<MockStringScalarAttribute>(),
-    );
-    expect(
-      mergedMixData.attributeOf<MockDoubleScalarAttribute>(),
-      isInstanceOf<MockDoubleScalarAttribute>(),
-    );
-
-    expect(
-      mergedMixData.attributeOf<MockBooleanScalarAttribute>(),
-      const MockBooleanScalarAttribute(true),
-    );
-
-    expect(
-      mergedMixData.attributeOf<MockIntScalarAttribute>(),
-      const MockIntScalarAttribute(1),
-    );
-    expect(
-      mergedMixData.attributeOf<MockStringScalarAttribute>(),
-      const MockStringScalarAttribute('test'),
-    );
-    expect(
-      mergedMixData.attributeOf<MockDoubleScalarAttribute>(),
-      const MockDoubleScalarAttribute(4.0),
-    );
-  });
-
-  testWidgets(
-    'MixData.inherited shouldnt have attributes non inheritable',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(
-        MixProvider(
-          data: MixData.create(
-            MockBuildContext(),
-            Style(const _NonInheritableAttribute(), icon.color.black()),
-          ),
-          child: Builder(builder: (context) {
-            final inheritedMix = MixProvider.maybeOfInherited(context);
-            final iconSpec = IconSpec.of(inheritedMix!);
-
-            expect(inheritedMix.attributes.length, 1);
-            expect(iconSpec.color, Colors.black);
-
-            return const SizedBox();
-          }),
+  group('MixData', () {
+    final autoApplyVariant = ContextVariant((context) => true);
+    test('MixData create', () {
+      final mixData = MixData.create(
+        MockBuildContext(),
+        Style(
+          const MockIntScalarAttribute(1),
+          const MockStringScalarAttribute('test'),
+          const MockDoubleScalarAttribute(3.0),
+          const MockBooleanScalarAttribute(false),
+          autoApplyVariant(const MockDoubleScalarAttribute(2.0)),
         ),
       );
-    },
+
+      // Test that the `MixData` object is created with the correct properties.
+      expect(mixData, isInstanceOf<MixData>());
+
+      // Add any other additional assertions that are specific to your use case.
+      // If you become able to access properties _attributes and _resolver you would assert:
+      expect(mixData.attributes, isInstanceOf<AttributeMap>());
+      expect(mixData.tokens, isInstanceOf<MixTokenResolver>());
+      expect(mixData.attributes.length, 4);
+      expect(
+        mixData.attributeOf<MockIntScalarAttribute>(),
+        isInstanceOf<MockIntScalarAttribute>(),
+      );
+      expect(
+        mixData.attributeOf<MockStringScalarAttribute>(),
+        const MockStringScalarAttribute('test'),
+      );
+      expect(
+        mixData.attributeOf<MockStringScalarAttribute>(),
+        isInstanceOf<MockStringScalarAttribute>(),
+      );
+      expect(
+        mixData.attributeOf<MockDoubleScalarAttribute>(),
+        const MockDoubleScalarAttribute(2.0),
+      );
+
+      expect(
+        mixData.attributeOf<MockBooleanScalarAttribute>(),
+        const MockBooleanScalarAttribute(false),
+      );
+    });
+
+    test('MixData merge', () {
+      final mixData = MixData.create(
+        MockBuildContext(),
+        Style(
+          const MockIntScalarAttribute(1),
+          const MockStringScalarAttribute('test'),
+          const MockDoubleScalarAttribute(3.0),
+          const MockBooleanScalarAttribute(true),
+          autoApplyVariant(const MockDoubleScalarAttribute(2.0)),
+        ),
+      );
+
+      final mixData2 = MixData.create(
+        MockBuildContext(),
+        Style(
+          const MockDoubleScalarAttribute(5.0),
+          autoApplyVariant(const MockDoubleScalarAttribute(4.0)),
+        ),
+      );
+
+      final mergedMixData = mixData.merge(mixData2);
+
+      expect(mergedMixData, isInstanceOf<MixData>());
+      expect(mergedMixData.attributes.length, 4);
+      expect(
+        mergedMixData.attributeOf<MockIntScalarAttribute>(),
+        isInstanceOf<MockIntScalarAttribute>(),
+      );
+      expect(
+        mergedMixData.attributeOf<MockStringScalarAttribute>(),
+        isInstanceOf<MockStringScalarAttribute>(),
+      );
+      expect(
+        mergedMixData.attributeOf<MockDoubleScalarAttribute>(),
+        isInstanceOf<MockDoubleScalarAttribute>(),
+      );
+
+      expect(
+        mergedMixData.attributeOf<MockBooleanScalarAttribute>(),
+        const MockBooleanScalarAttribute(true),
+      );
+
+      expect(
+        mergedMixData.attributeOf<MockIntScalarAttribute>(),
+        const MockIntScalarAttribute(1),
+      );
+      expect(
+        mergedMixData.attributeOf<MockStringScalarAttribute>(),
+        const MockStringScalarAttribute('test'),
+      );
+      expect(
+        mergedMixData.attributeOf<MockDoubleScalarAttribute>(),
+        const MockDoubleScalarAttribute(4.0),
+      );
+    });
+
+    testWidgets(
+      'MixData.inherited shouldnt have attributes non inheritable',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(
+          MixProvider(
+            data: MixData.create(
+              MockBuildContext(),
+              Style(const _NonInheritableAttribute(), icon.color.black()),
+            ),
+            child: Builder(builder: (context) {
+              final inheritedMix = MixProvider.maybeOfInherited(context);
+              final iconSpec = IconSpec.of(inheritedMix!);
+
+              expect(inheritedMix.attributes.length, 1);
+              expect(iconSpec.color, Colors.black);
+
+              return const SizedBox();
+            }),
+          ),
+        );
+      },
+    );
+
+    group('applyContextToVisualAttributes', () {
+      test(
+          'must return the same Style that was inputted when there is not ContextVariant in the Style (simple variant)',
+          () {
+        final style = Style(
+          icon.color.black(),
+        );
+
+        final attributeList =
+            applyContextToVisualAttributes(MockBuildContext(), style);
+
+        expect(attributeList, style.styles.values);
+      });
+
+      test(
+          'must return the same Style that was inputted when is only Variants in the Style',
+          () {
+        _testApplyContextToVisualAttributes(
+          condition: MultiVariant.or(const [Variant('1'), Variant('2')]),
+          isExpectedToApply: false,
+        );
+
+        _testApplyContextToVisualAttributes(
+          condition: MultiVariant.and(const [Variant('1'), Variant('2')]),
+          isExpectedToApply: false,
+        );
+
+        _testApplyContextToVisualAttributes(
+          condition: MultiVariant.or([
+            const Variant('1'),
+            MultiVariant.or(const [Variant('2'), Variant('3')])
+          ]),
+          isExpectedToApply: false,
+        );
+
+        _testApplyContextToVisualAttributes(
+          condition: MultiVariant.or([
+            const Variant('1'),
+            MultiVariant.and(const [Variant('2'), Variant('3')])
+          ]),
+          isExpectedToApply: false,
+        );
+
+        _testApplyContextToVisualAttributes(
+          condition: MultiVariant.and([
+            const Variant('1'),
+            MultiVariant.or(const [Variant('2'), Variant('3')])
+          ]),
+          isExpectedToApply: false,
+        );
+
+        _testApplyContextToVisualAttributes(
+          condition: MultiVariant.and([
+            const Variant('1'),
+            MultiVariant.and(const [Variant('2'), Variant('3')])
+          ]),
+          isExpectedToApply: false,
+        );
+      });
+
+      group('must respect the condition', () {
+        test('with single ContextVariant', () {
+          _testApplyContextToVisualAttributes(
+            condition: ContextVariant((context) => false),
+            isExpectedToApply: false,
+          );
+
+          _testApplyContextToVisualAttributes(
+            condition: ContextVariant((context) => true),
+            isExpectedToApply: true,
+          );
+        });
+
+        test('with MultiVariant.or(ContextVariant, ContextVariant)', () {
+          void testCase(
+            bool v1,
+            bool v2, {
+            required bool equalsTo,
+          }) {
+            _testApplyContextToVisualAttributes(
+              condition: MultiVariant.or([
+                ContextVariant((context) => v1),
+                ContextVariant((context) => v2)
+              ]),
+              isExpectedToApply: equalsTo,
+            );
+          }
+
+          testCase(true, true, equalsTo: true);
+          testCase(true, false, equalsTo: true);
+          testCase(false, true, equalsTo: true);
+          testCase(false, false, equalsTo: false);
+        });
+
+        test('with MultiVariant.and(ContextVariant, ContextVariant)', () {
+          void testCase(
+            bool v1,
+            bool v2, {
+            required bool equalsTo,
+          }) {
+            _testApplyContextToVisualAttributes(
+              condition: MultiVariant.and([
+                ContextVariant((context) => v1),
+                ContextVariant((context) => v2)
+              ]),
+              isExpectedToApply: equalsTo,
+            );
+          }
+
+          testCase(true, true, equalsTo: true);
+          testCase(true, false, equalsTo: false);
+          testCase(false, true, equalsTo: false);
+          testCase(false, false, equalsTo: false);
+        });
+
+        test(
+            'with MultiVariant.and(MultiVariant.and(ContextVariant, ContextVariant), ContextVariant)',
+            () {
+          void testCase(
+            bool v1,
+            bool v2,
+            bool v3, {
+            required bool equalsTo,
+          }) {
+            _testApplyContextToVisualAttributes(
+              condition: MultiVariant.and([
+                ContextVariant((context) => v1),
+                MultiVariant.and([
+                  ContextVariant((context) => v2),
+                  ContextVariant((context) => v3)
+                ]),
+              ]),
+              isExpectedToApply: equalsTo,
+            );
+          }
+
+          testCase(true, true, true, equalsTo: true);
+          testCase(true, true, false, equalsTo: false);
+          testCase(true, false, true, equalsTo: false);
+          testCase(true, false, false, equalsTo: false);
+          testCase(false, true, true, equalsTo: false);
+          testCase(false, true, false, equalsTo: false);
+          testCase(false, false, true, equalsTo: false);
+          testCase(false, false, false, equalsTo: false);
+        });
+
+        test(
+            'with MultiVariant.or(MultiVariant.or(ContextVariant, ContextVariant), ContextVariant)',
+            () {
+          void testCase(
+            bool v1,
+            bool v2,
+            bool v3, {
+            required bool equalsTo,
+          }) {
+            _testApplyContextToVisualAttributes(
+              condition: MultiVariant.or([
+                ContextVariant((context) => v1),
+                MultiVariant.or([
+                  ContextVariant((context) => v2),
+                  ContextVariant((context) => v3)
+                ]),
+              ]),
+              isExpectedToApply: equalsTo,
+            );
+          }
+
+          testCase(true, true, true, equalsTo: true);
+          testCase(true, true, false, equalsTo: true);
+          testCase(true, false, true, equalsTo: true);
+          testCase(true, false, false, equalsTo: true);
+          testCase(false, true, true, equalsTo: true);
+          testCase(false, true, false, equalsTo: true);
+          testCase(false, false, true, equalsTo: true);
+          testCase(false, false, false, equalsTo: false);
+        });
+
+        test(
+            'with MultiVariant.and(MultiVariant.or(ContextVariant, ContextVariant), ContextVariant)',
+            () {
+          void testCase(
+            bool v1,
+            bool v2,
+            bool v3, {
+            required bool equalsTo,
+          }) {
+            _testApplyContextToVisualAttributes(
+              condition: MultiVariant.and([
+                ContextVariant((context) => v1),
+                MultiVariant.or([
+                  ContextVariant((context) => v2),
+                  ContextVariant((context) => v3)
+                ]),
+              ]),
+              isExpectedToApply: equalsTo,
+            );
+          }
+
+          testCase(true, true, true, equalsTo: true);
+          testCase(true, true, false, equalsTo: true);
+          testCase(true, false, true, equalsTo: true);
+          testCase(true, false, false, equalsTo: false);
+          testCase(false, true, true, equalsTo: false);
+          testCase(false, true, false, equalsTo: false);
+          testCase(false, false, true, equalsTo: false);
+          testCase(false, false, false, equalsTo: false);
+        });
+
+        test(
+            'with MultiVariant.or(MultiVariant.and(ContextVariant, ContextVariant), ContextVariant)',
+            () {
+          void testCase(
+            bool v1,
+            bool v2,
+            bool v3, {
+            required bool equalsTo,
+          }) {
+            _testApplyContextToVisualAttributes(
+              condition: MultiVariant.or([
+                ContextVariant((context) => v1),
+                MultiVariant.and([
+                  ContextVariant((context) => v2),
+                  ContextVariant((context) => v3)
+                ]),
+              ]),
+              isExpectedToApply: equalsTo,
+            );
+          }
+
+          testCase(true, true, true, equalsTo: true);
+          testCase(true, true, false, equalsTo: true);
+          testCase(true, false, true, equalsTo: true);
+          testCase(true, false, false, equalsTo: true);
+          testCase(false, true, true, equalsTo: true);
+          testCase(false, true, false, equalsTo: false);
+          testCase(false, false, true, equalsTo: false);
+          testCase(false, false, false, equalsTo: false);
+        });
+
+        test('with MultiVariant.or(Variant, ContextVariant)', () {
+          void testCase(
+            bool v1, {
+            required bool equalsTo,
+          }) {
+            _testApplyContextToVisualAttributes(
+              condition: MultiVariant.or([
+                const Variant('1'),
+                ContextVariant((context) => v1),
+              ]),
+              isExpectedToApply: equalsTo,
+            );
+          }
+
+          testCase(true, equalsTo: true);
+          testCase(false, equalsTo: false);
+        });
+
+        test('with MultiVariant.or(Variant, ContextVariant)', () {
+          void testCase(
+            bool v1, {
+            required bool equalsTo,
+          }) {
+            _testApplyContextToVisualAttributes(
+              condition: MultiVariant.or([
+                const Variant('1'),
+                ContextVariant((context) => v1),
+              ]),
+              isExpectedToApply: equalsTo,
+            );
+          }
+
+          testCase(true, equalsTo: true);
+          testCase(false, equalsTo: false);
+        });
+
+        test('with MultiVariant.and(Variant, ContextVariant)', () {
+          void testCase(
+            bool v1, {
+            required bool equalsTo,
+          }) {
+            _testApplyContextToVisualAttributes(
+              condition: MultiVariant.and([
+                const Variant('1'),
+                ContextVariant((context) => v1),
+              ]),
+              isExpectedToApply: equalsTo,
+            );
+          }
+
+          testCase(true, equalsTo: false);
+          testCase(false, equalsTo: false);
+        });
+
+        test(
+            'with MultiVariant.and(Variant, MultiVariant.and(Variant, ContextVariant))',
+            () {
+          void testCase(
+            bool v1, {
+            required bool equalsTo,
+          }) {
+            _testApplyContextToVisualAttributes(
+              condition: MultiVariant.and([
+                const Variant('1'),
+                MultiVariant.and([
+                  const Variant('2'),
+                  ContextVariant((context) => v1),
+                ]),
+              ]),
+              isExpectedToApply: equalsTo,
+            );
+          }
+
+          testCase(true, equalsTo: false);
+          testCase(false, equalsTo: false);
+        });
+
+        test(
+            'with MultiVariant.and(ContextVariant, MultiVariant.and(Variant, ContextVariant))',
+            () {
+          void testCase(
+            bool v1,
+            bool v2, {
+            required bool equalsTo,
+          }) {
+            _testApplyContextToVisualAttributes(
+              condition: MultiVariant.and([
+                ContextVariant((context) => v1),
+                MultiVariant.and([
+                  const Variant('1'),
+                  ContextVariant((context) => v2),
+                ]),
+              ]),
+              isExpectedToApply: equalsTo,
+            );
+          }
+
+          testCase(true, true, equalsTo: false);
+          testCase(true, false, equalsTo: false);
+          testCase(false, true, equalsTo: false);
+          testCase(false, false, equalsTo: false);
+        });
+
+        test(
+            'with MultiVariant.and(ContextVariant, MultiVariant.or(Variant, ContextVariant))',
+            () {
+          void testCase(
+            bool v1,
+            bool v2, {
+            required bool equalsTo,
+          }) {
+            _testApplyContextToVisualAttributes(
+              condition: MultiVariant.and([
+                ContextVariant((context) => v1),
+                MultiVariant.or([
+                  const Variant('1'),
+                  ContextVariant((context) => v2),
+                ]),
+              ]),
+              isExpectedToApply: equalsTo,
+            );
+          }
+
+          testCase(true, true, equalsTo: true);
+          testCase(true, false, equalsTo: false);
+          testCase(false, true, equalsTo: false);
+          testCase(false, false, equalsTo: false);
+        });
+
+        test(
+            'with MultiVariant.or(ContextVariant, MultiVariant.or(Variant, ContextVariant))',
+            () {
+          void testCase(
+            bool v1,
+            bool v2, {
+            required bool equalsTo,
+          }) {
+            _testApplyContextToVisualAttributes(
+              condition: MultiVariant.or([
+                ContextVariant((context) => v1),
+                MultiVariant.or([
+                  const Variant('1'),
+                  ContextVariant((context) => v2),
+                ]),
+              ]),
+              isExpectedToApply: equalsTo,
+            );
+          }
+
+          testCase(true, true, equalsTo: true);
+          testCase(true, false, equalsTo: true);
+          testCase(false, true, equalsTo: true);
+          testCase(false, false, equalsTo: false);
+        });
+      });
+    });
+  });
+}
+
+void _testApplyContextToVisualAttributes({
+  required dynamic condition,
+  required bool isExpectedToApply,
+}) {
+  final style = Style(
+    condition(
+      icon.color.black(),
+    ),
   );
+
+  final attributeList = applyContextToVisualAttributes(
+    MockBuildContext(),
+    style,
+  );
+
+  final expectedStyle = Style(
+    icon.color.black(),
+  );
+
+  expect(attributeList, isExpectedToApply ? expectedStyle.styles.values : []);
 }
 
 class _NonInheritableAttribute

--- a/test/src/factory/mix_provider_test.dart
+++ b/test/src/factory/mix_provider_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mix/mix.dart';
+
+import '../../helpers/testing_utils.dart';
+
+void main() {
+  group('MixProvider', () {
+    testWidgets('toInheritable()', (tester) async {
+      final style = Style(
+        icon.color.black(),
+        scale(2),
+      );
+
+      final mixData = MixData.create(
+        MockBuildContext(),
+        style,
+      );
+
+      final expectedMixData = MixData.create(
+        MockBuildContext(),
+        Style(
+          icon.color.black(),
+        ),
+      );
+
+      tester.pumpWidget(
+        MixProvider(
+          data: mixData,
+          child: Builder(
+            builder: (context) {
+              final inheritedMixData = MixProvider.of(context).toInheritable();
+              expect(inheritedMixData, expectedMixData);
+              return Container();
+            },
+          ),
+        ),
+      );
+    });
+  });
+}

--- a/test/src/variants/variant_test.dart
+++ b/test/src/variants/variant_test.dart
@@ -86,8 +86,8 @@ void main() {
       test(
           'MultiVariant.or with 2 PressableStateVariant (false & false) should return true',
           () {
-        final variant1 = PressableStateVariant((context) => false);
-        final variant2 = PressableStateVariant((context) => false);
+        final variant1 = ContextVariant((context) => false);
+        final variant2 = ContextVariant((context) => false);
         final multiVariant = MultiVariant.or([variant1, variant2]);
 
         final expectValue = multiVariant.when(MockBuildContext());
@@ -99,8 +99,8 @@ void main() {
       test(
           'MultiVariant.or with 2 PressableStateVariant (false & true) should return true',
           () {
-        final variant1 = PressableStateVariant((context) => false);
-        final variant2 = PressableStateVariant((context) => true);
+        final variant1 = ContextVariant((context) => false);
+        final variant2 = ContextVariant((context) => true);
         final multiVariant = MultiVariant.or([variant1, variant2]);
 
         final expectValue = multiVariant.when(MockBuildContext());
@@ -112,8 +112,8 @@ void main() {
       test(
           'MultiVariant.or with 2 PressableStateVariant (true & true) should return true',
           () {
-        final variant1 = PressableStateVariant((context) => true);
-        final variant2 = PressableStateVariant((context) => true);
+        final variant1 = ContextVariant((context) => true);
+        final variant2 = ContextVariant((context) => true);
         final multiVariant = MultiVariant.or([variant1, variant2]);
 
         final expectValue = multiVariant.when(MockBuildContext());
@@ -123,10 +123,10 @@ void main() {
       });
 
       test(
-          'MultiVariant.and with 2 PressableStateVariant (false & false) should return false',
+          'MultiVariant.and with 2 ContextVariant (false & false) should return false',
           () {
-        final variant1 = PressableStateVariant((context) => false);
-        final variant2 = PressableStateVariant((context) => false);
+        final variant1 = ContextVariant((context) => false);
+        final variant2 = ContextVariant((context) => false);
         final multiVariant = MultiVariant.and([variant1, variant2]);
 
         final expectValue = multiVariant.when(MockBuildContext());
@@ -136,10 +136,10 @@ void main() {
       });
 
       test(
-          'MultiVariant.and with 2 PressableStateVariant (false & true) should return false',
+          'MultiVariant.and with 2 ContextVariant (false & true) should return false',
           () {
-        final variant1 = PressableStateVariant((context) => false);
-        final variant2 = PressableStateVariant((context) => true);
+        final variant1 = ContextVariant((context) => false);
+        final variant2 = ContextVariant((context) => true);
         final multiVariant = MultiVariant.and([variant1, variant2]);
 
         final expectValue = multiVariant.when(MockBuildContext());
@@ -149,10 +149,10 @@ void main() {
       });
 
       test(
-          'MultiVariant.and with 2 PressableStateVariant (true & true) should return true',
+          'MultiVariant.and with 2 ContextVariant (true & true) should return true',
           () {
-        final variant1 = PressableStateVariant((context) => true);
-        final variant2 = PressableStateVariant((context) => true);
+        final variant1 = ContextVariant((context) => true);
+        final variant2 = ContextVariant((context) => true);
         final multiVariant = MultiVariant.and([variant1, variant2]);
 
         final expectValue = multiVariant.when(MockBuildContext());
@@ -161,7 +161,7 @@ void main() {
         expect(multiVariant.operatorType, MultiVariantOperator.and);
       });
 
-      test('Mv.or(v1, Mv.or(v2,v3)) with 3 PressableStateVariant', () {
+      test('Mv.or(v1, Mv.or(v2,v3)) with 3 ContextVariant', () {
         void testCase({
           required bool v1,
           required bool v2,
@@ -192,7 +192,7 @@ void main() {
         testCase(v1: false, v2: false, v3: false, expected: isFalse);
       });
 
-      test('Mv.and(v1, Mv.and(v2,v3)) with 3 PressableStateVariant', () {
+      test('Mv.and(v1, Mv.and(v2,v3)) with 3 ContextVariant', () {
         void testCase({
           required bool v1,
           required bool v2,
@@ -223,7 +223,7 @@ void main() {
         testCase(v1: false, v2: false, v3: false, expected: isFalse);
       });
 
-      test('Mv.or(v1, Mv.and(v2,v3)) with 3 PressableStateVariant', () {
+      test('Mv.or(v1, Mv.and(v2,v3)) with 3 ContextVariant', () {
         void testCase({
           required bool v1,
           required bool v2,
@@ -254,7 +254,7 @@ void main() {
         testCase(v1: false, v2: false, v3: false, expected: isFalse);
       });
 
-      test('Mv.and(v1, Mv.or(v2,v3)) with 3 PressableStateVariant', () {
+      test('Mv.and(v1, Mv.or(v2,v3)) with 3 ContextVariant', () {
         void testCase({
           required bool v1,
           required bool v2,
@@ -301,9 +301,9 @@ void _testWhenWithThreeVariants({
   required _ConditionBuilder condition,
   required Matcher expectedValue,
 }) {
-  final variant1 = PressableStateVariant((context) => v1);
-  final variant2 = PressableStateVariant((context) => v2);
-  final variant3 = PressableStateVariant((context) => v3);
+  final variant1 = ContextVariant((context) => v1);
+  final variant2 = ContextVariant((context) => v2);
+  final variant3 = ContextVariant((context) => v3);
 
   final multiVariant = condition(variant1, variant2, variant3);
 

--- a/test/src/variants/variant_test.dart
+++ b/test/src/variants/variant_test.dart
@@ -81,7 +81,235 @@ void main() {
       expect(multiVariant.variants, containsAll([variant1, variant2]));
       expect(multiVariant.operatorType, MultiVariantOperator.or);
     });
+
+    group('when', () {
+      test(
+          'MultiVariant.or with 2 PressableStateVariant (false & false) should return true',
+          () {
+        final variant1 = PressableStateVariant((context) => false);
+        final variant2 = PressableStateVariant((context) => false);
+        final multiVariant = MultiVariant.or([variant1, variant2]);
+
+        final expectValue = multiVariant.when(MockBuildContext());
+
+        expect(expectValue, isFalse);
+        expect(multiVariant.operatorType, MultiVariantOperator.or);
+      });
+
+      test(
+          'MultiVariant.or with 2 PressableStateVariant (false & true) should return true',
+          () {
+        final variant1 = PressableStateVariant((context) => false);
+        final variant2 = PressableStateVariant((context) => true);
+        final multiVariant = MultiVariant.or([variant1, variant2]);
+
+        final expectValue = multiVariant.when(MockBuildContext());
+
+        expect(expectValue, isTrue);
+        expect(multiVariant.operatorType, MultiVariantOperator.or);
+      });
+
+      test(
+          'MultiVariant.or with 2 PressableStateVariant (true & true) should return true',
+          () {
+        final variant1 = PressableStateVariant((context) => true);
+        final variant2 = PressableStateVariant((context) => true);
+        final multiVariant = MultiVariant.or([variant1, variant2]);
+
+        final expectValue = multiVariant.when(MockBuildContext());
+
+        expect(expectValue, isTrue);
+        expect(multiVariant.operatorType, MultiVariantOperator.or);
+      });
+
+      test(
+          'MultiVariant.and with 2 PressableStateVariant (false & false) should return false',
+          () {
+        final variant1 = PressableStateVariant((context) => false);
+        final variant2 = PressableStateVariant((context) => false);
+        final multiVariant = MultiVariant.and([variant1, variant2]);
+
+        final expectValue = multiVariant.when(MockBuildContext());
+
+        expect(expectValue, isFalse);
+        expect(multiVariant.operatorType, MultiVariantOperator.and);
+      });
+
+      test(
+          'MultiVariant.and with 2 PressableStateVariant (false & true) should return false',
+          () {
+        final variant1 = PressableStateVariant((context) => false);
+        final variant2 = PressableStateVariant((context) => true);
+        final multiVariant = MultiVariant.and([variant1, variant2]);
+
+        final expectValue = multiVariant.when(MockBuildContext());
+
+        expect(expectValue, isFalse);
+        expect(multiVariant.operatorType, MultiVariantOperator.and);
+      });
+
+      test(
+          'MultiVariant.and with 2 PressableStateVariant (true & true) should return true',
+          () {
+        final variant1 = PressableStateVariant((context) => true);
+        final variant2 = PressableStateVariant((context) => true);
+        final multiVariant = MultiVariant.and([variant1, variant2]);
+
+        final expectValue = multiVariant.when(MockBuildContext());
+
+        expect(expectValue, isTrue);
+        expect(multiVariant.operatorType, MultiVariantOperator.and);
+      });
+
+      test('Mv.or(v1, Mv.or(v2,v3)) with 3 PressableStateVariant', () {
+        void testCase({
+          required bool v1,
+          required bool v2,
+          required bool v3,
+          required Matcher expected,
+        }) {
+          _testWhenWithThreeVariants(
+            v1: v1,
+            v2: v2,
+            v3: v3,
+            condition: (v1, v2, v3) {
+              return MultiVariant.or([
+                v1,
+                MultiVariant.or([v2, v3]),
+              ]);
+            },
+            expectedValue: expected,
+          );
+        }
+
+        testCase(v1: true, v2: true, v3: true, expected: isTrue);
+        testCase(v1: true, v2: true, v3: false, expected: isTrue);
+        testCase(v1: true, v2: false, v3: true, expected: isTrue);
+        testCase(v1: true, v2: false, v3: false, expected: isTrue);
+        testCase(v1: false, v2: true, v3: true, expected: isTrue);
+        testCase(v1: false, v2: true, v3: false, expected: isTrue);
+        testCase(v1: false, v2: false, v3: true, expected: isTrue);
+        testCase(v1: false, v2: false, v3: false, expected: isFalse);
+      });
+
+      test('Mv.and(v1, Mv.and(v2,v3)) with 3 PressableStateVariant', () {
+        void testCase({
+          required bool v1,
+          required bool v2,
+          required bool v3,
+          required Matcher expected,
+        }) {
+          _testWhenWithThreeVariants(
+            v1: v1,
+            v2: v2,
+            v3: v3,
+            condition: (v1, v2, v3) {
+              return MultiVariant.and([
+                v1,
+                MultiVariant.and([v2, v3]),
+              ]);
+            },
+            expectedValue: expected,
+          );
+        }
+
+        testCase(v1: true, v2: true, v3: true, expected: isTrue);
+        testCase(v1: true, v2: true, v3: false, expected: isFalse);
+        testCase(v1: true, v2: false, v3: true, expected: isFalse);
+        testCase(v1: true, v2: false, v3: false, expected: isFalse);
+        testCase(v1: false, v2: true, v3: true, expected: isFalse);
+        testCase(v1: false, v2: true, v3: false, expected: isFalse);
+        testCase(v1: false, v2: false, v3: true, expected: isFalse);
+        testCase(v1: false, v2: false, v3: false, expected: isFalse);
+      });
+
+      test('Mv.or(v1, Mv.and(v2,v3)) with 3 PressableStateVariant', () {
+        void testCase({
+          required bool v1,
+          required bool v2,
+          required bool v3,
+          required Matcher expected,
+        }) {
+          _testWhenWithThreeVariants(
+            v1: v1,
+            v2: v2,
+            v3: v3,
+            condition: (v1, v2, v3) {
+              return MultiVariant.or([
+                v1,
+                MultiVariant.and([v2, v3]),
+              ]);
+            },
+            expectedValue: expected,
+          );
+        }
+
+        testCase(v1: true, v2: true, v3: true, expected: isTrue);
+        testCase(v1: true, v2: true, v3: false, expected: isTrue);
+        testCase(v1: true, v2: false, v3: true, expected: isTrue);
+        testCase(v1: true, v2: false, v3: false, expected: isTrue);
+        testCase(v1: false, v2: true, v3: true, expected: isTrue);
+        testCase(v1: false, v2: true, v3: false, expected: isFalse);
+        testCase(v1: false, v2: false, v3: true, expected: isFalse);
+        testCase(v1: false, v2: false, v3: false, expected: isFalse);
+      });
+
+      test('Mv.and(v1, Mv.or(v2,v3)) with 3 PressableStateVariant', () {
+        void testCase({
+          required bool v1,
+          required bool v2,
+          required bool v3,
+          required Matcher expected,
+        }) {
+          _testWhenWithThreeVariants(
+            v1: v1,
+            v2: v2,
+            v3: v3,
+            condition: (v1, v2, v3) {
+              return MultiVariant.and([
+                v1,
+                MultiVariant.or([v2, v3]),
+              ]);
+            },
+            expectedValue: expected,
+          );
+        }
+
+        testCase(v1: true, v2: true, v3: true, expected: isTrue);
+        testCase(v1: true, v2: true, v3: false, expected: isTrue);
+        testCase(v1: true, v2: false, v3: true, expected: isTrue);
+        testCase(v1: true, v2: false, v3: false, expected: isFalse);
+        testCase(v1: false, v2: true, v3: true, expected: isFalse);
+        testCase(v1: false, v2: true, v3: false, expected: isFalse);
+        testCase(v1: false, v2: false, v3: true, expected: isFalse);
+        testCase(v1: false, v2: false, v3: false, expected: isFalse);
+      });
+    });
   });
+}
+
+typedef _ConditionBuilder = MultiVariant Function(
+  StyleVariant v1,
+  StyleVariant v2,
+  StyleVariant v3,
+);
+
+void _testWhenWithThreeVariants({
+  required bool v1,
+  required bool v2,
+  required bool v3,
+  required _ConditionBuilder condition,
+  required Matcher expectedValue,
+}) {
+  final variant1 = PressableStateVariant((context) => v1);
+  final variant2 = PressableStateVariant((context) => v2);
+  final variant3 = PressableStateVariant((context) => v3);
+
+  final multiVariant = condition(variant1, variant2, variant3);
+
+  final expectValue = multiVariant.when(MockBuildContext());
+
+  expect(expectValue, expectedValue);
 }
 
 Widget _buildDefaultTestCase(Style style, List<Variant> variants) {

--- a/test/src/widgets/pressable/pressable_util_test.dart
+++ b/test/src/widgets/pressable/pressable_util_test.dart
@@ -21,7 +21,7 @@ void main() {
 
       final onPressAttr = onPressed(attribute1, attribute2, attribute3);
 
-      expect(onPressAttr.when(context), true);
+      expect(onPressAttr.variant.when(context), true);
       expect(onPressAttr.value, Style(attribute1, attribute2, attribute3));
 
       expect(onPressAttr.variant.when(context), true);
@@ -38,7 +38,7 @@ void main() {
 
       final onLongPressAttr = onLongPressed(attribute1, attribute2, attribute3);
 
-      expect(onLongPressAttr.when(context), true);
+      expect(onLongPressAttr.variant.when(context), true);
       expect(
         onLongPressAttr.value,
         Style(attribute1, attribute2, attribute3),
@@ -58,7 +58,6 @@ void main() {
 
       final onHoverAttr = onHover(attribute1, attribute2, attribute3);
 
-      expect(onHoverAttr.when(context), true);
       expect(onHoverAttr.value, Style(attribute1, attribute2, attribute3));
 
       expect(onHoverAttr.variant.when(context), true);
@@ -75,7 +74,6 @@ void main() {
 
       final onDisabledAttr = onDisabled(attribute1, attribute2, attribute3);
 
-      expect(onDisabledAttr.when(context), true);
       expect(
         onDisabledAttr.value,
         Style(attribute1, attribute2, attribute3),
@@ -96,7 +94,6 @@ void main() {
 
       final onEnabledAttr = onEnabled(attribute1, attribute2, attribute3);
 
-      expect(onEnabledAttr.when(context), true);
       expect(onEnabledAttr.value, Style(attribute1, attribute2, attribute3));
 
       expect(onEnabledAttr.variant.when(context), true);
@@ -114,7 +111,6 @@ void main() {
 
       final onFocusAttr = onFocused(attribute1, attribute2, attribute3);
 
-      expect(onFocusAttr.when(context), true);
       expect(onFocusAttr.value, Style(attribute1, attribute2, attribute3));
 
       expect(onFocusAttr.variant.when(context), true);

--- a/test/src/widgets/pressable/pressable_widget_test.dart
+++ b/test/src/widgets/pressable/pressable_widget_test.dart
@@ -233,6 +233,20 @@ void main() {
     });
 
     testWidgets(
+        'must restyle using attributes inside (onHover | onPressed | onLongPressed) when pressed',
+        (WidgetTester tester) async {
+      await pumpTestCase(
+        tester: tester,
+        duration: const Duration(milliseconds: 250),
+        condition: (onPressed | onHover | onLongPressed),
+        action: () async {
+          await tester.tap(find.byType(PressableBox));
+          await tester.pump();
+        },
+      );
+    });
+
+    testWidgets(
         'must restyle using attributes inside (onHover | onPressed) when hovered',
         (WidgetTester tester) async {
       await pumpTestCase(

--- a/test/src/widgets/pressable/pressable_widget_test.dart
+++ b/test/src/widgets/pressable/pressable_widget_test.dart
@@ -38,12 +38,12 @@ void main() {
       final secondNotifier = PressableState.of(secondContext);
       final thirdNotifier = PressableState.of(thirdContext);
 
-      expect(onEnabledAttr.when(firstContext), false);
+      expect(onEnabledAttr.variant.when(firstContext), false);
       expect(firstNotifier.disabled, true);
-      expect(onEnabledAttr.when(secondContext), false);
+      expect(onEnabledAttr.variant.when(secondContext), false);
       expect(secondNotifier.disabled, true);
 
-      expect(onEnabledAttr.when(thirdContext), true);
+      expect(onEnabledAttr.variant.when(thirdContext), true);
       expect(thirdNotifier.disabled, false);
     });
 


### PR DESCRIPTION
##### Issue ticket number

## Describe your changes
- Change the way context variants are applied. We have no more differences between `PressableStateVariant` and `ContextVariant`.
- Remove the PressableStateVariant `class`;
- Create more tests for the Variants feature, especially the `ContextVariants`;
## Type of change

- **Behavior change**
- **Test**

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
