### PR TITLE
fix: Exception when there is no children on flex

### DIFF
--- a/packages/mix/lib/src/specs/flex/flex_widget.dart
+++ b/packages/mix/lib/src/specs/flex/flex_widget.dart
@@ -2,7 +2,6 @@
 
 import 'package:flutter/widgets.dart';
 
-import '../../core/factory/style_mix.dart';
 import '../../core/styled_widget.dart';
 import '../box/box_spec.dart';
 import '../box/box_widget.dart';
@@ -67,6 +66,8 @@ class FlexSpecWidget extends StatelessWidget {
 
   List<Widget> _buildChildren(double? gap) {
     if (gap == null) return children;
+
+    if (children.isEmpty) return [];
 
     return List.generate(children.length + children.length - 1, (index) {
       if (index.isEven) return children[index ~/ 2];
@@ -211,11 +212,11 @@ class FlexBox extends StyledWidget {
 /// ```
 class HBox extends FlexBox {
   const HBox({
-    Style? style,
+    super.style,
     super.key,
     super.inherit,
     super.children = const <Widget>[],
-  }) : super(style: style, direction: Axis.horizontal);
+  }) : super(direction: Axis.horizontal);
 }
 
 /// A vertical flex container that uses `Style` for streamlined styling.
@@ -236,11 +237,11 @@ class HBox extends FlexBox {
 /// ```
 class VBox extends FlexBox {
   const VBox({
-    Style? style,
+    super.style,
     super.key,
     super.inherit,
     super.children = const <Widget>[],
-  }) : super(style: style, direction: Axis.vertical);
+  }) : super(direction: Axis.vertical);
 }
 
 final _defaultFlex = Flex(direction: Axis.horizontal, children: const []);

--- a/packages/mix/test/src/specs/flex/flex_widget_test.dart
+++ b/packages/mix/test/src/specs/flex/flex_widget_test.dart
@@ -87,6 +87,30 @@ void main() {
     expect(containerOffset.dy, 0);
   });
 
+  testWidgets('Does not render Gap with no children', (tester) async {
+    await tester.pumpMaterialApp(
+      HBox(
+        style: Style($flex.gap(10)),
+        children: const [],
+      ),
+    );
+
+    expect(find.byType(SizedBox), findsNothing);
+  });
+
+  testWidgets('Does not render Gap with one child', (tester) async {
+    await tester.pumpMaterialApp(
+      HBox(
+        style: Style($flex.gap(10)),
+        children: const [
+          Text('test'),
+        ],
+      ),
+    );
+
+    expect(find.byType(SizedBox), findsNothing);
+  });
+
   testWidgets(
     'should render correctly when gap is applied to Hbox with any MainAxisAlignment',
     (WidgetTester tester) async {


### PR DESCRIPTION
Exception on flex widget when there are no children and it tries to add a gap.

**Review Checklist**

- [ ] **Testing**: Have you tested your changes, including unit tests and integration tests for affected code?
- [ ] **Breaking Changes**: Does this change introduce breaking changes affecting existing code or users?
- [ ] **Documentation Updates**: Are all relevant documentation files (e.g. README, API docs) updated to reflect the changes in this PR?
- [ ] **Website Updates**: Is the website containing the updates you make on documentation?

### Impacted Packages

Please indicate which packages in our project are affected by these changes:

- [x] mix
- [ ] mix_lint
- [ ] mix_generator
- [ ] documentation

