### PR TITLE
Fix: Resolved conflict on generators when not configured on build.yaml

### DIFF
--- a/packages/mix/lib/src/core/spec.dart
+++ b/packages/mix/lib/src/core/spec.dart
@@ -8,7 +8,7 @@ import 'attribute.dart';
 import 'factory/mix_data.dart';
 
 @immutable
-abstract base class Spec<T extends Spec<T>> with EqualityMixin {
+abstract class Spec<T extends Spec<T>> with EqualityMixin {
   final AnimatedData? animated;
 
   const Spec({this.animated});
@@ -46,5 +46,5 @@ abstract base class SpecUtility<Attr extends Attribute,
   final Attr Function(Value) builder;
   const SpecUtility(this.builder);
 
-  Attr only({AnimatedDataDto? animated});
+  Attr only();
 }

--- a/packages/mix_generator/build.yaml
+++ b/packages/mix_generator/build.yaml
@@ -7,28 +7,26 @@ targets:
           exclude:
             - test
             - example
-          include:
-            - lib/**_spec.dart
       dto:
         enabled: true
         generate_for:
           exclude:
             - test
             - example
-          include:
-            - lib/**_dto.dart
 
 
 builders:
   spec:
     import: "package:mix_generator/mix_generator.dart"
     builder_factories: ["specDefinition"]
-    build_extensions: {".dart": [".g.dart"]}
+    build_extensions: {".dart": ["spec.g.part"]}
     auto_apply: dependents
-    build_to: source
+    build_to: cache
+    applies_builders: ["source_gen|combining_builder"]
   dto:
     import: "package:mix_generator/mix_generator.dart"
     builder_factories: ["dtoDefinition"]
-    build_extensions: {".dart": [".g.dart"]}
+    build_extensions: {".dart": ["dto.g.part"]}
     auto_apply: dependents
-    build_to: source
+    build_to: cache
+    applies_builders: ["source_gen|combining_builder"]

--- a/packages/mix_generator/lib/mix_generator.dart
+++ b/packages/mix_generator/lib/mix_generator.dart
@@ -3,16 +3,14 @@ import 'package:mix_generator/src/mixable_dto_generator.dart';
 import 'package:mix_generator/src/mixable_spec_generator.dart';
 import 'package:source_gen/source_gen.dart';
 
-Builder specDefinition(BuilderOptions options) => PartBuilder(
+Builder specDefinition(BuilderOptions options) => SharedPartBuilder(
       [MixableSpecGenerator()],
-      '.g.dart',
+      'spec',
       allowSyntaxErrors: true,
-      options: options,
     );
 
-Builder dtoDefinition(BuilderOptions options) => PartBuilder(
+Builder dtoDefinition(BuilderOptions options) => SharedPartBuilder(
       [MixableDtoGenerator()],
-      '.g.dart',
+      'dto',
       allowSyntaxErrors: true,
-      options: options,
     );


### PR DESCRIPTION
### Description

When not configuring to run each generator in a different file user ge4ts an error about conflict.

### Changes

Generators are now a shared resource to avoid conflict and to allow them to run simultaneously.

- Spec is no longer a 

**Review Checklist**

- [x] **Testing**: Have you tested your changes, including unit tests and integration tests for affected code?

### Impacted Packages
- [x] mix
- [ ] mix_lint
- [x] mix_generator
- [ ] documentation
