### PR TITLE
Fix: mix - Improved merge behavior between ShapeDecoration and BoxDecoration

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -18,4 +18,6 @@ scripts:
     run: melos exec --depends-on="build_runner" dart run build_runner clean
     description: Clean build_runner for projects that have it as a dependency
   fix:
-    run: dart fix --apply &&  melos exec --depends-on="dart_code_metrics_presets" dcm fix .
+    run: melos exec dart fix --apply . &&  melos exec --depends-on="dart_code_metrics_presets" dcm fix .
+  analyze:
+    run: melos exec --category="mix_deps" dart analyze . && melos exec --category="mix_deps" --depends-on="dart_code_metrics_presets" dcm analyze .

--- a/packages/mix/lib/src/attributes/border/border_dto.dart
+++ b/packages/mix/lib/src/attributes/border/border_dto.dart
@@ -75,10 +75,10 @@ class BoxBorderDto extends Dto<BoxBorder> {
   bool get isDirectional => _hasStartOrEnd && !_hasLeftOrRight;
 
   Type? checkMergeType(BoxBorderDto other) {
-    if (_hasLeftOrRight && !other._hasStartOrEnd) {
+    if (other._hasLeftOrRight || !other._hasStartOrEnd) {
       return Border;
     }
-    if (_hasStartOrEnd && !other._hasLeftOrRight) {
+    if (other._hasStartOrEnd || !other._hasLeftOrRight) {
       return BorderDirectional;
     }
 

--- a/packages/mix/lib/src/attributes/border/shape_border_dto.dart
+++ b/packages/mix/lib/src/attributes/border/shape_border_dto.dart
@@ -26,9 +26,7 @@ sealed class ShapeBorderDto<T extends ShapeBorder> extends Dto<T> {
     BorderSideDto? side,
     BorderRadiusGeometryDto? borderRadius,
     BoxShape? boxShape,
-  }) extract(
-    ShapeBorderDto? dto,
-  ) {
+  }) extract(ShapeBorderDto? dto) {
     return dto is OutlinedBorderDto
         ? (
             side: dto.side,
@@ -73,18 +71,6 @@ sealed class OutlinedBorderDto<T extends OutlinedBorder>
     return _exhaustiveMerge(a, b);
   }
 
-  BorderRadiusGeometryDto? get _borderRadius;
-
-  BoxShape? _toBoxShape() {
-    if (this is CircleBorderDto) {
-      return BoxShape.circle;
-    } else if (this is RoundedRectangleBorderDto) {
-      return BoxShape.rectangle;
-    }
-
-    return null;
-  }
-
   static OutlinedBorderDto _exhaustiveMerge(
     OutlinedBorderDto a,
     OutlinedBorderDto b,
@@ -116,6 +102,18 @@ sealed class OutlinedBorderDto<T extends OutlinedBorder>
         throw ArgumentError('Unknown OutlinedBorderDto type: ${b.runtimeType}');
     }
   }
+
+  BoxShape? _toBoxShape() {
+    if (this is CircleBorderDto) {
+      return BoxShape.circle;
+    } else if (this is RoundedRectangleBorderDto) {
+      return BoxShape.rectangle;
+    }
+
+    return null;
+  }
+
+  BorderRadiusGeometryDto? get _borderRadius;
 
   /// Tries to get borderRadius if available for [OutlineBorderDto]
 

--- a/packages/mix/lib/src/attributes/border/shape_border_dto.dart
+++ b/packages/mix/lib/src/attributes/border/shape_border_dto.dart
@@ -22,7 +22,22 @@ sealed class ShapeBorderDto<T extends ShapeBorder> extends Dto<T> {
     return OutlinedBorderDto.tryToMerge(a, b);
   }
 
-  BorderRadiusGeometryDto? get _borderRadius;
+  static ({
+    BorderSideDto? side,
+    BorderRadiusGeometryDto? borderRadius,
+    BoxShape? boxShape,
+  }) extract(
+    ShapeBorderDto? dto,
+  ) {
+    return dto is OutlinedBorderDto
+        ? (
+            side: dto.side,
+            borderRadius: dto._borderRadius,
+            boxShape: dto._toBoxShape(),
+          )
+        : (side: null, borderRadius: null, boxShape: null);
+  }
+
   BorderSideDto? get _side =>
       this is OutlinedBorderDto ? (this as OutlinedBorderDto).side : null;
 
@@ -56,6 +71,18 @@ sealed class OutlinedBorderDto<T extends OutlinedBorder>
     if (a == null) return b;
 
     return _exhaustiveMerge(a, b);
+  }
+
+  BorderRadiusGeometryDto? get _borderRadius;
+
+  BoxShape? _toBoxShape() {
+    if (this is CircleBorderDto) {
+      return BoxShape.circle;
+    } else if (this is RoundedRectangleBorderDto) {
+      return BoxShape.rectangle;
+    }
+
+    return null;
   }
 
   static OutlinedBorderDto _exhaustiveMerge(

--- a/packages/mix/lib/src/attributes/decoration/decoration_dto.dart
+++ b/packages/mix/lib/src/attributes/decoration/decoration_dto.dart
@@ -252,15 +252,19 @@ ShapeBorderDto? _fromBoxShape({
   required BorderSideDto? side,
   required BorderRadiusGeometryDto? borderRadius,
 }) {
-  if (shape == BoxShape.circle) {
-    return CircleBorderDto(side: side);
-  } else if (shape == BoxShape.rectangle) {
-    return RoundedRectangleBorderDto(borderRadius: borderRadius, side: side);
-  }
+  switch (shape) {
+    case BoxShape.circle:
+      return CircleBorderDto(side: side);
+    case BoxShape.rectangle:
+      return RoundedRectangleBorderDto(borderRadius: borderRadius, side: side);
+    default:
+      if (side != null || borderRadius != null) {
+        return RoundedRectangleBorderDto(
+          borderRadius: borderRadius,
+          side: side,
+        );
+      }
 
-  if (side != null || borderRadius != null) {
-    return RoundedRectangleBorderDto(borderRadius: borderRadius, side: side);
+      return null;
   }
-
-  return null;
 }

--- a/packages/mix/lib/src/attributes/decoration/decoration_dto.g.dart
+++ b/packages/mix/lib/src/attributes/decoration/decoration_dto.g.dart
@@ -18,17 +18,17 @@ base mixin _$BoxDecorationDto on Dto<BoxDecoration> {
   @override
   BoxDecoration resolve(MixData mix) {
     return BoxDecoration(
-      color: _$this.color?.resolve(mix) ?? defaultValue.color,
       border: _$this.border?.resolve(mix) ?? defaultValue.border,
       borderRadius:
           _$this.borderRadius?.resolve(mix) ?? defaultValue.borderRadius,
-      gradient: _$this.gradient?.resolve(mix) ?? defaultValue.gradient,
-      boxShadow: _$this.boxShadow?.map((e) => e.resolve(mix)).toList() ??
-          defaultValue.boxShadow,
       shape: _$this.shape ?? defaultValue.shape,
       backgroundBlendMode:
           _$this.backgroundBlendMode ?? defaultValue.backgroundBlendMode,
+      color: _$this.color?.resolve(mix) ?? defaultValue.color,
       image: _$this.image?.resolve(mix) ?? defaultValue.image,
+      gradient: _$this.gradient?.resolve(mix) ?? defaultValue.gradient,
+      boxShadow: _$this.boxShadow?.map((e) => e.resolve(mix)).toList() ??
+          defaultValue.boxShadow,
     );
   }
 
@@ -45,16 +45,16 @@ base mixin _$BoxDecorationDto on Dto<BoxDecoration> {
     if (other == null) return _$this;
 
     return BoxDecorationDto(
-      color: _$this.color?.merge(other.color) ?? other.color,
       border: _$this.border?.merge(other.border) ?? other.border,
       borderRadius:
           _$this.borderRadius?.merge(other.borderRadius) ?? other.borderRadius,
-      gradient: GradientDto.tryToMerge(_$this.gradient, other.gradient),
-      boxShadow: MixHelpers.mergeList(_$this.boxShadow, other.boxShadow),
       shape: other.shape ?? _$this.shape,
       backgroundBlendMode:
           other.backgroundBlendMode ?? _$this.backgroundBlendMode,
+      color: _$this.color?.merge(other.color) ?? other.color,
       image: _$this.image?.merge(other.image) ?? other.image,
+      gradient: GradientDto.tryToMerge(_$this.gradient, other.gradient),
+      boxShadow: MixHelpers.mergeList(_$this.boxShadow, other.boxShadow),
     );
   }
 
@@ -64,14 +64,14 @@ base mixin _$BoxDecorationDto on Dto<BoxDecoration> {
   /// compare two [BoxDecorationDto] instances for equality.
   @override
   List<Object?> get props => [
-        _$this.color,
         _$this.border,
         _$this.borderRadius,
-        _$this.gradient,
-        _$this.boxShadow,
         _$this.shape,
         _$this.backgroundBlendMode,
+        _$this.color,
         _$this.image,
+        _$this.gradient,
+        _$this.boxShadow,
       ];
 
   BoxDecorationDto get _$this => this as BoxDecorationDto;
@@ -83,9 +83,6 @@ base mixin _$BoxDecorationDto on Dto<BoxDecoration> {
 /// Use the methods of this class to configure specific properties of a [BoxDecorationDto].
 final class BoxDecorationUtility<T extends Attribute>
     extends DtoUtility<T, BoxDecorationDto, BoxDecoration> {
-  /// Utility for defining [BoxDecorationDto.color]
-  late final color = ColorUtility((v) => only(color: v));
-
   /// Utility for defining [BoxDecorationDto.border]
   late final border = BoxBorderUtility((v) => only(border: v));
 
@@ -99,6 +96,19 @@ final class BoxDecorationUtility<T extends Attribute>
   /// Utility for defining [BoxDecorationDto.borderRadius.directional]
   late final borderRadiusDirectional = borderRadius.directional;
 
+  /// Utility for defining [BoxDecorationDto.shape]
+  late final shape = BoxShapeUtility((v) => only(shape: v));
+
+  /// Utility for defining [BoxDecorationDto.backgroundBlendMode]
+  late final backgroundBlendMode =
+      BlendModeUtility((v) => only(backgroundBlendMode: v));
+
+  /// Utility for defining [BoxDecorationDto.color]
+  late final color = ColorUtility((v) => only(color: v));
+
+  /// Utility for defining [BoxDecorationDto.image]
+  late final image = DecorationImageUtility((v) => only(image: v));
+
   /// Utility for defining [BoxDecorationDto.gradient]
   late final gradient = GradientUtility((v) => only(gradient: v));
 
@@ -111,61 +121,51 @@ final class BoxDecorationUtility<T extends Attribute>
   /// Utility for defining [BoxDecorationDto.boxShadow]
   late final elevation = ElevationUtility((v) => only(boxShadow: v));
 
-  /// Utility for defining [BoxDecorationDto.shape]
-  late final shape = BoxShapeUtility((v) => only(shape: v));
-
-  /// Utility for defining [BoxDecorationDto.backgroundBlendMode]
-  late final backgroundBlendMode =
-      BlendModeUtility((v) => only(backgroundBlendMode: v));
-
-  /// Utility for defining [BoxDecorationDto.image]
-  late final image = DecorationImageUtility((v) => only(image: v));
-
   BoxDecorationUtility(super.builder) : super(valueToDto: (v) => v.toDto());
 
   /// Returns a new [BoxDecorationDto] with the specified properties.
   @override
   T only({
-    ColorDto? color,
     BoxBorderDto? border,
     BorderRadiusGeometryDto? borderRadius,
-    GradientDto? gradient,
-    List<BoxShadowDto>? boxShadow,
     BoxShape? shape,
     BlendMode? backgroundBlendMode,
+    ColorDto? color,
     DecorationImageDto? image,
+    GradientDto? gradient,
+    List<BoxShadowDto>? boxShadow,
   }) {
     return builder(BoxDecorationDto(
-      color: color,
       border: border,
       borderRadius: borderRadius,
-      gradient: gradient,
-      boxShadow: boxShadow,
       shape: shape,
       backgroundBlendMode: backgroundBlendMode,
+      color: color,
       image: image,
+      gradient: gradient,
+      boxShadow: boxShadow,
     ));
   }
 
   T call({
-    Color? color,
     BoxBorder? border,
     BorderRadiusGeometry? borderRadius,
-    Gradient? gradient,
-    List<BoxShadow>? boxShadow,
     BoxShape? shape,
     BlendMode? backgroundBlendMode,
+    Color? color,
     DecorationImage? image,
+    Gradient? gradient,
+    List<BoxShadow>? boxShadow,
   }) {
     return only(
-      color: color?.toDto(),
       border: border?.toDto(),
       borderRadius: borderRadius?.toDto(),
-      gradient: gradient?.toDto(),
-      boxShadow: boxShadow?.map((e) => e.toDto()).toList(),
       shape: shape,
       backgroundBlendMode: backgroundBlendMode,
+      color: color?.toDto(),
       image: image?.toDto(),
+      gradient: gradient?.toDto(),
+      boxShadow: boxShadow?.map((e) => e.toDto()).toList(),
     );
   }
 }
@@ -173,14 +173,14 @@ final class BoxDecorationUtility<T extends Attribute>
 extension BoxDecorationMixExt on BoxDecoration {
   BoxDecorationDto toDto() {
     return BoxDecorationDto(
-      color: color?.toDto(),
       border: border?.toDto(),
       borderRadius: borderRadius?.toDto(),
-      gradient: gradient?.toDto(),
-      boxShadow: boxShadow?.map((e) => e.toDto()).toList(),
       shape: shape,
       backgroundBlendMode: backgroundBlendMode,
+      color: color?.toDto(),
       image: image?.toDto(),
+      gradient: gradient?.toDto(),
+      boxShadow: boxShadow?.map((e) => e.toDto()).toList(),
     );
   }
 }
@@ -197,8 +197,9 @@ base mixin _$ShapeDecorationDto on Dto<ShapeDecoration> {
   @override
   ShapeDecoration resolve(MixData mix) {
     return ShapeDecoration(
-      color: _$this.color?.resolve(mix) ?? defaultValue.color,
       shape: _$this.shape?.resolve(mix) ?? defaultValue.shape,
+      color: _$this.color?.resolve(mix) ?? defaultValue.color,
+      image: _$this.image?.resolve(mix) ?? defaultValue.image,
       gradient: _$this.gradient?.resolve(mix) ?? defaultValue.gradient,
       shadows: _$this.shadows?.map((e) => e.resolve(mix)).toList() ??
           defaultValue.shadows,
@@ -218,8 +219,9 @@ base mixin _$ShapeDecorationDto on Dto<ShapeDecoration> {
     if (other == null) return _$this;
 
     return ShapeDecorationDto(
-      color: _$this.color?.merge(other.color) ?? other.color,
       shape: ShapeBorderDto.tryToMerge(_$this.shape, other.shape),
+      color: _$this.color?.merge(other.color) ?? other.color,
+      image: _$this.image?.merge(other.image) ?? other.image,
       gradient: GradientDto.tryToMerge(_$this.gradient, other.gradient),
       shadows: MixHelpers.mergeList(_$this.shadows, other.shadows),
     );
@@ -231,8 +233,9 @@ base mixin _$ShapeDecorationDto on Dto<ShapeDecoration> {
   /// compare two [ShapeDecorationDto] instances for equality.
   @override
   List<Object?> get props => [
-        _$this.color,
         _$this.shape,
+        _$this.color,
+        _$this.image,
         _$this.gradient,
         _$this.shadows,
       ];
@@ -246,11 +249,14 @@ base mixin _$ShapeDecorationDto on Dto<ShapeDecoration> {
 /// Use the methods of this class to configure specific properties of a [ShapeDecorationDto].
 final class ShapeDecorationUtility<T extends Attribute>
     extends DtoUtility<T, ShapeDecorationDto, ShapeDecoration> {
+  /// Utility for defining [ShapeDecorationDto.shape]
+  late final shape = ShapeBorderUtility((v) => only(shape: v));
+
   /// Utility for defining [ShapeDecorationDto.color]
   late final color = ColorUtility((v) => only(color: v));
 
-  /// Utility for defining [ShapeDecorationDto.shape]
-  late final shape = ShapeBorderUtility((v) => only(shape: v));
+  /// Utility for defining [ShapeDecorationDto.image]
+  late final image = DecorationImageUtility((v) => only(image: v));
 
   /// Utility for defining [ShapeDecorationDto.gradient]
   late final gradient = GradientUtility((v) => only(gradient: v));
@@ -263,28 +269,32 @@ final class ShapeDecorationUtility<T extends Attribute>
   /// Returns a new [ShapeDecorationDto] with the specified properties.
   @override
   T only({
-    ColorDto? color,
     ShapeBorderDto? shape,
+    ColorDto? color,
+    DecorationImageDto? image,
     GradientDto? gradient,
     List<BoxShadowDto>? shadows,
   }) {
     return builder(ShapeDecorationDto(
-      color: color,
       shape: shape,
+      color: color,
+      image: image,
       gradient: gradient,
       shadows: shadows,
     ));
   }
 
   T call({
-    Color? color,
     ShapeBorder? shape,
+    Color? color,
+    DecorationImage? image,
     Gradient? gradient,
     List<BoxShadow>? shadows,
   }) {
     return only(
-      color: color?.toDto(),
       shape: shape?.toDto(),
+      color: color?.toDto(),
+      image: image?.toDto(),
       gradient: gradient?.toDto(),
       shadows: shadows?.map((e) => e.toDto()).toList(),
     );
@@ -294,8 +304,9 @@ final class ShapeDecorationUtility<T extends Attribute>
 extension ShapeDecorationMixExt on ShapeDecoration {
   ShapeDecorationDto toDto() {
     return ShapeDecorationDto(
-      color: color?.toDto(),
       shape: shape.toDto(),
+      color: color?.toDto(),
+      image: image?.toDto(),
       gradient: gradient?.toDto(),
       shadows: shadows?.map((e) => e.toDto()).toList(),
     );

--- a/packages/mix/lib/src/attributes/text_style/text_style_dto.g.dart
+++ b/packages/mix/lib/src/attributes/text_style/text_style_dto.g.dart
@@ -135,7 +135,7 @@ base mixin _$TextStyleDto on Dto<TextStyle> {
     if (other == null) return _$this;
 
     return TextStyleDto._(
-      value: [...?_$this.value, ...?other.value],
+      value: [..._$this.value, ...other.value],
     );
   }
 

--- a/packages/mix/lib/src/attributes/text_style/text_style_dto.g.dart
+++ b/packages/mix/lib/src/attributes/text_style/text_style_dto.g.dart
@@ -135,7 +135,7 @@ base mixin _$TextStyleDto on Dto<TextStyle> {
     if (other == null) return _$this;
 
     return TextStyleDto._(
-      value: [..._$this.value, ...other.value],
+      value: [...?_$this.value, ...?other.value],
     );
   }
 

--- a/packages/mix/lib/src/specs/box/box_spec.dart
+++ b/packages/mix/lib/src/specs/box/box_spec.dart
@@ -35,11 +35,10 @@ const _boxDecor = MixableUtility(
 );
 
 const _shapeDecor = MixableUtility(
-    alias: 'shapeDecoration',
-    type: ShapeDecoration,
-    properties: [
-      (path: 'shape', alias: 'shape'),
-    ]);
+  alias: 'shapeDecoration',
+  type: ShapeDecoration,
+  properties: [(path: 'shape', alias: 'shape')],
+);
 
 @MixableSpec()
 final class BoxSpec extends Spec<BoxSpec> with _$BoxSpec {

--- a/packages/mix/lib/src/specs/box/box_spec.dart
+++ b/packages/mix/lib/src/specs/box/box_spec.dart
@@ -35,9 +35,11 @@ const _boxDecor = MixableUtility(
 );
 
 const _shapeDecor = MixableUtility(
-  alias: 'shapeDecoration',
-  type: ShapeDecoration,
-);
+    alias: 'shapeDecoration',
+    type: ShapeDecoration,
+    properties: [
+      (path: 'shape', alias: 'shape'),
+    ]);
 
 @MixableSpec()
 final class BoxSpec extends Spec<BoxSpec> with _$BoxSpec {

--- a/packages/mix/lib/src/specs/box/box_spec.g.dart
+++ b/packages/mix/lib/src/specs/box/box_spec.g.dart
@@ -315,6 +315,9 @@ base class BoxSpecUtility<T extends Attribute>
   late final shapeDecoration =
       ShapeDecorationUtility((v) => only(decoration: v));
 
+  /// Utility for defining [BoxSpecAttribute.shapeDecoration.shape]
+  late final shape = shapeDecoration.shape;
+
   /// Utility for defining [BoxSpecAttribute.foregroundDecoration]
   late final foregroundDecoration =
       BoxDecorationUtility((v) => only(foregroundDecoration: v));


### PR DESCRIPTION
Merge behavior for BoxDecorationDto and ShapeDecorationDto is much more flexible and attempts to merge so users can reuse utilities like borderRadius and boxShape.