### PR TITLE
refactor: use timer instead of future<void>

### DIFF
--- a/packages/mix/lib/src/widgets/widget_state/pressable_widget.dart
+++ b/packages/mix/lib/src/widgets/widget_state/pressable_widget.dart
@@ -294,6 +294,9 @@ abstract class _MixStateWidgetBuilderState<T extends _MixStateWidgetBuilder>
       }
     }
 
+    _timer?.cancel();
+    _timer = null;
+
     final delay = widget.unpressDelay;
 
     if (delay != Duration.zero) {

--- a/packages/mix/lib/src/widgets/widget_state/pressable_widget.dart
+++ b/packages/mix/lib/src/widgets/widget_state/pressable_widget.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
@@ -277,15 +279,27 @@ abstract class _MixStateWidgetBuilderState<T extends _MixStateWidgetBuilder>
     setState(fn);
   }
 
-  Future<void> unpressAfterDelay(int initialPressCount) async {
+  Timer? _timer;
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  void unpressAfterDelay(int initialPressCount) {
+    void unpressCallback() {
+      if (_isPressed && _pressCount == initialPressCount) {
+        updateState(() => _isPressed = false);
+      }
+    }
+
     final delay = widget.unpressDelay;
 
     if (delay != Duration.zero) {
-      await Future.delayed(delay);
-    }
-
-    if (_isPressed && _pressCount == initialPressCount) {
-      updateState(() => _isPressed = false);
+      _timer = Timer(delay, unpressCallback);
+    } else {
+      unpressCallback();
     }
   }
 

--- a/packages/mix/test/src/widgets/pressable/pressable_widget_test.dart
+++ b/packages/mix/test/src/widgets/pressable/pressable_widget_test.dart
@@ -131,6 +131,31 @@ void main() {
     });
   });
 
+  testWidgets('Pressable cancel timer on dispose', (WidgetTester tester) async {
+    var wasPressed = false;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Pressable(
+            autofocus: true,
+            unpressDelay: const Duration(minutes: 1),
+            onPress: () {
+              wasPressed = !wasPressed;
+            },
+            child: const Text('Tap me'),
+          ),
+        ),
+      ),
+    );
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    expect(wasPressed, isTrue);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    expect(wasPressed, isFalse);
+  });
+
   group('PressableBox', () {
     testWidgets(
       'must be clickable when enable is setted to true',


### PR DESCRIPTION
### Description

Use timer instead of future<void>. Because of this, we can dispose the timer.

### Changes

- Add a timer in `_MixStateWidgetBuilderState`

**Review Checklist**

- [x] **Testing**: Have you tested your changes, including unit tests and integration tests for affected code?
- [ ] **Breaking Changes**: Does this change introduce breaking changes affecting existing code or users?
- [ ] **Documentation Updates**: Are all relevant documentation files (e.g. README, API docs) updated to reflect the changes in this PR?
- [ ] **Website Updates**: Is the website containing the updates you make on documentation?

