### PR TITLE
feat: Improvements for the "extract attributes" assist 

### DIFF
--- a/packages/mix_lint/lib/src/assists/extract_attributes.dart
+++ b/packages/mix_lint/lib/src/assists/extract_attributes.dart
@@ -19,7 +19,7 @@ class ExtractAttributes extends DartAssist {
     final unit = await resolver.getResolvedUnitResult();
 
     context.registry.addInstanceCreationExpression((node) {
-      if (!node.sourceRange.covers(target)) return;
+      if (!node.argumentList.sourceRange.covers(target)) return;
       if (node.staticType == null ||
           !styleChecker.isAssignableFromType(node.staticType!)) return;
 

--- a/packages/mix_lint/lib/src/assists/extract_attributes.dart
+++ b/packages/mix_lint/lib/src/assists/extract_attributes.dart
@@ -1,9 +1,12 @@
+import 'dart:async';
+
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/source/source_range.dart';
+import 'package:analyzer_plugin/utilities/change_builder/change_builder_dart.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
-import 'package:mix_lint/src/utils/extensions/dart_file_edit_builder.dart'
-    as ext;
+import 'package:mix_lint/src/utils/extensions/dart_file_edit_builder.dart';
 import 'package:mix_lint/src/utils/type_checker.dart';
+import 'package:mix_lint/src/utils/visitors.dart';
 
 class ExtractAttributes extends DartAssist {
   @override
@@ -13,7 +16,6 @@ class ExtractAttributes extends DartAssist {
     CustomLintContext context,
     SourceRange target,
   ) async {
-    const extractedFieldName = 'extractedAttributes';
     final unit = await resolver.getResolvedUnitResult();
 
     context.registry.addInstanceCreationExpression((node) {
@@ -21,9 +23,8 @@ class ExtractAttributes extends DartAssist {
       if (node.staticType == null ||
           !styleChecker.isAssignableFromType(node.staticType!)) return;
 
-      final (ancestorNode, offset) = _getValidAncestor(node);
-
-      if (ancestorNode == null || offset == null) return;
+      final extractor = _getExtractionInfo(node, target);
+      if (extractor == null) return;
 
       final changeBuilder = reporter.createChangeBuilder(
         message: 'Extract Attributes',
@@ -31,16 +32,10 @@ class ExtractAttributes extends DartAssist {
       );
 
       changeBuilder.addDartFileEdit((builder) {
+        extractor.builder = builder;
+
         try {
-          builder.addSimpleReplacement(
-            target,
-            '$extractedFieldName(),',
-          );
-          builder.addSimpleInsertion(
-            offset,
-            'final $extractedFieldName = Style(${unit.content.substring(target.offset, target.end)});',
-          );
-          builder.formatBasedOnAncestor<ClassDeclaration>(node);
+          extractor.applyRefactor(unit.content);
         } catch (e) {
           return;
         }
@@ -48,20 +43,279 @@ class ExtractAttributes extends DartAssist {
     });
   }
 
-  (AstNode?, int? offset) _getValidAncestor(InstanceCreationExpression node) {
-    AstNode? result;
-    result = node.thisOrAncestorMatching<Block>((node) {
+  _AttributesExtractor? _getExtractionInfo(
+    InstanceCreationExpression node,
+    SourceRange target,
+  ) {
+    AstNode? ancestorNode;
+
+    ancestorNode = node.thisOrAncestorMatching<Block>((node) {
+      print('node ${node.runtimeType}');
       return node is Block;
     });
 
-    if (result != null) return (result, result.offset + 1);
+    if (ancestorNode != null && ancestorNode is Block)
+      return _BlockExtractor(
+        target: target,
+        node: ancestorNode,
+        extractedCodeName: _getNameForExtractedCode(node, target),
+      );
 
-    result = node.thisOrAncestorMatching<FieldDeclaration>((node) {
+    ancestorNode = node.thisOrAncestorMatching<FieldDeclaration>((node) {
       return node is FieldDeclaration;
     });
 
-    if (result != null) return (result, result.offset);
+    if (ancestorNode != null && ancestorNode is FieldDeclaration)
+      return _FieldDeclarationExtractor(
+        target: target,
+        node: ancestorNode,
+        extractedCodeName: _getNameForExtractedCode(node, target),
+      );
 
-    return (null, null);
+    ancestorNode = node.thisOrAncestorMatching<MethodDeclaration>((node) {
+      return node is MethodDeclaration && node.isGetter;
+    });
+
+    if (ancestorNode != null && ancestorNode is MethodDeclaration)
+      return _MethodDeclarationExtractor(
+        target: target,
+        node: ancestorNode,
+        extractedCodeName: _getNameForExtractedCode(node, target),
+      );
+
+    ancestorNode =
+        node.thisOrAncestorMatching<TopLevelVariableDeclaration>((node) {
+      print(node);
+      return node is TopLevelVariableDeclaration;
+    });
+
+    if (ancestorNode != null && ancestorNode is TopLevelVariableDeclaration)
+      return _TopLevelVariableDeclarationExtractor(
+        target: target,
+        node: ancestorNode,
+        extractedCodeName: _getNameForExtractedCode(node, target),
+      );
+
+    ancestorNode = node.thisOrAncestorMatching<FunctionDeclaration>((node) {
+      return node is FunctionDeclaration && node.isGetter;
+    });
+
+    if (ancestorNode != null && ancestorNode is FunctionDeclaration)
+      return _FunctionDeclarationExtractor(
+        target: target,
+        node: ancestorNode,
+        extractedCodeName: _getNameForExtractedCode(node, target),
+      );
+
+    return null;
+  }
+
+  String _getNameForExtractedCode(
+      InstanceCreationExpression node, SourceRange target) {
+    final functionExpression = <FunctionExpressionInvocation>[];
+    final visitor = RecursiveFunctionExpressionInvocationVisitor(
+      onVisitFunctionExpressionInvocation: functionExpression.add,
+    );
+    node.argumentList.accept(visitor);
+
+    final variants = functionExpression
+        .where(
+          (e) =>
+              variantAttributeChecker.isAssignableFromType(e.staticType!) &&
+              e.sourceRange.covers(target),
+        )
+        .map((e) => e.function.endToken);
+
+    if (variants.isEmpty) return 'extractedAttributes';
+    ;
+
+    return '${variants.last}Variant';
+  }
+}
+
+abstract class _AttributesExtractor<T extends AstNode> {
+  final SourceRange target;
+  final T node;
+  final String extractedCodeName;
+  DartFileEditBuilder? builder = null;
+
+  _AttributesExtractor({
+    required this.target,
+    required this.node,
+    required this.extractedCodeName,
+  });
+
+  void applyRefactor(String content);
+}
+
+class _BlockExtractor extends _AttributesExtractor<Block> {
+  _BlockExtractor({
+    required super.target,
+    required super.node,
+    required super.extractedCodeName,
+  });
+
+  void applyRefactor(String content) {
+    builder?.addSimpleReplacement(
+      target,
+      '$extractedCodeName(),',
+    );
+
+    builder?.addSimpleInsertion(
+      node.offset + 1,
+      'final $extractedCodeName = Style(${content.substring(target.offset, target.end)});',
+    );
+
+    builder?.formatBasedOnAncestor<ClassDeclaration>(node);
+  }
+}
+
+class _FieldDeclarationExtractor
+    extends _AttributesExtractor<FieldDeclaration> {
+  _FieldDeclarationExtractor({
+    required super.target,
+    required super.node,
+    required super.extractedCodeName,
+  });
+
+  String reformatCode(String content) {
+    return content.substring(node.offset, node.end).replaceRange(
+          target.offset - node.offset,
+          target.offset - node.offset + target.length,
+          '$extractedCodeName(),',
+        );
+  }
+
+  void applyRefactor(String content) {
+    final newFieldCode = reformatCode(content);
+
+    builder?.addReplacement(
+      node.sourceRange,
+      (builder) {
+        builder.writeFieldDeclaration(
+          extractedCodeName,
+          isFinal: true,
+          initializerWriter: () {
+            builder.write(
+                'Style(${content.substring(target.offset, target.end)})');
+          },
+        );
+
+        if (node.beginToken.toString() != 'late') {
+          builder.write('late ${newFieldCode}');
+        } else {
+          builder.write(newFieldCode);
+        }
+      },
+    );
+
+    builder?.formatBasedOnAncestor<ClassDeclaration>(node);
+  }
+}
+
+class _MethodDeclarationExtractor
+    extends _AttributesExtractor<MethodDeclaration> {
+  _MethodDeclarationExtractor({
+    required super.target,
+    required super.node,
+    required super.extractedCodeName,
+  });
+
+  void applyRefactor(String content) {
+    builder?.addSimpleReplacement(
+      target,
+      '$extractedCodeName(),',
+    );
+
+    builder?.addInsertion(
+      node.offset,
+      (builder) {
+        builder.writeGetterDeclaration(
+          extractedCodeName,
+          bodyWriter: () {
+            builder.write(
+              '=> Style(${content.substring(target.offset, target.end)});',
+            );
+          },
+        );
+      },
+    );
+
+    builder?.formatBasedOnAncestor<ClassDeclaration>(node);
+  }
+}
+
+class _TopLevelVariableDeclarationExtractor
+    extends _AttributesExtractor<TopLevelVariableDeclaration> {
+  _TopLevelVariableDeclarationExtractor({
+    required super.target,
+    required super.node,
+    required super.extractedCodeName,
+  });
+
+  String get privateExtractedCodeName => '_$extractedCodeName';
+
+  String reformatCode(String content) {
+    return content.substring(node.offset, node.end).replaceRange(
+          target.offset - node.offset,
+          target.offset - node.offset + target.length,
+          '$privateExtractedCodeName(),',
+        );
+  }
+
+  void applyRefactor(String content) {
+    final newFieldCode = reformatCode(content);
+
+    builder?.addReplacement(
+      node.sourceRange,
+      (builder) {
+        builder.writeFieldDeclaration(
+          privateExtractedCodeName,
+          isFinal: true,
+          initializerWriter: () {
+            builder.write(
+                'Style(${content.substring(target.offset, target.end)})');
+          },
+        );
+
+        builder.write(newFieldCode);
+      },
+    );
+
+    builder?.format(node.sourceRange);
+  }
+}
+
+class _FunctionDeclarationExtractor
+    extends _AttributesExtractor<FunctionDeclaration> {
+  _FunctionDeclarationExtractor({
+    required super.target,
+    required super.node,
+    required super.extractedCodeName,
+  });
+
+  String get privateExtractedCodeName => '_$extractedCodeName';
+
+  void applyRefactor(String content) {
+    builder?.addSimpleReplacement(
+      target,
+      '$privateExtractedCodeName(),',
+    );
+
+    builder?.addInsertion(
+      node.offset,
+      (builder) {
+        builder.writeGetterDeclaration(
+          privateExtractedCodeName,
+          bodyWriter: () {
+            builder.write(
+              '=> Style(${content.substring(target.offset, target.end)});',
+            );
+          },
+        );
+      },
+    );
+
+    builder?.format(node.sourceRange);
   }
 }

--- a/packages/mix_lint/lib/src/utils/visitors.dart
+++ b/packages/mix_lint/lib/src/utils/visitors.dart
@@ -14,3 +14,19 @@ class RecursiveSimpleIdentifierVisitor extends RecursiveAstVisitor<void> {
     node.visitChildren(this);
   }
 }
+
+class RecursiveFunctionExpressionInvocationVisitor
+    extends RecursiveAstVisitor<void> {
+  const RecursiveFunctionExpressionInvocationVisitor({
+    required this.onVisitFunctionExpressionInvocation,
+  });
+
+  final void Function(FunctionExpressionInvocation node)
+      onVisitFunctionExpressionInvocation;
+
+  @override
+  void visitFunctionExpressionInvocation(FunctionExpressionInvocation node) {
+    onVisitFunctionExpressionInvocation(node);
+    node.visitChildren(this);
+  }
+}


### PR DESCRIPTION
### Description

- Add new features to the assist "extract attributes" allowing extracting attributes from `TopLevelVariableDeclaration`, `FunctionDeclaration` and `MethodDeclaration`. 
- The new features include automatically adding 'late' at the beginning of a field when necessary, and '_' private to `TopLevelVariableDeclaration` and top-level getters.
- When attributes inside a variant's scope change it receives the name of the variant + "Variant"

### Changes

- The assist was refactored

**Review Checklist**

- [ ] **Testing**: Have you tested your changes, including unit tests and integration tests for affected code?
- [ ] **Breaking Changes**: Does this change introduce breaking changes affecting existing code or users?
- [ ] **Documentation Updates**: Are all relevant documentation files (e.g. README, API docs) updated to reflect the changes in this PR?
- [ ] **Website Updates**: Is the website containing the updates you make on documentation?
