### PR TITLE
feat: ColorSwatchToken and other token improvements

### DIFF
--- a/.github/workflows/add_label.yml
+++ b/.github/workflows/add_label.yml
@@ -15,10 +15,6 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
-      - uses: rogerluan/label-remover@v1.0.1
-        with:
-          github_token: ${{ secrets.github_token }}
-
       - uses: actions/github-script@v7
         with:
           script: |
@@ -34,43 +30,71 @@ jobs:
             // verify packages
             const packagesFiles = files.filter(file => file.startsWith('packages/') && !file.includes('mix_lint_test'))
             const packages = packagesFiles.map(file => file.split('/')[1])
-            const labels = Array.from(new Set(packages))
+            const newLabels = Array.from(new Set(packages))
 
             console.log('##### PackagesLabels #####')
-            console.log(labels)
+            console.log(newLabels)
             console.log('##########################')
             
             // verify documentation 
             const wasDocModified = files.filter(file => file.startsWith('website/')).length > 0
             if (wasDocModified) {
-              labels.push('documentation')
-              
+              newLabels.push('documentation')
               console.log('documentation label was added')
             }
 
             // verify examples
             const wasExampleModified = files.filter(file => file.startsWith('examples/')).length > 0
             if (wasExampleModified) {
-              labels.push('examples')
+              newLabels.push('examples')
               console.log('examples label was added')
             }
 
             // verify repo
             const wasRepoModified = files.filter(file => !file.startsWith('website/') && !file.startsWith('packages/') && !file.startsWith('examples/')).length > 0
             if (wasRepoModified) {
-              labels.push('repo')
+              newLabels.push('repo')
               console.log('rep label was added')
             }
 
-            console.log('##### Added Labels #####')
-            console.log(labels)
+            console.log('##### New Labels #####')
+            console.log(newLabels)
             console.log('##########################')
 
