### PR TITLE
feat: pressable supports keyboard events

### DIFF
--- a/packages/mix/lib/src/widgets/widget_state/pressable_widget.dart
+++ b/packages/mix/lib/src/widgets/widget_state/pressable_widget.dart
@@ -167,6 +167,12 @@ abstract class _MixStateWidgetBuilderState<T extends _MixStateWidgetBuilder>
   );
   int _pressCount = 0;
 
+  late final Map<Type, Action<Intent>> _actionMap = <Type, Action<Intent>>{
+    ActivateIntent: CallbackAction<ActivateIntent>(onInvoke: activateOnIntent),
+    ButtonActivateIntent:
+        CallbackAction<ButtonActivateIntent>(onInvoke: activateOnIntent),
+  };
+
   void _handleFocusUpdate(bool hasFocus) {
     updateState(() => _isFocused = hasFocus);
   }
@@ -235,6 +241,31 @@ abstract class _MixStateWidgetBuilderState<T extends _MixStateWidgetBuilder>
     }
   }
 
+  void _onTapUp(TapUpDetails details) {
+    if (_preventEvent) return;
+    _handlePressUpdate(false);
+  }
+
+  void _onTapCancel() {
+    if (_preventEvent) return;
+    _handlePressUpdate(false);
+  }
+
+  void _onLongPressStart(LongPressStartDetails details) {
+    if (_preventEvent) return;
+    handleLongPressUpdate(true);
+  }
+
+  void _onLongPressEnd(LongPressEndDetails details) {
+    if (_preventEvent) return;
+    handleLongPressUpdate(false);
+  }
+
+  void _onLongPressCancel() {
+    if (_preventEvent) return;
+    handleLongPressUpdate(false);
+  }
+
   void handleLongPressUpdate(bool isLongPressed) {
     if (isLongPressed == _isLongPressed) return;
 
@@ -265,31 +296,6 @@ abstract class _MixStateWidgetBuilderState<T extends _MixStateWidgetBuilder>
     if (widget.enableFeedback) Feedback.forTap(context);
   }
 
-  void _onTapUp(TapUpDetails details) {
-    if (_preventEvent) return;
-    _handlePressUpdate(false);
-  }
-
-  void _onTapCancel() {
-    if (_preventEvent) return;
-    _handlePressUpdate(false);
-  }
-
-  void _onLongPressStart(LongPressStartDetails details) {
-    if (_preventEvent) return;
-    handleLongPressUpdate(true);
-  }
-
-  void _onLongPressEnd(LongPressEndDetails details) {
-    if (_preventEvent) return;
-    handleLongPressUpdate(false);
-  }
-
-  void _onLongPressCancel() {
-    if (_preventEvent) return;
-    handleLongPressUpdate(false);
-  }
-
   void handleOnLongPress() {
     if (_preventEvent) return;
 
@@ -297,38 +303,45 @@ abstract class _MixStateWidgetBuilderState<T extends _MixStateWidgetBuilder>
     if (widget.enableFeedback) Feedback.forLongPress(context);
   }
 
+  void activateOnIntent(Intent? intent) {
+    handleOnPress();
+  }
+
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTapUp: _onTapUp,
-      onTap: handleOnPress,
-      onTapCancel: _onTapCancel,
-      onLongPressCancel: _onLongPressCancel,
-      onLongPress: handleOnLongPress,
-      onLongPressStart: _onLongPressStart,
-      onLongPressEnd: _onLongPressEnd,
-      onPanDown: _handlePanDown,
-      onPanUpdate: _handlePanUpdate,
-      onPanEnd: _handlePanUp,
-      behavior: widget.hitTestBehavior,
-      child: CustomFocusableActionDetector(
-        enabled: widget.enabled,
-        focusNode: widget.focusNode,
-        autofocus: widget.autofocus,
-        onShowFocusHighlight: _handleFocusUpdate,
-        onShowHoverHighlight: _handleHoverUpdate,
-        onFocusChange: widget.onFocusChange,
-        onMouseEnter: _handleOnMouseEnter,
-        onMouseExit: _handleOnMouseExit,
-        onMouseHover: _handleMouseHover,
-        child: WidgetStateModel(
+    return Actions(
+      actions: _actionMap,
+      child: GestureDetector(
+        onTapUp: _onTapUp,
+        onTap: handleOnPress,
+        onTapCancel: _onTapCancel,
+        onLongPressCancel: _onLongPressCancel,
+        onLongPress: handleOnLongPress,
+        onLongPressStart: _onLongPressStart,
+        onLongPressEnd: _onLongPressEnd,
+        onPanDown: _handlePanDown,
+        onPanUpdate: _handlePanUpdate,
+        onPanEnd: _handlePanUp,
+        behavior: widget.hitTestBehavior,
+        child: CustomFocusableActionDetector(
           enabled: widget.enabled,
-          hovered: _isHovered,
-          focused: _isFocused,
-          pressed: _isPressed,
-          longPressed: _isLongPressed,
-          pointerPosition: _pointerPosition,
-          child: widget.child,
+          focusNode: widget.focusNode,
+          autofocus: widget.autofocus,
+          onShowFocusHighlight: _handleFocusUpdate,
+          onShowHoverHighlight: _handleHoverUpdate,
+          onFocusChange: widget.onFocusChange,
+          onMouseEnter: _handleOnMouseEnter,
+          onMouseExit: _handleOnMouseExit,
+          onMouseHover: _handleMouseHover,
+          child: WidgetStateModel(
+            enabled: widget.enabled,
+            hovered: _isHovered,
+            focused: _isFocused,
+            pressed: _isPressed,
+            longPressed: _isLongPressed,
+            pointerPosition: _pointerPosition,
+            child: widget.child,
+          ),
         ),
       ),
     );

--- a/packages/mix/test/src/widgets/pressable/pressable_widget_test.dart
+++ b/packages/mix/test/src/widgets/pressable/pressable_widget_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mix/mix.dart';
 
@@ -104,6 +105,30 @@ void main() {
         expect(counter, 0);
       },
     );
+
+    testWidgets('Pressable responds to keyboard events',
+        (WidgetTester tester) async {
+      var wasPressed = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Pressable(
+              autofocus: true,
+              unpressDelay: Duration.zero,
+              onPress: () {
+                wasPressed = true;
+              },
+              child: const Text('Tap me'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+
+      expect(wasPressed, isTrue);
+    });
   });
 
   group('PressableBox', () {
@@ -158,6 +183,30 @@ void main() {
         expect(counter, 0);
       },
     );
+
+    testWidgets('PressableBox responds to keyboard events',
+        (WidgetTester tester) async {
+      var wasPressed = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: PressableBox(
+              autofocus: true,
+              unpressDelay: Duration.zero,
+              onPress: () {
+                wasPressed = true;
+              },
+              child: const Text('Tap me'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+
+      expect(wasPressed, isTrue);
+    });
 
     testWidgets(r'must change to attributes in $on.hover variant when hovered',
         (WidgetTester tester) async {


### PR DESCRIPTION
#### Related issue

#314 

### Description

Add the ability in Pressable and PressableBox to respond to keyboard events, specifically, space and enter.

### Changes

- Add an `Actions` on `Pressable`'s build method.

**Review Checklist**

- [x] **Testing**: Have you tested your changes, including unit tests and integration tests for affected code?
- [ ] **Breaking Changes**: Does this change introduce breaking changes affecting existing code or users?
- [ ] **Documentation Updates**: Are all relevant documentation files (e.g. README, API docs) updated to reflect the changes in this PR?
- [ ] **Website Updates**: Is the website containing the updates you make on documentation?
