### PR TITLE
fix: normalization of order of modifier when applied to a Styled Widget

### DIFF
--- a/packages/mix/lib/src/core/styled_widget.dart
+++ b/packages/mix/lib/src/core/styled_widget.dart
@@ -73,12 +73,14 @@ abstract class StyledWidget extends StatelessWidget {
         ? RenderAnimatedModifiers(
             modifiers: modifiers,
             duration: mix.animation!.duration,
+            mix: mix,
             orderOfModifiers: orderOfModifiers,
             curve: mix.animation!.curve,
             child: child,
           )
         : RenderModifiers(
             modifiers: modifiers,
+            mix: mix,
             orderOfModifiers: orderOfModifiers,
             child: child,
           );

--- a/packages/mix/lib/src/modifiers/internal/render_widget_modifier.dart
+++ b/packages/mix/lib/src/modifiers/internal/render_widget_modifier.dart
@@ -90,7 +90,9 @@ class RenderModifiers extends StatelessWidget {
   const RenderModifiers({
     required this.child,
     this.modifiers = const [],
-    @Deprecated("Use modifiers parameter") this.mix,
+    // the mix parameter is needed to allow users to specify the order of modifiers
+    // in two different ways. Using Attributes and Specs
+    this.mix,
     required this.orderOfModifiers,
     super.key,
   });
@@ -130,11 +132,12 @@ class _RenderModifiers extends StatelessWidget {
 class RenderAnimatedModifiers extends StatelessWidget {
   const RenderAnimatedModifiers({
     super.key,
-    //TODO Should be required in the next version
     this.modifiers = const [],
     required this.child,
     required this.duration,
-    @Deprecated("Use modifiers parameter") this.mix,
+    // the mix parameter is needed to allow users to specify the order of modifiers
+    // in two different ways. Using Attributes and Specs
+    this.mix,
     required this.orderOfModifiers,
     this.curve = Curves.linear,
     this.onEnd,

--- a/packages/mix/test/helpers/override_modifiers_order.dart
+++ b/packages/mix/test/helpers/override_modifiers_order.dart
@@ -16,7 +16,7 @@ testOverrideModifiersOrder(
     const ClipOvalModifierAttribute(),
     const PaddingModifierAttribute(EdgeInsetsDirectionalDto(top: 10)),
   );
-  const orderOfModifiers = [
+  const orderOfModifiersOnlySpecs = [
     ClipOvalModifierSpec,
     AspectRatioModifierSpec,
     TransformModifierSpec,
@@ -24,7 +24,52 @@ testOverrideModifiersOrder(
     VisibilityModifierSpec,
   ];
 
-  final widget = widgetBuilder(style, orderOfModifiers);
+  // JUST SPECS
+  await verifyDescendants(
+    widgetBuilder(style, orderOfModifiersOnlySpecs),
+    style,
+    orderOfModifiersOnlySpecs,
+    tester,
+  );
+
+  // SPECS + ATTRIBUTES
+  const orderOfModifiersSpecsAndAttributes = [
+    ClipOvalModifierSpec,
+    AspectRatioModifierAttribute,
+    TransformModifierAttribute,
+    OpacityModifierSpec,
+    VisibilityModifierAttribute,
+  ];
+  await verifyDescendants(
+    widgetBuilder(style, orderOfModifiersSpecsAndAttributes),
+    style,
+    orderOfModifiersSpecsAndAttributes,
+    tester,
+  );
+
+  // JUST ATTRIBUTES
+  const orderOfModifiersOnlyAttributes = [
+    ClipOvalModifierAttribute,
+    AspectRatioModifierAttribute,
+    TransformModifierAttribute,
+    OpacityModifierAttribute,
+    VisibilityModifierAttribute,
+  ];
+
+  await verifyDescendants(
+    widgetBuilder(style, orderOfModifiersOnlyAttributes),
+    style,
+    orderOfModifiersOnlyAttributes,
+    tester,
+  );
+}
+
+Future<void> verifyDescendants(
+  Widget widget,
+  Style style,
+  List<Type> orderOfModifiers,
+  WidgetTester tester,
+) async {
   await tester.pumpMaterialApp(
     widget,
   );


### PR DESCRIPTION
### Description

- The StyledWidgets could not receive a list with `Specs` and `Attributes`.

### Changes

- The unit test was enhanced to include tests for three scenarios: only `Specs`, only `Attributes`, and `Specs + Attributes`.
- The parameter "mix" is no longer deprecated. It is now used for normalization.

**Review Checklist**

- [x] **Testing**: Have you tested your changes, including unit tests and integration tests for affected code?
- [ ] **Breaking Changes**: Does this change introduce breaking changes affecting existing code or users?
- [ ] **Documentation Updates**: Are all relevant documentation files (e.g. README, API docs) updated to reflect the changes in this PR?
- [ ] **Website Updates**: Is the website containing the updates you make on documentation?

