### PR TITLE
feat: create an assist to extract attributes from a Style

### DIFF
--- a/packages/mix_lint/lib/mix_lint.dart
+++ b/packages/mix_lint/lib/mix_lint.dart
@@ -1,6 +1,7 @@
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 import 'package:mix_lint/src/lints/max_number_of_attributes_per_style/max_number_of_attributes_per_style.dart';
 
+import 'src/assists/extract_attributes.dart';
 import 'src/lints/attributes_ordering.dart';
 import 'src/lints/avoid_defining_tokens_or_variants_within_style.dart';
 import 'src/lints/avoid_defining_tokens_within_theme_data.dart';
@@ -10,6 +11,11 @@ import 'src/lints/avoid_variant_inside_context_variant.dart';
 PluginBase createPlugin() => _MixLint();
 
 class _MixLint extends PluginBase {
+  @override
+  List<Assist> getAssists() {
+    return [ExtractAttributes()];
+  }
+
   @override
   List<LintRule> getLintRules(CustomLintConfigs configs) => [
         AttributesOrdering(),

--- a/packages/mix_lint/lib/src/assists/extract_attributes.dart
+++ b/packages/mix_lint/lib/src/assists/extract_attributes.dart
@@ -1,0 +1,67 @@
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/source/source_range.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+import 'package:mix_lint/src/utils/extensions/dart_file_edit_builder.dart'
+    as ext;
+import 'package:mix_lint/src/utils/type_checker.dart';
+
+class ExtractAttributes extends DartAssist {
+  @override
+  Future<void> run(
+    CustomLintResolver resolver,
+    ChangeReporter reporter,
+    CustomLintContext context,
+    SourceRange target,
+  ) async {
+    const extractedFieldName = 'extractedAttributes';
+    final unit = await resolver.getResolvedUnitResult();
+
+    context.registry.addInstanceCreationExpression((node) {
+      if (!node.sourceRange.covers(target)) return;
+      if (node.staticType == null ||
+          !styleChecker.isAssignableFromType(node.staticType!)) return;
+
+      final (ancestorNode, offset) = _getValidAncestor(node);
+
+      if (ancestorNode == null || offset == null) return;
+
+      final changeBuilder = reporter.createChangeBuilder(
+        message: 'Extract Attributes',
+        priority: 100,
+      );
+
+      changeBuilder.addDartFileEdit((builder) {
+        try {
+          builder.addSimpleReplacement(
+            target,
+            '$extractedFieldName(),',
+          );
+          builder.addSimpleInsertion(
+            offset,
+            'final $extractedFieldName = Style(${unit.content.substring(target.offset, target.end)});',
+          );
+          builder.formatBasedOnAncestor<ClassDeclaration>(node);
+        } catch (e) {
+          return;
+        }
+      });
+    });
+  }
+
+  (AstNode?, int? offset) _getValidAncestor(InstanceCreationExpression node) {
+    AstNode? result;
+    result = node.thisOrAncestorMatching<Block>((node) {
+      return node is Block;
+    });
+
+    if (result != null) return (result, result.offset + 1);
+
+    result = node.thisOrAncestorMatching<FieldDeclaration>((node) {
+      return node is FieldDeclaration;
+    });
+
+    if (result != null) return (result, result.offset);
+
+    return (null, null);
+  }
+}

--- a/packages/mix_lint/lib/src/utils/extensions/dart_file_edit_builder.dart
+++ b/packages/mix_lint/lib/src/utils/extensions/dart_file_edit_builder.dart
@@ -1,0 +1,13 @@
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer_plugin/utilities/change_builder/change_builder_dart.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+
+extension DartFileEditBuilderExt on DartFileEditBuilder {
+  void formatBasedOnAncestor<E extends AstNode>(AstNode node) {
+    final ancestorClass = node.thisOrAncestorMatching<E>((node) {
+      return node is E;
+    });
+    if (ancestorClass == null) return;
+    format(ancestorClass.sourceRange);
+  }
+}


### PR DESCRIPTION
### Description

- This assist can extract a group of attributes from a style and wrap them in a variable called `extractedAttributes`.

### Changes

- Add a folder called `assists`
- Create the first assist.

**Review Checklist**

- [ ] **Testing**: Have you tested your changes, including unit tests and integration tests for affected code?
- [ ] **Breaking Changes**: Does this change introduce breaking changes affecting existing code or users?
- [ ] **Documentation Updates**: Are all relevant documentation files (e.g. README, API docs) updated to reflect the changes in this PR?
- [ ] **Website Updates**: Is the website containing the updates you make on documentation?

### Additional Information (optional)


https://github.com/user-attachments/assets/533e263b-db80-46a3-ad44-304e2fd909f6


https://github.com/user-attachments/assets/50377d96-8c09-4912-8ac4-9c696caa2e49