-            github.rest.issues.addLabels({
+            // Get existing labels
+            const existingLabels = await github.rest.issues.listLabelsOnIssue({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              labels: labels
             })
 
+            const labelsToAdd = newLabels.filter(label => !existingLabels.data.some(existingLabel => existingLabel.name === label))
+            const labelsToRemove = existingLabels.data.filter(existingLabel => !newLabels.includes(existingLabel.name))
 
+            console.log('##### Labels to Add #####')
+            console.log(labelsToAdd)
+            console.log('##########################')
+
+            console.log('##### Labels to Remove #####')
+            console.log(labelsToRemove)
+            console.log('##########################')
+
+            // Add new labels
+            if (labelsToAdd.length > 0) {
+              await github.rest.issues.addLabels({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                labels: labelsToAdd
+              })
+            }
+
+            // Remove unnecessary labels
+            for (const label of labelsToRemove) {
+              await github.rest.issues.removeLabel({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: label.name
+              })
+            }

--- a/examples/themed_button/lib/button/button.style.dart
+++ b/examples/themed_button/lib/button/button.style.dart
@@ -1,5 +1,4 @@
 import 'package:mix/mix.dart';
-import 'package:themed_button/styles/tokens.dart';
 
 import 'button.variants.dart';
 
@@ -16,20 +15,12 @@ Style container() => Style(
       //   $box.padding.horizontal.ref($token.space.xsmall),
       //   $box.padding.vertical.ref($token.space.xxsmall),
       // ),
-      ButtonSize.medium(
-        $box.padding.horizontal.ref($token.space.small),
-        $box.padding.vertical.ref($token.space.xxsmall),
-      ),
+
       // ButtonSize.large(
       //   $box.padding.horizontal.ref($token.space.medium),
       //   $box.padding.vertical.ref($token.space.xsmall),
       // ),
-      ButtonType.primary(
-        $box.color.ref($token.color.primary),
-        $on.hover(
-          $box.color.ref($token.color.primaryHover),
-        ),
-      ),
+
       // ButtonType.secondary(
       //   $box.color.grey.shade200(),
       //   $on.hover(
@@ -98,9 +89,7 @@ Style label() => Style(
       // ButtonSize.large(
       //   $text.style.fontSize(18),
       // ),
-      ButtonType.primary(
-        $text.style.color.ref($token.color.onPrimary),
-      ),
+
       // ButtonType.secondary(
       //   $text.style.color.ref($token.color.primaryHover),
       // ),

--- a/examples/themed_button/lib/styles/orbit.dart
+++ b/examples/themed_button/lib/styles/orbit.dart
@@ -2,36 +2,40 @@ import 'package:flutter/material.dart';
 import 'package:mix/mix.dart';
 import 'package:themed_button/styles/tokens.dart';
 
+final _color = ColorTokens();
+final _radius = RadiusTokens();
+final _space = SpaceTokens();
+final _textStyle = TextStyleTokens();
 final orbitTheme = MixThemeData(
   colors: {
-    $token.color.primary: const Color(0xff00A58E),
-    $token.color.primaryHover: const Color(0xFF009580),
-    $token.color.onPrimary: Colors.white,
+    _color.primary: const Color(0xff00A58E),
+    _color.primaryHover: const Color(0xFF009580),
+    _color.onPrimary: Colors.white,
   },
   radii: {
-    $token.radius.small: const Radius.circular(4),
-    $token.radius.normal: const Radius.circular(6),
-    $token.radius.large: const Radius.circular(12),
-    $token.radius.full: const Radius.circular(9999),
+    _radius.small: const Radius.circular(4),
+    _radius.normal: const Radius.circular(6),
+    _radius.large: const Radius.circular(12),
+    _radius.full: const Radius.circular(9999),
   },
   spaces: {
-    $token.space.xxxsmall: 4,
-    $token.space.xxsmall: 8,
-    $token.space.xsmall: 12,
-    $token.space.small: 16,
-    $token.space.medium: 24,
-    $token.space.large: 32,
+    _space.xxxsmall: 4,
+    _space.xxsmall: 8,
+    _space.xsmall: 12,
+    _space.small: 16,
+    _space.medium: 24,
+    _space.large: 32,
   },
   textStyles: {
-    $token.textStyle.small: const TextStyle(
+    _textStyle.small: const TextStyle(
       fontSize: 12,
       fontWeight: FontWeight.normal,
     ),
-    $token.textStyle.normal: const TextStyle(
+    _textStyle.normal: const TextStyle(
       fontSize: 14,
       fontWeight: FontWeight.normal,
     ),
-    $token.textStyle.large: const TextStyle(
+    _textStyle.large: const TextStyle(
       fontSize: 16,
       fontWeight: FontWeight.normal,
     )

--- a/examples/themed_button/lib/styles/schadcn.dart
+++ b/examples/themed_button/lib/styles/schadcn.dart
@@ -1,12 +1,13 @@
 import 'package:flutter/material.dart';
-import 'package:mix/mix.dart';
 import 'package:themed_button/styles/orbit.dart';
 import 'package:themed_button/styles/tokens.dart';
 
+final _color = ColorTokens();
+
 final shadcnTheme = orbitTheme.copyWith(
   colors: {
-    $token.color.primary: Colors.black,
-    $token.color.primaryHover: const Color.fromARGB(255, 66, 66, 66),
-    $token.color.onPrimary: Colors.white,
+    _color.primary: Colors.black,
+    _color.primaryHover: const Color.fromARGB(255, 66, 66, 66),
+    _color.onPrimary: Colors.white,
   },
 );

--- a/examples/themed_button/lib/styles/tokens.dart
+++ b/examples/themed_button/lib/styles/tokens.dart
@@ -1,32 +1,34 @@
 import 'package:mix/mix.dart';
 
-extension ColorExt on ColorTokenUtil {
-  ColorToken get primary => const ColorToken('primary');
-  ColorToken get primaryHover => const ColorToken('primary.hover');
-  ColorToken get onPrimary => const ColorToken('on.primary');
-  // ColorToken get secondary => const ColorToken('secondary');
-  // ColorToken get onSecondary => const ColorToken('on.secondary');
-  // ColorToken get outline => const ColorToken('outline');
+class ColorTokens {
+  final ColorToken primary = const ColorToken('primary');
+  final ColorToken primaryHover = const ColorToken('primary.hover');
+  final ColorToken onPrimary = const ColorToken('on.primary');
+  // final ColorToken secondary = const ColorToken('secondary');
+  // final ColorToken onSecondary = const ColorToken('on.secondary');
+  // final ColorToken outline = const ColorToken('outline');
 }
 
-extension RadiusExt on RadiusTokenUtil {
-  RadiusToken get small => const RadiusToken('radius.small');
-  RadiusToken get normal => const RadiusToken('radius.normal');
-  RadiusToken get large => const RadiusToken('radius.large');
-  RadiusToken get full => const RadiusToken('radius.full');
+class RadiusTokens {
+  final RadiusToken small = const RadiusToken('radius.small');
+  final RadiusToken normal = const RadiusToken('radius.normal');
+  final RadiusToken large = const RadiusToken('radius.large');
+  final RadiusToken full = const RadiusToken('radius.full');
 }
 
-extension SpacingExt on SpaceTokenUtil {
-  SpaceToken get xxxsmall => const SpaceToken('space.xxxsmall');
-  SpaceToken get xxsmall => const SpaceToken('space.xxsmall');
-  SpaceToken get xsmall => const SpaceToken('space.xsmall');
-  SpaceToken get small => const SpaceToken('space.small');
-  SpaceToken get medium => const SpaceToken('space.medium');
+class SpaceTokens {
+  final SpaceToken xxxsmall = const SpaceToken('space.xxxsmall');
+  final SpaceToken xxsmall = const SpaceToken('space.xxsmall');
+  final SpaceToken xsmall = const SpaceToken('space.xsmall');
+  final SpaceToken small = const SpaceToken('space.small');
+  final SpaceToken medium = const SpaceToken('space.medium');
+  final SpaceToken large = const SpaceToken('space.large');
 }
 
-extension TextStyleExt on TextStyleTokenUtil {
-  TextStyleToken get small => const TextStyleToken('textstyle.small');
-  TextStyleToken get normal => const TextStyleToken('textstyle.normall');
-  TextStyleToken get large => const TextStyleToken('textstyle.large');
-  TextStyleToken get extraLarge => const TextStyleToken('textstyle.extraLarge');
+class TextStyleTokens {
+  final TextStyleToken small = const TextStyleToken('textstyle.small');
+  final TextStyleToken normal = const TextStyleToken('textstyle.normall');
+  final TextStyleToken large = const TextStyleToken('textstyle.large');
+  final TextStyleToken extraLarge =
+      const TextStyleToken('textstyle.extraLarge');
 }

--- a/examples/todo_list/lib/pages/add_task_page.dart
+++ b/examples/todo_list/lib/pages/add_task_page.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
-import 'package:mix/mix.dart';
 import 'package:todo_list/model/task.dart';
 import 'package:todo_list/pages/controller/task_controller.dart';
 import 'package:todo_list/style/design_tokens.dart';
 
 import '../style/components/button.dart';
+
+const _colors = ColorTokens();
+const _textStyles = TextStyleTokens();
 
 class AddTaskPage extends StatefulWidget {
   const AddTaskPage({super.key, required this.controller});
@@ -22,12 +24,12 @@ class _AddTaskPageState extends State<AddTaskPage> {
   Widget build(BuildContext context) {
     return Material(
       child: Scaffold(
-        backgroundColor: $token.color.surface.resolve(context),
+        backgroundColor: _colors.surface.resolve(context),
         appBar: AppBar(
-          backgroundColor: $token.color.surface.resolve(context),
+          backgroundColor: _colors.surface.resolve(context),
           title: Text(
             'Create Task',
-            style: $token.textStyle.heading2.resolve(context),
+            style: _textStyles.heading2.resolve(context),
           ),
         ),
         body: Padding(

--- a/examples/todo_list/lib/pages/todo_list_page.dart
+++ b/examples/todo_list/lib/pages/todo_list_page.dart
@@ -6,6 +6,9 @@ import 'package:todo_list/style/components/icon_button.dart';
 import 'package:todo_list/style/components/list_tile.dart';
 import 'package:todo_list/style/design_tokens.dart';
 
+const _colors = ColorTokens();
+const _textStyles = TextStyleTokens();
+
 class TodoListPage extends StatefulWidget {
   const TodoListPage({super.key});
 
@@ -19,13 +22,13 @@ class _TodoListPageState extends State<TodoListPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: $token.color.surface.resolve(context),
+      backgroundColor: _colors.surface.resolve(context),
       appBar: AppBar(
-        backgroundColor: $token.color.surface.resolve(context),
+        backgroundColor: _colors.surface.resolve(context),
         title: StyledText(
           'To Do List',
           style: Style(
-            $text.style.ref($token.textStyle.heading2),
+            $text.style.ref(_textStyles.heading2),
           ),
         ),
       ),
@@ -39,7 +42,7 @@ class _TodoListPageState extends State<TodoListPage> {
               if (index == 0) {
                 return Text(
                   'Today',
-                  style: $token.textStyle.heading1.resolve(context),
+                  style: _textStyles.heading1.resolve(context),
                 );
               }
               final item = value[index - 1];

--- a/examples/todo_list/lib/style/components/button.dart
+++ b/examples/todo_list/lib/style/components/button.dart
@@ -4,6 +4,9 @@ import 'package:todo_list/style/design_tokens.dart';
 
 import '../patterns/scale_effect.dart';
 
+const _colors = ColorTokens();
+const _textStyles = TextStyleTokens();
+
 class TodoButton extends StatelessWidget {
   final String text;
   final VoidCallback? onPressed;
@@ -19,7 +22,7 @@ class TodoButton extends StatelessWidget {
     return PressableBox(
       onPress: onPressed,
       style: Style(
-        $box.color.ref($token.color.primary),
+        $box.color.ref(_colors.primary),
         $box.height(50),
         $box.borderRadius(6),
         scaleEffect(),
@@ -29,8 +32,8 @@ class TodoButton extends StatelessWidget {
       child: StyledText(
         text,
         style: Style(
-          $text.style.color.ref($token.color.surface),
-          $text.style.ref($token.textStyle.heading3),
+          $text.style.color.ref(_colors.surface),
+          $text.style.ref(_textStyles.heading3),
           $text.style.bold(),
           $with.scale(1),
           $with.align(alignment: Alignment.center),

--- a/examples/todo_list/lib/style/components/checkbox.dart
+++ b/examples/todo_list/lib/style/components/checkbox.dart
@@ -4,6 +4,8 @@ import 'package:todo_list/style/design_tokens.dart';
 import 'package:todo_list/style/patterns/outline.dart';
 import 'package:todo_list/style/patterns/scale_effect.dart';
 
+const _colors = ColorTokens();
+
 class _CheckboxVariant {
   static const checked = Variant("checked");
   static const unchecked = Variant("unchecked");
@@ -26,21 +28,18 @@ class TodoCheckbox extends StatelessWidget {
       style: Style(
         $box.height(20),
         $box.width(20),
-        $box.color.ref($token.color.surface),
+        $box.color.ref(_colors.surface),
         $box.borderRadius(3),
         scaleEffect(),
         outlinePattern(),
         $icon.size(16),
-        $icon.color.ref($token.color.surface),
+        $icon.color.ref($material.colorScheme.surface),
         $icon.wrap.opacity(0),
         $icon.wrap.padding.top(5),
         $icon.wrap.scale(0.5),
         _CheckboxVariant.checked(
-          $icon.wrap.padding.top(0),
-          $icon.wrap.scale(2),
-          $icon.wrap.opacity(1),
-          $box.color.ref($token.color.primary),
-          $box.border.color.ref($token.color.primary),
+          $box.color.ref(_colors.primary),
+          $box.border.color.ref(_colors.primary),
         ),
       )
           .applyVariant(
@@ -49,8 +48,24 @@ class TodoCheckbox extends StatelessWidget {
           .animate(
             duration: const Duration(milliseconds: 150),
           ),
-      child: const StyledIcon(
+      child: StyledIcon(
         Icons.check,
+        style: Style(
+          $icon.weight(16),
+          $icon.color.ref(_colors.surface),
+          $with.opacity(0),
+          $with.padding.top(5),
+          _CheckboxVariant.checked(
+            $with.padding.top(0),
+            $with.opacity(1),
+          ),
+        )
+            .applyVariant(
+              value ? _CheckboxVariant.checked : _CheckboxVariant.unchecked,
+            )
+            .animate(
+              duration: const Duration(milliseconds: 300),
+            ),
       ),
     );
   }

--- a/examples/todo_list/lib/style/components/icon_button.dart
+++ b/examples/todo_list/lib/style/components/icon_button.dart
@@ -5,6 +5,8 @@ import 'package:todo_list/style/design_tokens.dart';
 import '../patterns/outline.dart';
 import '../patterns/scale_effect.dart';
 
+const _colors = ColorTokens();
+
 class TodoIconButton extends StatelessWidget {
   final IconData icon;
   final VoidCallback? onPressed;
@@ -20,16 +22,16 @@ class TodoIconButton extends StatelessWidget {
     return PressableBox(
       onPress: onPressed,
       style: Style(
-        $box.color.ref($token.color.surface),
+        $box.color.ref(_colors.surface),
         $box.height(50),
         $box.width(50),
         $box.borderRadius(4),
         scaleEffect(),
-        $icon.color.ref($token.color.primary),
+        $icon.color.ref(_colors.primary),
         $icon.weight(20),
         outlinePattern(),
         $on.press(
-          $box.color.ref($token.color.surfaceContainer),
+          $box.color.ref(_colors.surfaceContainer),
         ),
       ).animate(
         duration: const Duration(milliseconds: 150),

--- a/examples/todo_list/lib/style/components/list_tile.dart
+++ b/examples/todo_list/lib/style/components/list_tile.dart
@@ -4,6 +4,9 @@ import 'package:todo_list/style/components/checkbox.dart';
 import 'package:todo_list/style/design_tokens.dart';
 import 'package:todo_list/style/patterns/scale_effect.dart';
 
+const _colors = ColorTokens();
+const _textStyles = TextStyleTokens();
+
 class CheckboxTileVariant {
   static const checked = Variant("checked");
   static const unchecked = Variant("unchecked");
@@ -38,11 +41,11 @@ class TodoCheckboxListTile extends StatelessWidget {
           StyledText(
             text,
             style: Style(
-              $text.style.ref($token.textStyle.heading3),
-              $text.style.color.ref($token.color.onSurface),
+              $text.style.ref(_textStyles.heading3),
+              $text.style.color.ref(_colors.onSurface),
               CheckboxTileVariant.checked(
                 $text.style.decoration.lineThrough(),
-                $text.style.color.ref($token.color.onSurfaceVariant),
+                $text.style.color.ref(_colors.onSurfaceVariant),
               ),
             )
                 .applyVariant(

--- a/examples/todo_list/lib/style/design_tokens.dart
+++ b/examples/todo_list/lib/style/design_tokens.dart
@@ -2,49 +2,53 @@ import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:mix/mix.dart';
 
+const _color = ColorTokens();
+const _textStyle = TextStyleTokens();
 final lightTheme = MixThemeData(
   colors: {
-    $token.color.surface: Colors.white,
-    $token.color.onSurface: const Color(0xFF141217),
-    $token.color.onSurfaceVariant: const Color.fromARGB(255, 74, 70, 81),
-    $token.color.surfaceContainer: const Color(0xFFE0DBE5),
-    $token.color.outline: const Color(0xFFE0DBE5),
-    $token.color.primary: const Color(0xFF7326E0),
-    $token.color.onPrimary: Colors.white,
+    _color.surface: Colors.white,
+    _color.onSurface: const Color(0xFF141217),
+    _color.onSurfaceVariant: const Color.fromARGB(255, 74, 70, 81),
+    _color.surfaceContainer: const Color(0xFFE0DBE5),
+    _color.outline: const Color(0xFFE0DBE5),
+    _color.primary: const Color(0xFF7326E0),
+    _color.onPrimary: Colors.white,
   },
   textStyles: {
-    $token.textStyle.heading1: GoogleFonts.manrope(
+    _textStyle.heading1: GoogleFonts.manrope(
       fontSize: 28,
       fontWeight: FontWeight.bold,
     ),
-    $token.textStyle.heading2: GoogleFonts.manrope(
+    _textStyle.heading2: GoogleFonts.manrope(
       fontSize: 23,
       fontWeight: FontWeight.bold,
     ),
-    $token.textStyle.heading3: GoogleFonts.manrope(
+    _textStyle.heading3: GoogleFonts.manrope(
       fontSize: 16,
       fontWeight: FontWeight.w500,
     ),
-    $token.textStyle.body: GoogleFonts.manrope(
+    _textStyle.body: GoogleFonts.manrope(
       fontSize: 14,
       fontWeight: FontWeight.w200,
     ),
   },
 );
 
-extension ColorExt on ColorTokenUtil {
-  ColorToken get surface => const ColorToken('surface');
-  ColorToken get onSurface => const ColorToken('on.surface');
-  ColorToken get surfaceContainer => const ColorToken('surface.container');
-  ColorToken get onSurfaceVariant => const ColorToken('on.surface.variant');
-  ColorToken get primary => const ColorToken('primary');
-  ColorToken get onPrimary => const ColorToken('on.primary');
-  ColorToken get outline => const ColorToken('outline');
+class ColorTokens {
+  const ColorTokens();
+  final surface = const ColorToken('surface');
+  final onSurface = const ColorToken('on.surface');
+  final surfaceContainer = const ColorToken('surface.container');
+  final onSurfaceVariant = const ColorToken('on.surface.variant');
+  final primary = const ColorToken('primary');
+  final onPrimary = const ColorToken('on.primary');
+  final outline = const ColorToken('outline');
 }
 
-extension TextStyleExt on TextStyleTokenUtil {
-  TextStyleToken get heading1 => const TextStyleToken('heading1');
-  TextStyleToken get heading2 => const TextStyleToken('heading2');
-  TextStyleToken get heading3 => const TextStyleToken('heading3');
-  TextStyleToken get body => const TextStyleToken('body');
+class TextStyleTokens {
+  const TextStyleTokens();
+  final heading1 = const TextStyleToken('heading1');
+  final heading2 = const TextStyleToken('heading2');
+  final heading3 = const TextStyleToken('heading3');
+  final body = const TextStyleToken('body');
 }

--- a/examples/todo_list/lib/style/patterns/outline.dart
+++ b/examples/todo_list/lib/style/patterns/outline.dart
@@ -1,7 +1,9 @@
 import 'package:mix/mix.dart';
 import 'package:todo_list/style/design_tokens.dart';
 
+const _colors = ColorTokens();
+
 Style outlinePattern = Style(
   $box.border.width(2),
-  $box.border.color.ref($token.color.outline),
+  $box.border.color.ref(_colors.outline),
 );

--- a/packages/mix/lib/src/attributes/border/border_dto.dart
+++ b/packages/mix/lib/src/attributes/border/border_dto.dart
@@ -1,5 +1,5 @@
 // ignore_for_file: prefer_relative_imports,avoid-importing-entrypoint-exports
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 import 'package:mix/mix.dart';
 import 'package:mix_annotations/mix_annotations.dart';
 
@@ -83,7 +83,7 @@ final class BorderDto extends BoxBorderDto<Border> with _$BorderDto {
   bool get isUniform => top == bottom && top == left && top == right;
 
   @override
-  Border get defaultValue => const Border();
+  Border get defaultValue => Border.all();
 }
 
 @MixableDto(generateUtility: false)

--- a/packages/mix/lib/src/core/attributes_map.dart
+++ b/packages/mix/lib/src/core/attributes_map.dart
@@ -53,8 +53,7 @@ class AttributeMap<T extends Attribute> {
 
   Attr? attributeOfType<Attr extends SpecAttribute>() => _map?[Attr] as Attr?;
 
-  Iterable<Attr> whereType<Attr extends T>() =>
-      _map?.values.whereType<Attr>() ?? [];
+  Iterable<Attr> whereType<Attr extends T>() => _map?.values.whereType() ?? [];
 
   AttributeMap<T> merge(AttributeMap<T>? other) {
     return other == null ? this : AttributeMap([...values, ...other.values]);

--- a/packages/mix/lib/src/modifiers/render_widget_modifier.dart
+++ b/packages/mix/lib/src/modifiers/render_widget_modifier.dart
@@ -125,13 +125,12 @@ class RenderAnimatedModifiersState
 
   @override
   void didUpdateWidget(covariant RenderAnimatedModifiers oldWidget) {
+    super.didUpdateWidget(oldWidget);
     if (oldWidget.modifiers != widget.modifiers ||
         oldWidget.mix != widget.mix ||
         oldWidget.orderOfModifiers != widget.orderOfModifiers) {
       cleanUpSpecs();
     }
-
-    super.didUpdateWidget(oldWidget);
   }
 
   @override

--- a/packages/mix/lib/src/theme/mix/mix_theme.dart
+++ b/packages/mix/lib/src/theme/mix/mix_theme.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 
-import '../../internal/compare_mixin.dart';
 import '../material/material_theme.dart';
 import '../tokens/breakpoints_token.dart';
 import '../tokens/color_token.dart';
@@ -32,7 +31,7 @@ class MixTheme extends InheritedWidget {
 }
 
 @immutable
-class MixThemeData with EqualityMixin {
+class MixThemeData {
   final StyledTokens<RadiusToken, Radius> radii;
   final StyledTokens<ColorToken, Color> colors;
   final StyledTokens<TextStyleToken, TextStyle> textStyles;
@@ -120,13 +119,33 @@ class MixThemeData with EqualityMixin {
   }
 
   @override
-  get props => [spaces, breakpoints, colors, textStyles, radii];
+  operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is MixThemeData &&
+        other.textStyles == textStyles &&
+        other.colors == colors &&
+        other.breakpoints == breakpoints &&
+        other.radii == radii &&
+        other.spaces == spaces;
+  }
+
+  @override
+  int get hashCode {
+    return textStyles.hashCode ^
+        colors.hashCode ^
+        breakpoints.hashCode ^
+        radii.hashCode ^
+        spaces.hashCode;
+  }
 }
 
 final _breakpointTokenMap = StyledTokens({
   BreakpointToken.xsmall: const Breakpoint(maxWidth: 599),
   BreakpointToken.small: const Breakpoint(minWidth: 600, maxWidth: 1023),
   BreakpointToken.medium: const Breakpoint(minWidth: 1024, maxWidth: 1439),
-  BreakpointToken.large:
-      const Breakpoint(minWidth: 1440, maxWidth: double.infinity),
+  BreakpointToken.large: const Breakpoint(
+    minWidth: 1440,
+    maxWidth: double.infinity,
+  ),
 });

--- a/packages/mix/lib/src/theme/tokens/breakpoints_token.dart
+++ b/packages/mix/lib/src/theme/tokens/breakpoints_token.dart
@@ -86,11 +86,18 @@ class BreakpointResolver extends Breakpoint with WithTokenResolver<Breakpoint> {
 
 /// A reference to a breakpoint token.
 @immutable
-class BreakpointRef extends Breakpoint
-    with TokenRef<BreakpointToken, Breakpoint> {
+class BreakpointRef extends Breakpoint with TokenRef<BreakpointToken> {
   @override
   final BreakpointToken token;
 
   /// Creates a new breakpoint reference with the given [token].
   const BreakpointRef(this.token);
+}
+
+class BreakpointTokenUtil {
+  final xsmall = BreakpointToken.xsmall;
+  final small = BreakpointToken.small;
+  final medium = BreakpointToken.medium;
+  final large = BreakpointToken.large;
+  const BreakpointTokenUtil();
 }

--- a/packages/mix/lib/src/theme/tokens/color_token.dart
+++ b/packages/mix/lib/src/theme/tokens/color_token.dart
@@ -35,6 +35,69 @@ class ColorToken extends MixToken<Color> {
   }
 }
 
+@immutable
+class ColorTokenOfSwatch<T> extends ColorToken {
+  final ColorSwatchToken<T> _swatchToken;
+  final T index;
+
+  const ColorTokenOfSwatch(super.name, this._swatchToken, this.index);
+
+  @override
+  ColorRef call() => ColorRef(this);
+
+  @override
+  Color resolve(BuildContext context) {
+    final colorSwatch = MixTheme.of(context).colors[_swatchToken];
+    assert(
+      colorSwatch != null,
+      'ColorSwatchToken $name is not defined in the theme',
+    );
+
+    assert(
+      colorSwatch is ColorSwatch<T>,
+      'ColorSwatchToken $name is not of type ColorSwatch<$T>',
+    );
+
+    return (colorSwatch as ColorSwatch<T>)[index]!;
+  }
+}
+
+@immutable
+class ColorSwatchToken<T> extends ColorToken {
+  final Map<T, String> swatch;
+  const ColorSwatchToken(super.name, this.swatch);
+
+  operator [](T index) {
+    final colorName = swatch[index];
+    assert(
+      colorName != null,
+      'ColorSwatchToken $name does not have a value for index $index',
+    );
+    return ColorTokenOfSwatch(colorName!, this, index);
+  }
+
+  static ColorSwatchToken<int> scale(
+    String name,
+    int steps, {
+    String separator = '-',
+  }) {
+    return ColorSwatchToken(name, {
+      for (var i = 1; i <= steps; i++) i: '$name$separator$i',
+    });
+  }
+
+  @override
+  ColorSwatch<T> resolve(BuildContext context) {
+    final themeValue = MixTheme.of(context).colors[this];
+    assert(
+      themeValue != null,
+      'ColorSwatchToken $name is not defined in the theme',
+    );
+
+    return themeValue as ColorSwatch<T>;
+  }
+}
+
 /// A color resolver that allows dynamic resolution of a color value.
 ///
 /// This is useful when the color value is dependent on the current [BuildContext],
@@ -51,7 +114,7 @@ class ColorResolver extends Color with WithTokenResolver<Color> {
 ///
 /// This is used to reference a color token in a theme, and is used to resolve the color value.
 /// Allows pass a [ColorToken] as a [Color] value.
-class ColorRef extends Color with TokenRef<ColorToken, Color> {
+class ColorRef extends Color with TokenRef<ColorToken> {
   /// The token associated with the color reference.
   @override
   final ColorToken token;

--- a/packages/mix/lib/src/theme/tokens/color_token.dart
+++ b/packages/mix/lib/src/theme/tokens/color_token.dart
@@ -37,17 +37,19 @@ class ColorToken extends MixToken<Color> {
 
 @immutable
 class ColorTokenOfSwatch<T> extends ColorToken {
-  final ColorSwatchToken<T> _swatchToken;
   final T index;
 
-  const ColorTokenOfSwatch(super.name, this._swatchToken, this.index);
+  @visibleForTesting
+  final ColorSwatchToken<T> swatchToken;
+
+  const ColorTokenOfSwatch(super.name, this.swatchToken, this.index);
 
   @override
   ColorRef call() => ColorRef(this);
 
   @override
   Color resolve(BuildContext context) {
-    final colorSwatch = MixTheme.of(context).colors[_swatchToken];
+    final colorSwatch = MixTheme.of(context).colors[swatchToken];
     assert(
       colorSwatch != null,
       'ColorSwatchToken $name is not defined in the theme',
@@ -67,15 +69,6 @@ class ColorSwatchToken<T> extends ColorToken {
   final Map<T, String> swatch;
   const ColorSwatchToken(super.name, this.swatch);
 
-  operator [](T index) {
-    final colorName = swatch[index];
-    assert(
-      colorName != null,
-      'ColorSwatchToken $name does not have a value for index $index',
-    );
-    return ColorTokenOfSwatch(colorName!, this, index);
-  }
-
   static ColorSwatchToken<int> scale(
     String name,
     int steps, {
@@ -84,6 +77,16 @@ class ColorSwatchToken<T> extends ColorToken {
     return ColorSwatchToken(name, {
       for (var i = 1; i <= steps; i++) i: '$name$separator$i',
     });
+  }
+
+  operator [](T index) {
+    final colorName = swatch[index];
+    assert(
+      colorName != null,
+      'ColorSwatchToken $name does not have a value for index $index',
+    );
+
+    return ColorTokenOfSwatch(colorName!, this, index);
   }
 
   @override

--- a/packages/mix/lib/src/theme/tokens/mix_token.dart
+++ b/packages/mix/lib/src/theme/tokens/mix_token.dart
@@ -1,27 +1,18 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 
-import '../../core/dto.dart';
-import '../../internal/compare_mixin.dart';
 import '../../internal/iterable_ext.dart';
-import 'color_token.dart';
-import 'radius_token.dart';
-import 'text_style_token.dart';
 
 @immutable
 abstract class MixToken<T> {
   final String name;
   const MixToken(this.name);
 
-  static ColorToken color(String name) => ColorToken(name);
-
-  static TextStyleToken textStyle(String name) => TextStyleToken(name);
-
-  static RadiusToken radius(String name) => RadiusToken(name);
-
   T call();
 
   T resolve(BuildContext context);
+
   @override
   operator ==(Object other) {
     if (identical(this, other)) return true;
@@ -35,12 +26,8 @@ abstract class MixToken<T> {
   int get hashCode => Object.hash(name, runtimeType);
 }
 
-mixin TokenRef<T extends MixToken<V>, V> {
+mixin TokenRef<T extends MixToken> {
   T get token;
-}
-
-mixin DtoRef<T extends Dto<V>, V> {
-  T get data;
 }
 
 mixin WithTokenResolver<V> {
@@ -49,7 +36,7 @@ mixin WithTokenResolver<V> {
 
 typedef BuildContextResolver<T> = T Function(BuildContext context);
 
-class StyledTokens<T extends MixToken<V>, V> with EqualityMixin {
+class StyledTokens<T extends MixToken<V>, V> {
   final Map<T, V> _map;
 
   const StyledTokens(this._map);
@@ -74,5 +61,16 @@ class StyledTokens<T extends MixToken<V>, V> with EqualityMixin {
   }
 
   @override
-  get props => [_map];
+  operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is StyledTokens &&
+        mapEquals(
+          other._map,
+          _map,
+        );
+  }
+
+  @override
+  int get hashCode => _map.hashCode;
 }

--- a/packages/mix/lib/src/theme/tokens/mix_token.dart
+++ b/packages/mix/lib/src/theme/tokens/mix_token.dart
@@ -64,11 +64,7 @@ class StyledTokens<T extends MixToken<V>, V> {
   operator ==(Object other) {
     if (identical(this, other)) return true;
 
-    return other is StyledTokens &&
-        mapEquals(
-          other._map,
-          _map,
-        );
+    return other is StyledTokens && mapEquals(other._map, _map);
   }
 
   @override

--- a/packages/mix/lib/src/theme/tokens/radius_token.dart
+++ b/packages/mix/lib/src/theme/tokens/radius_token.dart
@@ -35,8 +35,7 @@ class RadiusResolver extends Radius with WithTokenResolver<Radius> {
 }
 
 @immutable
-class RadiusRef extends Radius
-    with TokenRef<RadiusToken, Radius>, Diagnosticable {
+class RadiusRef extends Radius with TokenRef<RadiusToken>, Diagnosticable {
   @override
   final RadiusToken token;
 

--- a/packages/mix/lib/src/theme/tokens/text_style_token.dart
+++ b/packages/mix/lib/src/theme/tokens/text_style_token.dart
@@ -34,7 +34,7 @@ class TextStyleResolver extends TextStyle with WithTokenResolver<TextStyle> {
 }
 
 @immutable
-class TextStyleRef extends TextStyle with TokenRef<TextStyleToken, TextStyle> {
+final class TextStyleRef extends TextStyle with TokenRef<TextStyleToken> {
   @override
   final TextStyleToken token;
 

--- a/packages/mix/lib/src/theme/tokens/token_util.dart
+++ b/packages/mix/lib/src/theme/tokens/token_util.dart
@@ -1,14 +1,13 @@
-import 'package:flutter/widgets.dart';
-
 import '../material/material_tokens.dart';
 import 'breakpoints_token.dart';
 import 'radius_token.dart';
 import 'space_token.dart';
 
 const $material = MaterialTokens();
+@Deprecated('You should define your own token utility')
 const $token = MixTokens();
 
-@immutable
+@Deprecated('You should define your own token utility')
 class MixTokens {
   final space = const SpaceTokenUtil();
   final radius = const RadiusTokenUtil();
@@ -19,7 +18,7 @@ class MixTokens {
   const MixTokens();
 }
 
-@immutable
+@Deprecated('You should define your own token utility')
 class RadiusTokenUtil {
   final small = const RadiusToken('mix.radius.small');
   final medium = const RadiusToken('mix.radius.medium');
@@ -27,7 +26,7 @@ class RadiusTokenUtil {
   const RadiusTokenUtil();
 }
 
-@immutable
+@Deprecated('You should define your own token utility')
 class SpaceTokenUtil {
   final large = const SpaceToken('mix.space.large');
   final medium = const SpaceToken('mix.space.medium');
@@ -36,21 +35,12 @@ class SpaceTokenUtil {
   const SpaceTokenUtil();
 }
 
-@immutable
+@Deprecated('You should define your own token utility')
 class ColorTokenUtil {
   const ColorTokenUtil();
 }
 
-@immutable
+@Deprecated('You should define your own token utility')
 class TextStyleTokenUtil {
   const TextStyleTokenUtil();
-}
-
-@immutable
-class BreakpointTokenUtil {
-  final xsmall = BreakpointToken.xsmall;
-  final small = BreakpointToken.small;
-  final medium = BreakpointToken.medium;
-  final large = BreakpointToken.large;
-  const BreakpointTokenUtil();
 }

--- a/packages/mix/test/helpers/testing_utils.dart
+++ b/packages/mix/test/helpers/testing_utils.dart
@@ -387,3 +387,36 @@ abstract base class TestScalarAttribute<
     return other ?? this as Self;
   }
 }
+
+class MixTokensTest {
+  final space = const SpaceTokenUtil();
+  final radius = const RadiusTokenUtil();
+  final color = const ColorTokenUtil();
+  final breakpoint = const BreakpointTokenUtil();
+  final textStyle = const TextStyleTokenUtil();
+
+  const MixTokensTest();
+}
+
+class RadiusTokenUtil {
+  final small = const RadiusToken('mix.radius.small');
+  final medium = const RadiusToken('mix.radius.medium');
+  final large = const RadiusToken('mix.radius.large');
+  const RadiusTokenUtil();
+}
+
+class SpaceTokenUtil {
+  final large = const SpaceToken('mix.space.large');
+  final medium = const SpaceToken('mix.space.medium');
+  final small = const SpaceToken('mix.space.small');
+
+  const SpaceTokenUtil();
+}
+
+class ColorTokenUtil {
+  const ColorTokenUtil();
+}
+
+class TextStyleTokenUtil {
+  const TextStyleTokenUtil();
+}

--- a/packages/mix/test/src/specs/flex/flex_attribute_test.dart
+++ b/packages/mix/test/src/specs/flex/flex_attribute_test.dart
@@ -5,6 +5,7 @@ import 'package:mix/mix.dart';
 import '../../../helpers/testing_utils.dart';
 
 void main() {
+  const token = MixTokensTest();
   group('FlexMixAttribute', () {
     test('of returns correct FlexMixAttribute', () {
       const attribute = FlexSpecAttribute();
@@ -51,7 +52,7 @@ void main() {
 
       final theme = MixThemeData(
         spaces: {
-          $token.space.small: tokenValue,
+          token.space.small: tokenValue,
         },
       );
 
@@ -67,7 +68,7 @@ void main() {
                   mixData = MixData.create(
                     context,
                     Style(
-                      $flex.gap.ref($token.space.small),
+                      $flex.gap.ref(token.space.small),
                     ),
                   );
 

--- a/packages/mix/test/src/theme/material/material_tokens_test.dart
+++ b/packages/mix/test/src/theme/material/material_tokens_test.dart
@@ -9,8 +9,8 @@ import '../../../helpers/testing_utils.dart';
 void main() {
   // Create a test that checks if all the values of these tokens match the ThemeData from the MaterialApp
   group('Material tokens', () {
-    Value refResolver<T extends MixToken<Value>, R extends TokenRef<T, Value>,
-        Value>(R ref, BuildContext context) {
+    Value refResolver<T extends MixToken<Value>, R extends TokenRef<T>, Value>(
+        R ref, BuildContext context) {
       return ref.token.resolve(context);
     }
 

--- a/packages/mix/test/src/theme/mix_theme_test.dart
+++ b/packages/mix/test/src/theme/mix_theme_test.dart
@@ -6,15 +6,16 @@ import '../../helpers/testing_utils.dart';
 
 void main() {
   const primaryColor = ColorToken('primary');
+  const tokenUtil = MixTokensTest();
   final theme = MixThemeData(
     breakpoints: {
-      $token.breakpoint.small: const Breakpoint(minWidth: 0, maxWidth: 599),
+      tokenUtil.breakpoint.small: const Breakpoint(minWidth: 0, maxWidth: 599),
     },
     colors: {
       primaryColor: Colors.blue,
       $material.colorScheme.error: Colors.redAccent,
     },
-    spaces: {$token.space.small: 30},
+    spaces: {tokenUtil.space.small: 30},
     textStyles: {
       $material.textTheme.bodyLarge: const TextStyle(
         fontSize: 200,
@@ -22,8 +23,8 @@ void main() {
       ),
     },
     radii: {
-      $token.radius.small: const Radius.circular(200),
-      $token.radius.large: const Radius.circular(2000),
+      tokenUtil.radius.small: const Radius.circular(200),
+      tokenUtil.radius.large: const Radius.circular(2000),
     },
   );
 
@@ -46,8 +47,8 @@ void main() {
           Box(
             style: Style(
               $box.color.ref(primaryColor),
-              $box.borderRadius.all.ref($token.radius.small),
-              $box.padding.horizontal.ref($token.space.small),
+              $box.borderRadius.all.ref(tokenUtil.radius.small),
+              $box.padding.horizontal.ref(tokenUtil.space.small),
               $text.style.ref($material.textTheme.bodyLarge),
             ),
             key: key,
@@ -67,12 +68,13 @@ void main() {
           container.decoration,
           BoxDecoration(
             color: theme.colors[primaryColor],
-            borderRadius: BorderRadius.all(theme.radii[$token.radius.small]!),
+            borderRadius:
+                BorderRadius.all(theme.radii[tokenUtil.radius.small]!),
           ),
         );
 
         expect(container.padding!.horizontal / 2,
-            theme.spaces[$token.space.small]);
+            theme.spaces[tokenUtil.space.small]);
 
         final textWidget = tester.widget<Text>(
           find.descendant(of: find.byKey(key), matching: find.byType(Text)),

--- a/packages/mix/test/src/theme/tokens/color_token_test.dart
+++ b/packages/mix/test/src/theme/tokens/color_token_test.dart
@@ -135,4 +135,79 @@ void main() {
       expect(colorRef1.hashCode, colorRef2.hashCode);
     });
   });
+
+  group('ColorSwatchToken Tests', () {
+    test('Constructor assigns name and swatch correctly', () {
+      const swatchToken =
+          ColorSwatchToken('testSwatch', {100: 'color100', 200: 'color200'});
+      expect(swatchToken.name, 'testSwatch');
+      expect(swatchToken.swatch, {100: 'color100', 200: 'color200'});
+    });
+
+    test('[] operator returns ColorTokenOfSwatch', () {
+      const swatchToken =
+          ColorSwatchToken('testSwatch', {100: 'color100', 200: 'color200'});
+      final tokenOfSwatch = swatchToken[100];
+      expect(tokenOfSwatch, isA<ColorTokenOfSwatch>());
+      expect(tokenOfSwatch.name, 'color100');
+      expect(tokenOfSwatch.index, 100);
+    });
+
+    test('scale method creates ColorSwatchToken with correct swatch', () {
+      final swatchToken = ColorSwatchToken.scale('testSwatch', 3);
+      expect(swatchToken.name, 'testSwatch');
+      expect(swatchToken.swatch,
+          {1: 'testSwatch-1', 2: 'testSwatch-2', 3: 'testSwatch-3'});
+    });
+
+    testWidgets('resolve method returns correct ColorSwatch', (tester) async {
+      const swatchToken =
+          ColorSwatchToken('testSwatch', {100: 'color100', 200: 'color200'});
+      final theme = MixThemeData(
+        colors: {
+          swatchToken:
+              const ColorSwatch(100, {100: Colors.red, 200: Colors.blue}),
+        },
+      );
+
+      await tester.pumpWidget(createWithMixTheme(theme));
+
+      final context = tester.element(find.byType(Container));
+      final resolvedSwatch = swatchToken.resolve(context);
+
+      expect(resolvedSwatch, isA<ColorSwatch>());
+      expect(resolvedSwatch[100], Colors.red);
+      expect(resolvedSwatch[200], Colors.blue);
+    });
+  });
+
+  group('ColorTokenOfSwatch Tests', () {
+    test('Constructor assigns name, swatchToken, and index correctly', () {
+      const swatchToken =
+          ColorSwatchToken('testSwatch', {100: 'color100', 200: 'color200'});
+      const tokenOfSwatch = ColorTokenOfSwatch('color100', swatchToken, 100);
+      expect(tokenOfSwatch.name, 'color100');
+      expect(tokenOfSwatch.swatchToken, swatchToken);
+      expect(tokenOfSwatch.index, 100);
+    });
+
+    testWidgets('resolve method returns correct Color', (tester) async {
+      const swatchToken =
+          ColorSwatchToken('testSwatch', {100: 'color100', 200: 'color200'});
+      const tokenOfSwatch = ColorTokenOfSwatch('color100', swatchToken, 100);
+      final theme = MixThemeData(
+        colors: {
+          swatchToken:
+              const ColorSwatch(100, {100: Colors.red, 200: Colors.blue}),
+        },
+      );
+
+      await tester.pumpWidget(createWithMixTheme(theme));
+
+      final context = tester.element(find.byType(Container));
+      final resolvedColor = tokenOfSwatch.resolve(context);
+
+      expect(resolvedColor, Colors.red);
+    });
+  });
 }

--- a/packages/mix/test/src/theme/tokens/color_token_test.dart
+++ b/packages/mix/test/src/theme/tokens/color_token_test.dart
@@ -153,6 +153,22 @@ void main() {
       expect(tokenOfSwatch.index, 100);
     });
 
+    test('[] operator throws assertion error for non-existent index', () {
+      const swatchToken = ColorSwatchToken('testSwatch', {100: 'color100'});
+      expect(() => swatchToken[200], throwsAssertionError);
+    });
+
+    test('Equality and hashCode', () {
+      const swatchToken1 = ColorSwatchToken('testSwatch', {100: 'color100'});
+      const swatchToken2 = ColorSwatchToken('testSwatch', {100: 'color100'});
+      const swatchToken3 =
+          ColorSwatchToken('differentSwatch', {100: 'color100'});
+
+      expect(swatchToken1, equals(swatchToken2));
+      expect(swatchToken1.hashCode, equals(swatchToken2.hashCode));
+      expect(swatchToken1, isNot(equals(swatchToken3)));
+    });
+
     test('scale method creates ColorSwatchToken with correct swatch', () {
       final swatchToken = ColorSwatchToken.scale('testSwatch', 3);
       expect(swatchToken.name, 'testSwatch');
@@ -208,6 +224,23 @@ void main() {
       final resolvedColor = tokenOfSwatch.resolve(context);
 
       expect(resolvedColor, Colors.red);
+    });
+
+    test('call() method returns ColorRef with correct token', () {
+      const swatchToken = ColorSwatchToken('testSwatch', {100: 'color100'});
+      const tokenOfSwatch = ColorTokenOfSwatch('color100', swatchToken, 100);
+      expect(tokenOfSwatch(), equals(const ColorRef(tokenOfSwatch)));
+    });
+
+    test('Equality and hashCode', () {
+      const swatchToken = ColorSwatchToken('testSwatch', {100: 'color100'});
+      const tokenOfSwatch1 = ColorTokenOfSwatch('color100', swatchToken, 100);
+      const tokenOfSwatch2 = ColorTokenOfSwatch('color100', swatchToken, 100);
+      const tokenOfSwatch3 = ColorTokenOfSwatch('color200', swatchToken, 200);
+
+      expect(tokenOfSwatch1, equals(tokenOfSwatch2));
+      expect(tokenOfSwatch1.hashCode, equals(tokenOfSwatch2.hashCode));
+      expect(tokenOfSwatch1, isNot(equals(tokenOfSwatch3)));
     });
   });
 }

--- a/packages/mix/test/src/theme/tokens/text_style_token_test.dart
+++ b/packages/mix/test/src/theme/tokens/text_style_token_test.dart
@@ -4,6 +4,7 @@ import 'package:mix/mix.dart';
 
 import '../../../helpers/testing_utils.dart';
 
+const _tokens = MixTokensTest();
 void main() {
   group('TextStyleToken', () {
     test('Constructor assigns name correctly', () {
@@ -70,8 +71,8 @@ void main() {
         $material.colorScheme.background: Colors.red,
       },
       spaces: {
-        $token.space.large: 100,
-        $token.space.medium: 50,
+        _tokens.space.large: 100,
+        _tokens.space.medium: 50,
       },
       textStyles: {
         $material.textTheme.bodyText1: const TextStyle(
@@ -84,8 +85,8 @@ void main() {
             fontVariations: [FontVariation('wght', 700)]),
       },
       radii: {
-        $token.radius.medium: const Radius.elliptical(10, 50),
-        $token.radius.large: const Radius.elliptical(50, 50),
+        _tokens.radius.medium: const Radius.elliptical(10, 50),
+        _tokens.radius.large: const Radius.elliptical(50, 50),
       },
     );
 
@@ -98,10 +99,10 @@ void main() {
           $text.style.ref($material.textTheme.bodyText2),
           $box.color.ref($material.colorScheme.background),
           $box.color.ref($material.colorScheme.error),
-          $box.borderRadius.all.ref($token.radius.medium),
-          $box.borderRadius.all.ref($token.radius.large),
-          $box.padding.horizontal.ref($token.space.medium),
-          $box.padding.horizontal.ref($token.space.large),
+          $box.borderRadius.all.ref(_tokens.radius.medium),
+          $box.borderRadius.all.ref(_tokens.radius.large),
+          $box.padding.horizontal.ref(_tokens.space.medium),
+          $box.padding.horizontal.ref(_tokens.space.large),
         ),
         key: key,
         child: const StyledText('Hello'),
@@ -139,12 +140,12 @@ void main() {
 
     expect(
       (containerWidget.decoration as BoxDecoration).borderRadius,
-      BorderRadius.all(themeData.radii[$token.radius.large]!),
+      BorderRadius.all(themeData.radii[_tokens.radius.large]!),
     );
 
     expect(
       containerWidget.padding!.horizontal / 2,
-      themeData.spaces[$token.space.large],
+      themeData.spaces[_tokens.space.large],
     );
   });
 

--- a/packages/mix_annotations/.gitignore
+++ b/packages/mix_annotations/.gitignore
@@ -1,7 +1,0 @@
-# https://dart.dev/guides/libraries/private-files
-# Created by `dart pub`
-.dart_tool/
-
-# Avoid committing pubspec.lock for library packages; see
-# https://dart.dev/guides/libraries/private-files#pubspeclock.
-pubspec.lock

--- a/packages/mix_generator/lib/src/builders/method_merge.dart
+++ b/packages/mix_generator/lib/src/builders/method_merge.dart
@@ -18,15 +18,16 @@ String mergeMethodBuilder({
   final fieldStatements = fields.map((field) {
     final propName = field.name;
     final thisName = isInternalRef ? field.asInternalRef : field.name;
-    final nullable = field.nullable ? '?' : '';
+    final nullable = '?';
 
     var propAssignment = '$propName:';
 
     if (field.isListType) {
+      final listNullable = field.nullable ? '?' : '';
       if (shouldMergeLists) {
         return '$propAssignment ${MixHelperRef.mergeList}($thisName, other.$propName)';
       } else {
-        return '$propAssignment [...$nullable$thisName,...${nullable}other.$propName]';
+        return '$propAssignment [...$listNullable$thisName,...${listNullable}other.$propName]';
       }
     }
     if (field.hasDto) {
@@ -49,11 +50,7 @@ String mergeMethodBuilder({
 
       return '$propAssignment $thisName$nullable.merge(other.$propName) ?? other.$propName';
     } else {
-      if (field.nullable) {
-        return '$propAssignment other.$propName ?? $thisName';
-      } else {
-        return '$propAssignment other.$propName';
-      }
+      return '$propAssignment other.$propName ?? $thisName';
     }
   }).join(',\n      ');
 

--- a/packages/mix_generator/lib/src/mixable_dto_generator.dart
+++ b/packages/mix_generator/lib/src/mixable_dto_generator.dart
@@ -6,7 +6,6 @@ import 'package:mix_annotations/mix_annotations.dart';
 import 'package:mix_generator/src/builders/dto/class_utility_dto.dart';
 import 'package:mix_generator/src/builders/dto/extension_value.dart';
 import 'package:mix_generator/src/builders/dto/mixin_dto.dart';
-// ignore_for_file: prefer_relative_imports
 import 'package:mix_generator/src/helpers/field_info.dart';
 import 'package:mix_generator/src/helpers/settings.dart';
 import 'package:mix_generator/src/helpers/visitors.dart';

--- a/packages/mix_lint/.gitignore
+++ b/packages/mix_lint/.gitignore
@@ -1,3 +1,0 @@
-# https://dart.dev/guides/libraries/private-files
-# Created by `dart pub`
-.dart_tool/


### PR DESCRIPTION
This allows to add a ColorSwatch as a token value to MixThemeData. Also some improvements on typing for other tokens and simpler merge behavior for code gen.


**Review Checklist**

- [x] **Testing**: Have you tested your changes, including unit tests and integration tests for affected code?
- [ ] **Breaking Changes**: Does this change introduce breaking changes affecting existing code or users?
- [ ] **Documentation Updates**: Are all relevant documentation files (e.g. README, API docs) updated to reflect the changes in this PR?
- [ ] **Website Updates**: Is the website containing the updates you make on documentation?

