### PR TITLE
fix: add flexible as the first in the order of modifiers

### DIFF
--- a/packages/mix/lib/src/modifiers/render_widget_modifier.dart
+++ b/packages/mix/lib/src/modifiers/render_widget_modifier.dart
@@ -5,46 +5,43 @@ import 'package:flutter/material.dart';
 import '../core/factory/mix_data.dart';
 import '../core/modifier.dart';
 import '../core/spec.dart';
-import 'align_widget_modifier.dart';
-import 'aspect_ratio_widget_modifier.dart';
-import 'clip_widget_modifier.dart';
-import 'fractionally_sized_box_widget_modifier.dart';
-import 'intrinsic_widget_modifier.dart';
-import 'opacity_widget_modifier.dart';
-import 'sized_box_widget_modifier.dart';
-import 'transform_widget_modifier.dart';
-import 'visibility_widget_modifier.dart';
+import 'modifiers.dart';
 
 const _defaultOrder = [
-  // 1. VisibilityModifier: Controls overall visibility. If the widget is set to be invisible,
+  // 1. FlexibleModifier: When the widget is used inside a Row, Column, or Flex widget, it will
+  // automatically adjust its size to fill the available space. This modifier is applied first to
+  // ensure that the widget is not affected by any other modifiers.
+  FlexibleModifierSpec,
+
+  // 2. VisibilityModifier: Controls overall visibility. If the widget is set to be invisible,
   // none of the subsequent decorations are processed, providing an early exit and optimizing performance.
   VisibilityModifierSpec,
 
-  // 2. SizedBoxModifier: Explicitly sets the size of the widget before any other transformations are applied.
+  // 3. SizedBoxModifier: Explicitly sets the size of the widget before any other transformations are applied.
   // This ensures that the widget occupies a predetermined space, which is crucial for layouts that require exact dimensions.
   SizedBoxModifierSpec,
 
-  // 3. FractionallySizedBoxModifier: Adjusts the widget's size relative to its parent's size,
+  // 4. FractionallySizedBoxModifier: Adjusts the widget's size relative to its parent's size,
   // allowing for responsive layouts that scale with the parent widget. This modifier is applied after
   // explicit sizing to refine the widget's dimensions based on available space.
   FractionallySizedBoxModifierSpec,
 
-  // 4. AlignModifier: Aligns the widget within its allocated space, which is especially important
+  // 5. AlignModifier: Aligns the widget within its allocated space, which is especially important
   // for positioning the widget correctly before applying any transformations that could affect its position.
   // Alignment is based on the size constraints established by previous modifiers.
   AlignModifierSpec,
 
-  // 5. IntrinsicHeightModifier: Adjusts the widget's height to fit its child's intrinsic height,
+  // 6. IntrinsicHeightModifier: Adjusts the widget's height to fit its child's intrinsic height,
   // ensuring that the widget does not force its children to conform to an unnatural height. This is particularly
   // useful for widgets that should size themselves based on content.
   IntrinsicHeightModifierSpec,
 
-  // 6. IntrinsicWidthModifier: Similar to the IntrinsicHeightModifier, this adjusts the widget's width
+  // 7. IntrinsicWidthModifier: Similar to the IntrinsicHeightModifier, this adjusts the widget's width
   // to its child's intrinsic width. This modifier allows for content-driven width adjustments, making it ideal
   // for widgets that need to wrap their content tightly.
   IntrinsicWidthModifierSpec,
 
-  // 7. AspectRatioModifier: Maintains the widget's aspect ratio after sizing adjustments.
+  // 8. AspectRatioModifier: Maintains the widget's aspect ratio after sizing adjustments.
   // This modifier ensures that the widget scales correctly within its given aspect ratio constraints,
   // which is critical for preserving the visual integrity of images and other aspect-sensitive content.
   AspectRatioModifierSpec,
@@ -54,7 +51,16 @@ const _defaultOrder = [
   // and position in more complex ways without altering the logical layout.
   TransformModifierSpec,
 
-  // 10. Clip Modifiers: Applies clipping in various shapes to the transformed widget, shaping the final appearance.
+  // 10. PaddingModifier: Adds padding or empty space around a widget. Padding is applied after all
+  // sizing adjustments to ensure that the widget's contents are not affected by the padding.
+  PaddingSpec,
+
+  // 11. TransformModifier: Applies arbitrary transformations, such as rotation, scaling, and translation.
+  // Transformations are applied after all sizing and positioning adjustments to modify the widget's appearance
+  // and position in more complex ways without altering the logical layout.
+  RotatedBoxModifierSpec,
+
+  // 12. Clip Modifiers: Applies clipping in various shapes to the transformed widget, shaping the final appearance.
   // Clipping is one of the last steps to ensure it is applied to the widget's final size, position, and transformation state.
   ClipOvalModifierSpec,
   ClipRRectModifierSpec,
@@ -62,7 +68,7 @@ const _defaultOrder = [
   ClipTriangleModifierSpec,
   ClipRectModifierSpec,
 
-  // 11. OpacityModifier: Modifies the widget's opacity as the final decoration step. Applying opacity last ensures
+  // 13. OpacityModifier: Modifies the widget's opacity as the final decoration step. Applying opacity last ensures
   // that it does not influence the layout or transformations, serving purely as a visual effect to alter the transparency
   // of the widget and its decorations.
   OpacityModifierSpec,

--- a/packages/mix/lib/src/modifiers/render_widget_modifier.dart
+++ b/packages/mix/lib/src/modifiers/render_widget_modifier.dart
@@ -55,9 +55,8 @@ const _defaultOrder = [
   // sizing adjustments to ensure that the widget's contents are not affected by the padding.
   PaddingSpec,
 
-  // 11. TransformModifier: Applies arbitrary transformations, such as rotation, scaling, and translation.
-  // Transformations are applied after all sizing and positioning adjustments to modify the widget's appearance
-  // and position in more complex ways without altering the logical layout.
+  // 11. RotatedBoxModifier: Rotates the widget by a given angle. This modifier is applied after all sizing
+  // and positioning adjustments to ensure that the widget's contents will be rotated correctly.
   RotatedBoxModifierSpec,
 
   // 12. Clip Modifiers: Applies clipping in various shapes to the transformed widget, shaping the final appearance.


### PR DESCRIPTION
#### Related issue
closes #373 

### Description

Review the order of modifiers

### Changes

Add FlexibleModifier, PaddingModifier, and RotatedModifier.

**Review Checklist**

- [ ] **Testing**: Have you tested your changes, including unit tests and integration tests for the affected code?
- [ ] **Breaking Changes**: Does this change introduce breaking changes affecting existing code or users?
- [ ] **Documentation Updates**: Are all relevant documentation files (e.g. README, API docs) updated to reflect the changes in this PR?
- [ ] **Website Updates**: Is the website containing the updates you make on documentation?