### PR TITLE
fix: Gap resolve in flex attribute

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -24,7 +24,7 @@ scripts:
   brb:
     description: Run build_runner for projects that have it as a dependency
     steps:
-      - melos run build_runner_clean
+      - melos run brbc
       - melos exec --depends-on="build_runner" --category="mix_deps" dart run build_runner build --delete-conflicting-outputs
   brbc: 
     run: melos exec --depends-on="build_runner" dart run build_runner clean

--- a/packages/mix/lib/src/attributes/attributes.dart
+++ b/packages/mix/lib/src/attributes/attributes.dart
@@ -21,6 +21,8 @@ export 'constraints/constraints_dto.dart';
 export 'decoration/decoration_dto.dart';
 export 'decoration/image/decoration_image_dto.dart';
 export 'enum/enum_util.dart';
+export 'gap/gap_util.dart';
+export 'gap/spacing_side_dto.dart';
 export 'gradient/gradient_dto.dart';
 export 'nested_style/nested_style_attribute.dart';
 export 'nested_style/nested_style_util.dart';

--- a/packages/mix/lib/src/attributes/gap/gap_dto.dart
+++ b/packages/mix/lib/src/attributes/gap/gap_dto.dart
@@ -1,0 +1,24 @@
+import '../../core/dto.dart';
+import '../../core/factory/mix_data.dart';
+
+class GapDto extends Dto<double> {
+  final double? value;
+
+  const GapDto(this.value);
+
+  @override
+  GapDto merge(GapDto? other) {
+    return GapDto(other?.value ?? value);
+  }
+
+  @override
+  double resolve(MixData mix) {
+    return mix.tokens.spaceTokenRef(value ?? defaultValue);
+  }
+
+  @override
+  double get defaultValue => 0;
+
+  @override
+  List<Object?> get props => [value];
+}

--- a/packages/mix/lib/src/attributes/gap/gap_util.dart
+++ b/packages/mix/lib/src/attributes/gap/gap_util.dart
@@ -1,12 +1,13 @@
 import '../../core/attribute.dart';
 import '../../core/utility.dart';
 import '../../theme/tokens/space_token.dart';
-import 'gap_dto.dart';
+import 'spacing_side_dto.dart';
 
-final class GapUtility<T extends Attribute> extends MixUtility<T, GapDto> {
+final class GapUtility<T extends Attribute>
+    extends MixUtility<T, SpacingSideDto> {
   const GapUtility(super.builder);
 
-  T call(double value) => builder(GapDto(value));
+  T call(double value) => builder(SpacingSideDto(value));
 
-  T ref(SpaceToken ref) => builder(GapDto(ref()));
+  T ref(SpaceToken ref) => builder(SpacingSideDto(ref()));
 }

--- a/packages/mix/lib/src/attributes/gap/gap_util.dart
+++ b/packages/mix/lib/src/attributes/gap/gap_util.dart
@@ -1,0 +1,12 @@
+import '../../core/attribute.dart';
+import '../../core/utility.dart';
+import '../../theme/tokens/space_token.dart';
+import 'gap_dto.dart';
+
+final class GapUtility<T extends Attribute> extends MixUtility<T, GapDto> {
+  const GapUtility(super.builder);
+
+  T call(double value) => builder(GapDto(value));
+
+  T ref(SpaceToken ref) => builder(GapDto(ref()));
+}

--- a/packages/mix/lib/src/attributes/gap/spacing_side_dto.dart
+++ b/packages/mix/lib/src/attributes/gap/spacing_side_dto.dart
@@ -1,14 +1,14 @@
 import '../../core/dto.dart';
 import '../../core/factory/mix_data.dart';
 
-class GapDto extends Dto<double> {
+class SpacingSideDto extends Dto<double> {
   final double? value;
 
-  const GapDto(this.value);
+  const SpacingSideDto(this.value);
 
   @override
-  GapDto merge(GapDto? other) {
-    return GapDto(other?.value ?? value);
+  SpacingSideDto merge(SpacingSideDto? other) {
+    return SpacingSideDto(other?.value ?? value);
   }
 
   @override

--- a/packages/mix/lib/src/specs/flex/flex_spec.dart
+++ b/packages/mix/lib/src/specs/flex/flex_spec.dart
@@ -3,6 +3,9 @@ import 'package:flutter/widgets.dart';
 import 'package:mix/mix.dart';
 import 'package:mix_annotations/mix_annotations.dart';
 
+import '../../attributes/gap/gap_dto.dart';
+import '../../attributes/gap/gap_util.dart';
+
 part 'flex_spec.g.dart';
 
 @MixableSpec()
@@ -25,7 +28,10 @@ final class FlexSpec extends Spec<FlexSpec> with _$FlexSpec {
   final TextDirection? textDirection;
   final TextBaseline? textBaseline;
   final Clip? clipBehavior;
-  @MixableProperty(utilities: [MixableUtility(type: SpacingSideUtility)])
+  @MixableProperty(
+    dto: MixableFieldDto(type: GapDto),
+    utilities: [MixableUtility(type: GapUtility)],
+  )
   final double? gap;
 
   static const of = _$FlexSpec.of;

--- a/packages/mix/lib/src/specs/flex/flex_spec.dart
+++ b/packages/mix/lib/src/specs/flex/flex_spec.dart
@@ -3,9 +3,6 @@ import 'package:flutter/widgets.dart';
 import 'package:mix/mix.dart';
 import 'package:mix_annotations/mix_annotations.dart';
 
-import '../../attributes/gap/gap_dto.dart';
-import '../../attributes/gap/gap_util.dart';
-
 part 'flex_spec.g.dart';
 
 @MixableSpec()
@@ -29,7 +26,7 @@ final class FlexSpec extends Spec<FlexSpec> with _$FlexSpec {
   final TextBaseline? textBaseline;
   final Clip? clipBehavior;
   @MixableProperty(
-    dto: MixableFieldDto(type: GapDto),
+    dto: MixableFieldDto(type: SpacingSideDto),
     utilities: [MixableUtility(type: GapUtility)],
   )
   final double? gap;

--- a/packages/mix/lib/src/specs/flex/flex_spec.g.dart
+++ b/packages/mix/lib/src/specs/flex/flex_spec.g.dart
@@ -169,7 +169,7 @@ final class FlexSpecAttribute extends SpecAttribute<FlexSpec> {
       textDirection: textDirection,
       textBaseline: textBaseline,
       clipBehavior: clipBehavior,
-      gap: gap,
+      gap: mix.tokens.spaceTokenRef(gap ?? 0),
       animated: animated?.resolve(mix) ?? mix.animation,
     );
   }

--- a/packages/mix/lib/src/specs/flex/flex_spec.g.dart
+++ b/packages/mix/lib/src/specs/flex/flex_spec.g.dart
@@ -135,7 +135,7 @@ final class FlexSpecAttribute extends SpecAttribute<FlexSpec> {
   final TextDirection? textDirection;
   final TextBaseline? textBaseline;
   final Clip? clipBehavior;
-  final GapDto? gap;
+  final SpacingSideDto? gap;
 
   const FlexSpecAttribute({
     this.crossAxisAlignment,
@@ -280,7 +280,7 @@ base class FlexSpecUtility<T extends Attribute>
     TextDirection? textDirection,
     TextBaseline? textBaseline,
     Clip? clipBehavior,
-    GapDto? gap,
+    SpacingSideDto? gap,
     AnimatedDataDto? animated,
   }) {
     return builder(FlexSpecAttribute(

--- a/packages/mix/lib/src/specs/flex/flex_spec.g.dart
+++ b/packages/mix/lib/src/specs/flex/flex_spec.g.dart
@@ -135,7 +135,7 @@ final class FlexSpecAttribute extends SpecAttribute<FlexSpec> {
   final TextDirection? textDirection;
   final TextBaseline? textBaseline;
   final Clip? clipBehavior;
-  final double? gap;
+  final GapDto? gap;
 
   const FlexSpecAttribute({
     this.crossAxisAlignment,
@@ -169,7 +169,7 @@ final class FlexSpecAttribute extends SpecAttribute<FlexSpec> {
       textDirection: textDirection,
       textBaseline: textBaseline,
       clipBehavior: clipBehavior,
-      gap: mix.tokens.spaceTokenRef(gap ?? 0),
+      gap: gap?.resolve(mix),
       animated: animated?.resolve(mix) ?? mix.animation,
     );
   }
@@ -195,7 +195,7 @@ final class FlexSpecAttribute extends SpecAttribute<FlexSpec> {
       textDirection: other.textDirection ?? textDirection,
       textBaseline: other.textBaseline ?? textBaseline,
       clipBehavior: other.clipBehavior ?? clipBehavior,
-      gap: other.gap ?? gap,
+      gap: gap?.merge(other.gap) ?? other.gap,
       animated: animated?.merge(other.animated) ?? other.animated,
     );
   }
@@ -260,7 +260,7 @@ base class FlexSpecUtility<T extends Attribute>
   late final clipBehavior = ClipUtility((v) => only(clipBehavior: v));
 
   /// Utility for defining [FlexSpecAttribute.gap]
-  late final gap = SpacingSideUtility((v) => only(gap: v));
+  late final gap = GapUtility((v) => only(gap: v));
 
   /// Utility for defining [FlexSpecAttribute.animated]
   late final animated = AnimatedUtility((v) => only(animated: v));
@@ -280,7 +280,7 @@ base class FlexSpecUtility<T extends Attribute>
     TextDirection? textDirection,
     TextBaseline? textBaseline,
     Clip? clipBehavior,
-    double? gap,
+    GapDto? gap,
     AnimatedDataDto? animated,
   }) {
     return builder(FlexSpecAttribute(

--- a/packages/mix/test/src/specs/flex/flex_attribute_test.dart
+++ b/packages/mix/test/src/specs/flex/flex_attribute_test.dart
@@ -46,6 +46,45 @@ void main() {
       expect(resolvedSpec.gap, 10.0);
     });
 
+    testWidgets('tokens resolve returns correct FlexSpec', (tester) async {
+      const tokenValue = 8.0;
+
+      final theme = MixThemeData(
+        spaces: {
+          $token.space.small: tokenValue,
+        },
+      );
+
+      late MixData mixData;
+
+      await tester.pumpWidget(
+        MixTheme(
+          data: theme,
+          child: MaterialApp(
+            home: Scaffold(
+              body: Builder(
+                builder: (BuildContext context) {
+                  mixData = MixData.create(
+                    context,
+                    Style(
+                      $flex.gap.ref($token.space.small),
+                    ),
+                  );
+
+                  return Container();
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final attribute = mixData.whereType<FlexSpecAttribute>().first;
+      final resolvedSpec = attribute.resolve(mixData);
+
+      expect(resolvedSpec.gap, tokenValue);
+    });
+
     test('merge returns correct FlexMixAttribute', () {
       const attribute1 = FlexSpecAttribute(
         direction: Axis.horizontal,

--- a/packages/mix/test/src/specs/flex/flex_attribute_test.dart
+++ b/packages/mix/test/src/specs/flex/flex_attribute_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mix/mix.dart';
-import 'package:mix/src/attributes/gap/gap_dto.dart';
 
 import '../../../helpers/testing_utils.dart';
 
@@ -31,7 +30,7 @@ void main() {
         textDirection: TextDirection.rtl,
         textBaseline: TextBaseline.alphabetic,
         clipBehavior: Clip.antiAlias,
-        gap: GapDto(10.0),
+        gap: SpacingSideDto(10.0),
       );
       final mixData = MixData.create(MockBuildContext(), Style(attribute));
       final resolvedSpec = attribute.resolve(mixData);
@@ -96,7 +95,7 @@ void main() {
         textDirection: TextDirection.rtl,
         textBaseline: TextBaseline.alphabetic,
         clipBehavior: Clip.antiAlias,
-        gap: GapDto(10.0),
+        gap: SpacingSideDto(10.0),
       );
       const attribute2 = FlexSpecAttribute(
         direction: Axis.vertical,
@@ -107,7 +106,7 @@ void main() {
         textDirection: TextDirection.ltr,
         textBaseline: TextBaseline.ideographic,
         clipBehavior: Clip.hardEdge,
-        gap: GapDto(20.0),
+        gap: SpacingSideDto(20.0),
       );
       final mergedAttribute = attribute1.merge(attribute2);
 
@@ -119,7 +118,7 @@ void main() {
       expect(mergedAttribute.textDirection, TextDirection.ltr);
       expect(mergedAttribute.textBaseline, TextBaseline.ideographic);
       expect(mergedAttribute.clipBehavior, Clip.hardEdge);
-      expect(mergedAttribute.gap, const GapDto(20.0));
+      expect(mergedAttribute.gap, const SpacingSideDto(20.0));
     });
   });
 }

--- a/packages/mix/test/src/specs/flex/flex_attribute_test.dart
+++ b/packages/mix/test/src/specs/flex/flex_attribute_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mix/mix.dart';
+import 'package:mix/src/attributes/gap/gap_dto.dart';
 
 import '../../../helpers/testing_utils.dart';
 
@@ -30,7 +31,7 @@ void main() {
         textDirection: TextDirection.rtl,
         textBaseline: TextBaseline.alphabetic,
         clipBehavior: Clip.antiAlias,
-        gap: 10.0,
+        gap: GapDto(10.0),
       );
       final mixData = MixData.create(MockBuildContext(), Style(attribute));
       final resolvedSpec = attribute.resolve(mixData);
@@ -95,7 +96,7 @@ void main() {
         textDirection: TextDirection.rtl,
         textBaseline: TextBaseline.alphabetic,
         clipBehavior: Clip.antiAlias,
-        gap: 10.0,
+        gap: GapDto(10.0),
       );
       const attribute2 = FlexSpecAttribute(
         direction: Axis.vertical,
@@ -106,7 +107,7 @@ void main() {
         textDirection: TextDirection.ltr,
         textBaseline: TextBaseline.ideographic,
         clipBehavior: Clip.hardEdge,
-        gap: 20.0,
+        gap: GapDto(20.0),
       );
       final mergedAttribute = attribute1.merge(attribute2);
 
@@ -118,7 +119,7 @@ void main() {
       expect(mergedAttribute.textDirection, TextDirection.ltr);
       expect(mergedAttribute.textBaseline, TextBaseline.ideographic);
       expect(mergedAttribute.clipBehavior, Clip.hardEdge);
-      expect(mergedAttribute.gap, 20.0);
+      expect(mergedAttribute.gap, const GapDto(20.0));
     });
   });
 }

--- a/packages/mix/test/src/specs/flex/flex_spec_test.dart
+++ b/packages/mix/test/src/specs/flex/flex_spec_test.dart
@@ -3,7 +3,6 @@ import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mix/mix.dart';
-import 'package:mix/src/attributes/gap/gap_dto.dart';
 
 import '../../../helpers/testing_utils.dart';
 
@@ -22,7 +21,7 @@ void main() {
             textDirection: TextDirection.ltr,
             textBaseline: TextBaseline.alphabetic,
             clipBehavior: Clip.antiAlias,
-            gap: GapDto(10),
+            gap: SpacingSideDto(10),
           ),
         ),
       );

--- a/packages/mix/test/src/specs/flex/flex_spec_test.dart
+++ b/packages/mix/test/src/specs/flex/flex_spec_test.dart
@@ -3,6 +3,7 @@ import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mix/mix.dart';
+import 'package:mix/src/attributes/gap/gap_dto.dart';
 
 import '../../../helpers/testing_utils.dart';
 
@@ -21,7 +22,7 @@ void main() {
             textDirection: TextDirection.ltr,
             textBaseline: TextBaseline.alphabetic,
             clipBehavior: Clip.antiAlias,
-            gap: 10,
+            gap: GapDto(10),
           ),
         ),
       );

--- a/packages/mix/test/src/specs/flex/flex_util_test.dart
+++ b/packages/mix/test/src/specs/flex/flex_util_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mix/mix.dart';
-import 'package:mix/src/attributes/gap/gap_dto.dart';
 
 void main() {
   group('FlexUtility', () {
@@ -90,7 +89,7 @@ void main() {
     test('gap() returns correct instance', () {
       final flex = flexUtility.gap(10);
 
-      expect(flex.gap, const GapDto(10));
+      expect(flex.gap, const SpacingSideDto(10));
     });
 
     // row()

--- a/packages/mix/test/src/specs/flex/flex_util_test.dart
+++ b/packages/mix/test/src/specs/flex/flex_util_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mix/mix.dart';
+import 'package:mix/src/attributes/gap/gap_dto.dart';
 
 void main() {
   group('FlexUtility', () {
@@ -89,7 +90,7 @@ void main() {
     test('gap() returns correct instance', () {
       final flex = flexUtility.gap(10);
 
-      expect(flex.gap, 10);
+      expect(flex.gap, const GapDto(10));
     });
 
     // row()


### PR DESCRIPTION
#### Related issue
#326

### Description

`FlexSpecAttribute` didn't resolve correctly when using tokens.

### Changes

- Create `GapDto`, `GapUtility`
- Change the Dto used in `FlexSpecAttribute`

**Review Checklist**

- [x] **Testing**: Have you tested your changes, including unit tests and integration tests for affected code?
- [ ] **Breaking Changes**: Does this change introduce breaking changes affecting existing code or users?
- [ ] **Documentation Updates**: Are all relevant documentation files (e.g. README, API docs) updated to reflect the changes in this PR?
- [ ] **Website Updates**: Is the website containing the updates you make on documentation?

### Impacted Packages

Please indicate which packages in our project are affected by these changes:

- [x] mix
- [ ] mix_lint
- [ ] mix_generator
- [ ] documentation
