### PR TITLE
fix: Code gen linting fixes

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -73,9 +73,19 @@ runs:
         fatal_performance: true
         fatal_warnings: true
 
-    - name: Run fixes
+    - name: Run melos fix
       run: melos run fix
       shell: bash
+      
+    - name: Commit changes
+      run: |
+        git config --global user.email "github-actions[bot]@users.noreply.github.com"
+        git config --global user.name "github-actions[bot]"
+        git add .
+        git diff-index --quiet HEAD || git commit -m "Automated code fixes"
+        git push
+      shell: bash
+
 
     # Lint
     - name: analyze

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -76,16 +76,6 @@ runs:
     - name: Run melos fix
       run: melos run fix
       shell: bash
-      
-    - name: Commit changes
-      run: |
-        git config --global user.email "github-actions[bot]@users.noreply.github.com"
-        git config --global user.name "github-actions[bot]"
-        git add .
-        git diff-index --quiet HEAD || git commit -m "Automated code fixes"
-        git push
-      shell: bash
-
 
     # Lint
     - name: analyze

--- a/packages/mix/analysis_options.yaml
+++ b/packages/mix/analysis_options.yaml
@@ -5,7 +5,6 @@ analyzer:
   exclude: 
     # - "**/*.g.dart
 linter:
-
   rules:
     # TODO: Turn this to true when all public apis are documented 
     public_member_api_docs: false

--- a/packages/mix/lib/mix.dart
+++ b/packages/mix/lib/mix.dart
@@ -67,6 +67,7 @@ export 'src/core/spec.dart';
 export 'src/core/styled_widget.dart';
 export 'src/core/utility.dart';
 export 'src/core/variant.dart';
+export 'src/core/widget_state/widget_state_controller.dart';
 /// MODIFIERS
 export 'src/modifiers/align_widget_modifier.dart';
 export 'src/modifiers/aspect_ratio_widget_modifier.dart';

--- a/packages/mix/lib/src/modifiers/align_widget_modifier.dart
+++ b/packages/mix/lib/src/modifiers/align_widget_modifier.dart
@@ -6,7 +6,6 @@ import 'package:mix_annotations/mix_annotations.dart';
 
 import '../core/attribute.dart';
 import '../core/factory/mix_data.dart';
-import '../core/factory/mix_provider.dart';
 import '../core/helpers.dart';
 import '../core/modifier.dart';
 import '../core/utility.dart';

--- a/packages/mix/lib/src/modifiers/align_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/align_widget_modifier.g.dart
@@ -7,28 +7,6 @@ part of 'align_widget_modifier.dart';
 // **************************************************************************
 
 mixin _$AlignModifierSpec on WidgetModifierSpec<AlignModifierSpec> {
-  static AlignModifierSpec from(MixData mix) {
-    return mix.attributeOf<AlignModifierSpecAttribute>()?.resolve(mix) ??
-        const AlignModifierSpec();
-  }
-
-  /// {@template align_modifier_spec_of}
-  /// Retrieves the [AlignModifierSpec] from the nearest [Mix] ancestor in the widget tree.
-  ///
-  /// This method uses [Mix.of] to obtain the [Mix] instance associated with the
-  /// given [BuildContext], and then retrieves the [AlignModifierSpec] from that [Mix].
-  /// If no ancestor [Mix] is found, this method returns an empty [AlignModifierSpec].
-  ///
-  /// Example:
-  ///
-  /// ```dart
-  /// final alignModifierSpec = AlignModifierSpec.of(context);
-  /// ```
-  /// {@endtemplate}
-  static AlignModifierSpec of(BuildContext context) {
-    return _$AlignModifierSpec.from(Mix.of(context));
-  }
-
   /// Creates a copy of this [AlignModifierSpec] but with the given fields
   /// replaced with the new values.
   @override

--- a/packages/mix/lib/src/modifiers/align_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/align_widget_modifier.g.dart
@@ -6,8 +6,6 @@ part of 'align_widget_modifier.dart';
 // MixableSpecGenerator
 // **************************************************************************
 
-// ignore_for_file: deprecated_member_use_from_same_package
-
 mixin _$AlignModifierSpec on WidgetModifierSpec<AlignModifierSpec> {
   static AlignModifierSpec from(MixData mix) {
     return mix.attributeOf<AlignModifierSpecAttribute>()?.resolve(mix) ??

--- a/packages/mix/lib/src/modifiers/align_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/align_widget_modifier.g.dart
@@ -162,8 +162,13 @@ class AlignModifierSpecTween extends Tween<AlignModifierSpec?> {
 
   @override
   AlignModifierSpec lerp(double t) {
-    if (begin == null && end == null) return const AlignModifierSpec();
-    if (begin == null) return end!;
+    if (begin == null && end == null) {
+      return const AlignModifierSpec();
+    }
+
+    if (begin == null) {
+      return end!;
+    }
 
     return begin!.lerp(end!, t);
   }

--- a/packages/mix/lib/src/modifiers/aspect_ratio_widget_modifier.dart
+++ b/packages/mix/lib/src/modifiers/aspect_ratio_widget_modifier.dart
@@ -6,7 +6,6 @@ import 'package:mix_annotations/mix_annotations.dart';
 
 import '../core/attribute.dart';
 import '../core/factory/mix_data.dart';
-import '../core/factory/mix_provider.dart';
 import '../core/helpers.dart';
 import '../core/modifier.dart';
 import '../core/utility.dart';

--- a/packages/mix/lib/src/modifiers/aspect_ratio_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/aspect_ratio_widget_modifier.g.dart
@@ -6,8 +6,6 @@ part of 'aspect_ratio_widget_modifier.dart';
 // MixableSpecGenerator
 // **************************************************************************
 
-// ignore_for_file: deprecated_member_use_from_same_package
-
 mixin _$AspectRatioModifierSpec on WidgetModifierSpec<AspectRatioModifierSpec> {
   static AspectRatioModifierSpec from(MixData mix) {
     return mix.attributeOf<AspectRatioModifierSpecAttribute>()?.resolve(mix) ??

--- a/packages/mix/lib/src/modifiers/aspect_ratio_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/aspect_ratio_widget_modifier.g.dart
@@ -139,8 +139,13 @@ class AspectRatioModifierSpecTween extends Tween<AspectRatioModifierSpec?> {
 
   @override
   AspectRatioModifierSpec lerp(double t) {
-    if (begin == null && end == null) return const AspectRatioModifierSpec();
-    if (begin == null) return end!;
+    if (begin == null && end == null) {
+      return const AspectRatioModifierSpec();
+    }
+
+    if (begin == null) {
+      return end!;
+    }
 
     return begin!.lerp(end!, t);
   }

--- a/packages/mix/lib/src/modifiers/aspect_ratio_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/aspect_ratio_widget_modifier.g.dart
@@ -7,28 +7,6 @@ part of 'aspect_ratio_widget_modifier.dart';
 // **************************************************************************
 
 mixin _$AspectRatioModifierSpec on WidgetModifierSpec<AspectRatioModifierSpec> {
-  static AspectRatioModifierSpec from(MixData mix) {
-    return mix.attributeOf<AspectRatioModifierSpecAttribute>()?.resolve(mix) ??
-        const AspectRatioModifierSpec();
-  }
-
-  /// {@template aspect_ratio_modifier_spec_of}
-  /// Retrieves the [AspectRatioModifierSpec] from the nearest [Mix] ancestor in the widget tree.
-  ///
-  /// This method uses [Mix.of] to obtain the [Mix] instance associated with the
-  /// given [BuildContext], and then retrieves the [AspectRatioModifierSpec] from that [Mix].
-  /// If no ancestor [Mix] is found, this method returns an empty [AspectRatioModifierSpec].
-  ///
-  /// Example:
-  ///
-  /// ```dart
-  /// final aspectRatioModifierSpec = AspectRatioModifierSpec.of(context);
-  /// ```
-  /// {@endtemplate}
-  static AspectRatioModifierSpec of(BuildContext context) {
-    return _$AspectRatioModifierSpec.from(Mix.of(context));
-  }
-
   /// Creates a copy of this [AspectRatioModifierSpec] but with the given fields
   /// replaced with the new values.
   @override

--- a/packages/mix/lib/src/modifiers/clip_widget_modifier.dart
+++ b/packages/mix/lib/src/modifiers/clip_widget_modifier.dart
@@ -7,7 +7,6 @@ import 'package:mix_annotations/mix_annotations.dart';
 import '../attributes/border/border_radius_dto.dart';
 import '../core/attribute.dart';
 import '../core/factory/mix_data.dart';
-import '../core/factory/mix_provider.dart';
 import '../core/modifier.dart';
 import '../core/utility.dart';
 

--- a/packages/mix/lib/src/modifiers/clip_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/clip_widget_modifier.g.dart
@@ -6,8 +6,6 @@ part of 'clip_widget_modifier.dart';
 // MixableSpecGenerator
 // **************************************************************************
 
-// ignore_for_file: deprecated_member_use_from_same_package
-
 mixin _$ClipOvalModifierSpec on WidgetModifierSpec<ClipOvalModifierSpec> {
   static ClipOvalModifierSpec from(MixData mix) {
     return mix.attributeOf<ClipOvalModifierSpecAttribute>()?.resolve(mix) ??
@@ -179,8 +177,6 @@ class ClipOvalModifierSpecTween extends Tween<ClipOvalModifierSpec?> {
   }
 }
 
-// ignore_for_file: deprecated_member_use_from_same_package
-
 mixin _$ClipRectModifierSpec on WidgetModifierSpec<ClipRectModifierSpec> {
   static ClipRectModifierSpec from(MixData mix) {
     return mix.attributeOf<ClipRectModifierSpecAttribute>()?.resolve(mix) ??
@@ -351,8 +347,6 @@ class ClipRectModifierSpecTween extends Tween<ClipRectModifierSpec?> {
     return begin!.lerp(end!, t);
   }
 }
-
-// ignore_for_file: deprecated_member_use_from_same_package
 
 mixin _$ClipRRectModifierSpec on WidgetModifierSpec<ClipRRectModifierSpec> {
   static ClipRRectModifierSpec from(MixData mix) {
@@ -539,8 +533,6 @@ class ClipRRectModifierSpecTween extends Tween<ClipRRectModifierSpec?> {
   }
 }
 
-// ignore_for_file: deprecated_member_use_from_same_package
-
 mixin _$ClipPathModifierSpec on WidgetModifierSpec<ClipPathModifierSpec> {
   static ClipPathModifierSpec from(MixData mix) {
     return mix.attributeOf<ClipPathModifierSpecAttribute>()?.resolve(mix) ??
@@ -711,8 +703,6 @@ class ClipPathModifierSpecTween extends Tween<ClipPathModifierSpec?> {
     return begin!.lerp(end!, t);
   }
 }
-
-// ignore_for_file: deprecated_member_use_from_same_package
 
 mixin _$ClipTriangleModifierSpec
     on WidgetModifierSpec<ClipTriangleModifierSpec> {

--- a/packages/mix/lib/src/modifiers/clip_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/clip_widget_modifier.g.dart
@@ -7,28 +7,6 @@ part of 'clip_widget_modifier.dart';
 // **************************************************************************
 
 mixin _$ClipOvalModifierSpec on WidgetModifierSpec<ClipOvalModifierSpec> {
-  static ClipOvalModifierSpec from(MixData mix) {
-    return mix.attributeOf<ClipOvalModifierSpecAttribute>()?.resolve(mix) ??
-        const ClipOvalModifierSpec();
-  }
-
-  /// {@template clip_oval_modifier_spec_of}
-  /// Retrieves the [ClipOvalModifierSpec] from the nearest [Mix] ancestor in the widget tree.
-  ///
-  /// This method uses [Mix.of] to obtain the [Mix] instance associated with the
-  /// given [BuildContext], and then retrieves the [ClipOvalModifierSpec] from that [Mix].
-  /// If no ancestor [Mix] is found, this method returns an empty [ClipOvalModifierSpec].
-  ///
-  /// Example:
-  ///
-  /// ```dart
-  /// final clipOvalModifierSpec = ClipOvalModifierSpec.of(context);
-  /// ```
-  /// {@endtemplate}
-  static ClipOvalModifierSpec of(BuildContext context) {
-    return _$ClipOvalModifierSpec.from(Mix.of(context));
-  }
-
   /// Creates a copy of this [ClipOvalModifierSpec] but with the given fields
   /// replaced with the new values.
   @override
@@ -178,28 +156,6 @@ class ClipOvalModifierSpecTween extends Tween<ClipOvalModifierSpec?> {
 }
 
 mixin _$ClipRectModifierSpec on WidgetModifierSpec<ClipRectModifierSpec> {
-  static ClipRectModifierSpec from(MixData mix) {
-    return mix.attributeOf<ClipRectModifierSpecAttribute>()?.resolve(mix) ??
-        const ClipRectModifierSpec();
-  }
-
-  /// {@template clip_rect_modifier_spec_of}
-  /// Retrieves the [ClipRectModifierSpec] from the nearest [Mix] ancestor in the widget tree.
-  ///
-  /// This method uses [Mix.of] to obtain the [Mix] instance associated with the
-  /// given [BuildContext], and then retrieves the [ClipRectModifierSpec] from that [Mix].
-  /// If no ancestor [Mix] is found, this method returns an empty [ClipRectModifierSpec].
-  ///
-  /// Example:
-  ///
-  /// ```dart
-  /// final clipRectModifierSpec = ClipRectModifierSpec.of(context);
-  /// ```
-  /// {@endtemplate}
-  static ClipRectModifierSpec of(BuildContext context) {
-    return _$ClipRectModifierSpec.from(Mix.of(context));
-  }
-
   /// Creates a copy of this [ClipRectModifierSpec] but with the given fields
   /// replaced with the new values.
   @override
@@ -349,28 +305,6 @@ class ClipRectModifierSpecTween extends Tween<ClipRectModifierSpec?> {
 }
 
 mixin _$ClipRRectModifierSpec on WidgetModifierSpec<ClipRRectModifierSpec> {
-  static ClipRRectModifierSpec from(MixData mix) {
-    return mix.attributeOf<ClipRRectModifierSpecAttribute>()?.resolve(mix) ??
-        const ClipRRectModifierSpec();
-  }
-
-  /// {@template clip_r_rect_modifier_spec_of}
-  /// Retrieves the [ClipRRectModifierSpec] from the nearest [Mix] ancestor in the widget tree.
-  ///
-  /// This method uses [Mix.of] to obtain the [Mix] instance associated with the
-  /// given [BuildContext], and then retrieves the [ClipRRectModifierSpec] from that [Mix].
-  /// If no ancestor [Mix] is found, this method returns an empty [ClipRRectModifierSpec].
-  ///
-  /// Example:
-  ///
-  /// ```dart
-  /// final clipRRectModifierSpec = ClipRRectModifierSpec.of(context);
-  /// ```
-  /// {@endtemplate}
-  static ClipRRectModifierSpec of(BuildContext context) {
-    return _$ClipRRectModifierSpec.from(Mix.of(context));
-  }
-
   /// Creates a copy of this [ClipRRectModifierSpec] but with the given fields
   /// replaced with the new values.
   @override
@@ -534,28 +468,6 @@ class ClipRRectModifierSpecTween extends Tween<ClipRRectModifierSpec?> {
 }
 
 mixin _$ClipPathModifierSpec on WidgetModifierSpec<ClipPathModifierSpec> {
-  static ClipPathModifierSpec from(MixData mix) {
-    return mix.attributeOf<ClipPathModifierSpecAttribute>()?.resolve(mix) ??
-        const ClipPathModifierSpec();
-  }
-
-  /// {@template clip_path_modifier_spec_of}
-  /// Retrieves the [ClipPathModifierSpec] from the nearest [Mix] ancestor in the widget tree.
-  ///
-  /// This method uses [Mix.of] to obtain the [Mix] instance associated with the
-  /// given [BuildContext], and then retrieves the [ClipPathModifierSpec] from that [Mix].
-  /// If no ancestor [Mix] is found, this method returns an empty [ClipPathModifierSpec].
-  ///
-  /// Example:
-  ///
-  /// ```dart
-  /// final clipPathModifierSpec = ClipPathModifierSpec.of(context);
-  /// ```
-  /// {@endtemplate}
-  static ClipPathModifierSpec of(BuildContext context) {
-    return _$ClipPathModifierSpec.from(Mix.of(context));
-  }
-
   /// Creates a copy of this [ClipPathModifierSpec] but with the given fields
   /// replaced with the new values.
   @override
@@ -706,28 +618,6 @@ class ClipPathModifierSpecTween extends Tween<ClipPathModifierSpec?> {
 
 mixin _$ClipTriangleModifierSpec
     on WidgetModifierSpec<ClipTriangleModifierSpec> {
-  static ClipTriangleModifierSpec from(MixData mix) {
-    return mix.attributeOf<ClipTriangleModifierSpecAttribute>()?.resolve(mix) ??
-        const ClipTriangleModifierSpec();
-  }
-
-  /// {@template clip_triangle_modifier_spec_of}
-  /// Retrieves the [ClipTriangleModifierSpec] from the nearest [Mix] ancestor in the widget tree.
-  ///
-  /// This method uses [Mix.of] to obtain the [Mix] instance associated with the
-  /// given [BuildContext], and then retrieves the [ClipTriangleModifierSpec] from that [Mix].
-  /// If no ancestor [Mix] is found, this method returns an empty [ClipTriangleModifierSpec].
-  ///
-  /// Example:
-  ///
-  /// ```dart
-  /// final clipTriangleModifierSpec = ClipTriangleModifierSpec.of(context);
-  /// ```
-  /// {@endtemplate}
-  static ClipTriangleModifierSpec of(BuildContext context) {
-    return _$ClipTriangleModifierSpec.from(Mix.of(context));
-  }
-
   /// Creates a copy of this [ClipTriangleModifierSpec] but with the given fields
   /// replaced with the new values.
   @override

--- a/packages/mix/lib/src/modifiers/clip_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/clip_widget_modifier.g.dart
@@ -148,8 +148,13 @@ class ClipOvalModifierSpecTween extends Tween<ClipOvalModifierSpec?> {
 
   @override
   ClipOvalModifierSpec lerp(double t) {
-    if (begin == null && end == null) return const ClipOvalModifierSpec();
-    if (begin == null) return end!;
+    if (begin == null && end == null) {
+      return const ClipOvalModifierSpec();
+    }
+
+    if (begin == null) {
+      return end!;
+    }
 
     return begin!.lerp(end!, t);
   }
@@ -297,8 +302,13 @@ class ClipRectModifierSpecTween extends Tween<ClipRectModifierSpec?> {
 
   @override
   ClipRectModifierSpec lerp(double t) {
-    if (begin == null && end == null) return const ClipRectModifierSpec();
-    if (begin == null) return end!;
+    if (begin == null && end == null) {
+      return const ClipRectModifierSpec();
+    }
+
+    if (begin == null) {
+      return end!;
+    }
 
     return begin!.lerp(end!, t);
   }
@@ -460,8 +470,13 @@ class ClipRRectModifierSpecTween extends Tween<ClipRRectModifierSpec?> {
 
   @override
   ClipRRectModifierSpec lerp(double t) {
-    if (begin == null && end == null) return const ClipRRectModifierSpec();
-    if (begin == null) return end!;
+    if (begin == null && end == null) {
+      return const ClipRRectModifierSpec();
+    }
+
+    if (begin == null) {
+      return end!;
+    }
 
     return begin!.lerp(end!, t);
   }
@@ -609,8 +624,13 @@ class ClipPathModifierSpecTween extends Tween<ClipPathModifierSpec?> {
 
   @override
   ClipPathModifierSpec lerp(double t) {
-    if (begin == null && end == null) return const ClipPathModifierSpec();
-    if (begin == null) return end!;
+    if (begin == null && end == null) {
+      return const ClipPathModifierSpec();
+    }
+
+    if (begin == null) {
+      return end!;
+    }
 
     return begin!.lerp(end!, t);
   }
@@ -749,8 +769,13 @@ class ClipTriangleModifierSpecTween extends Tween<ClipTriangleModifierSpec?> {
 
   @override
   ClipTriangleModifierSpec lerp(double t) {
-    if (begin == null && end == null) return const ClipTriangleModifierSpec();
-    if (begin == null) return end!;
+    if (begin == null && end == null) {
+      return const ClipTriangleModifierSpec();
+    }
+
+    if (begin == null) {
+      return end!;
+    }
 
     return begin!.lerp(end!, t);
   }

--- a/packages/mix/lib/src/modifiers/flexible_widget_modifier.dart
+++ b/packages/mix/lib/src/modifiers/flexible_widget_modifier.dart
@@ -7,7 +7,6 @@ import 'package:mix_annotations/mix_annotations.dart';
 import '../attributes/enum/enum_util.dart';
 import '../core/attribute.dart';
 import '../core/factory/mix_data.dart';
-import '../core/factory/mix_provider.dart';
 import '../core/modifier.dart';
 import '../core/utility.dart';
 

--- a/packages/mix/lib/src/modifiers/flexible_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/flexible_widget_modifier.g.dart
@@ -7,28 +7,6 @@ part of 'flexible_widget_modifier.dart';
 // **************************************************************************
 
 mixin _$FlexibleModifierSpec on WidgetModifierSpec<FlexibleModifierSpec> {
-  static FlexibleModifierSpec from(MixData mix) {
-    return mix.attributeOf<FlexibleModifierSpecAttribute>()?.resolve(mix) ??
-        const FlexibleModifierSpec();
-  }
-
-  /// {@template flexible_modifier_spec_of}
-  /// Retrieves the [FlexibleModifierSpec] from the nearest [Mix] ancestor in the widget tree.
-  ///
-  /// This method uses [Mix.of] to obtain the [Mix] instance associated with the
-  /// given [BuildContext], and then retrieves the [FlexibleModifierSpec] from that [Mix].
-  /// If no ancestor [Mix] is found, this method returns an empty [FlexibleModifierSpec].
-  ///
-  /// Example:
-  ///
-  /// ```dart
-  /// final flexibleModifierSpec = FlexibleModifierSpec.of(context);
-  /// ```
-  /// {@endtemplate}
-  static FlexibleModifierSpec of(BuildContext context) {
-    return _$FlexibleModifierSpec.from(Mix.of(context));
-  }
-
   /// Creates a copy of this [FlexibleModifierSpec] but with the given fields
   /// replaced with the new values.
   @override

--- a/packages/mix/lib/src/modifiers/flexible_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/flexible_widget_modifier.g.dart
@@ -148,8 +148,13 @@ class FlexibleModifierSpecTween extends Tween<FlexibleModifierSpec?> {
 
   @override
   FlexibleModifierSpec lerp(double t) {
-    if (begin == null && end == null) return const FlexibleModifierSpec();
-    if (begin == null) return end!;
+    if (begin == null && end == null) {
+      return const FlexibleModifierSpec();
+    }
+
+    if (begin == null) {
+      return end!;
+    }
 
     return begin!.lerp(end!, t);
   }

--- a/packages/mix/lib/src/modifiers/flexible_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/flexible_widget_modifier.g.dart
@@ -6,8 +6,6 @@ part of 'flexible_widget_modifier.dart';
 // MixableSpecGenerator
 // **************************************************************************
 
-// ignore_for_file: deprecated_member_use_from_same_package
-
 mixin _$FlexibleModifierSpec on WidgetModifierSpec<FlexibleModifierSpec> {
   static FlexibleModifierSpec from(MixData mix) {
     return mix.attributeOf<FlexibleModifierSpecAttribute>()?.resolve(mix) ??

--- a/packages/mix/lib/src/modifiers/fractionally_sized_box_widget_modifier.dart
+++ b/packages/mix/lib/src/modifiers/fractionally_sized_box_widget_modifier.dart
@@ -6,7 +6,6 @@ import 'package:mix_annotations/mix_annotations.dart';
 
 import '../core/attribute.dart';
 import '../core/factory/mix_data.dart';
-import '../core/factory/mix_provider.dart';
 import '../core/helpers.dart';
 import '../core/modifier.dart';
 import '../core/utility.dart';

--- a/packages/mix/lib/src/modifiers/fractionally_sized_box_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/fractionally_sized_box_widget_modifier.g.dart
@@ -168,9 +168,8 @@ class FractionallySizedBoxModifierSpecTween
 
   @override
   FractionallySizedBoxModifierSpec lerp(double t) {
-    if (begin == null && end == null) {
+    if (begin == null && end == null)
       return const FractionallySizedBoxModifierSpec();
-    }
     if (begin == null) return end!;
 
     return begin!.lerp(end!, t);

--- a/packages/mix/lib/src/modifiers/fractionally_sized_box_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/fractionally_sized_box_widget_modifier.g.dart
@@ -8,30 +8,6 @@ part of 'fractionally_sized_box_widget_modifier.dart';
 
 mixin _$FractionallySizedBoxModifierSpec
     on WidgetModifierSpec<FractionallySizedBoxModifierSpec> {
-  static FractionallySizedBoxModifierSpec from(MixData mix) {
-    return mix
-            .attributeOf<FractionallySizedBoxModifierSpecAttribute>()
-            ?.resolve(mix) ??
-        const FractionallySizedBoxModifierSpec();
-  }
-
-  /// {@template fractionally_sized_box_modifier_spec_of}
-  /// Retrieves the [FractionallySizedBoxModifierSpec] from the nearest [Mix] ancestor in the widget tree.
-  ///
-  /// This method uses [Mix.of] to obtain the [Mix] instance associated with the
-  /// given [BuildContext], and then retrieves the [FractionallySizedBoxModifierSpec] from that [Mix].
-  /// If no ancestor [Mix] is found, this method returns an empty [FractionallySizedBoxModifierSpec].
-  ///
-  /// Example:
-  ///
-  /// ```dart
-  /// final fractionallySizedBoxModifierSpec = FractionallySizedBoxModifierSpec.of(context);
-  /// ```
-  /// {@endtemplate}
-  static FractionallySizedBoxModifierSpec of(BuildContext context) {
-    return _$FractionallySizedBoxModifierSpec.from(Mix.of(context));
-  }
-
   /// Creates a copy of this [FractionallySizedBoxModifierSpec] but with the given fields
   /// replaced with the new values.
   @override
@@ -192,8 +168,9 @@ class FractionallySizedBoxModifierSpecTween
 
   @override
   FractionallySizedBoxModifierSpec lerp(double t) {
-    if (begin == null && end == null)
+    if (begin == null && end == null) {
       return const FractionallySizedBoxModifierSpec();
+    }
     if (begin == null) return end!;
 
     return begin!.lerp(end!, t);

--- a/packages/mix/lib/src/modifiers/fractionally_sized_box_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/fractionally_sized_box_widget_modifier.g.dart
@@ -6,8 +6,6 @@ part of 'fractionally_sized_box_widget_modifier.dart';
 // MixableSpecGenerator
 // **************************************************************************
 
-// ignore_for_file: deprecated_member_use_from_same_package
-
 mixin _$FractionallySizedBoxModifierSpec
     on WidgetModifierSpec<FractionallySizedBoxModifierSpec> {
   static FractionallySizedBoxModifierSpec from(MixData mix) {

--- a/packages/mix/lib/src/modifiers/fractionally_sized_box_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/fractionally_sized_box_widget_modifier.g.dart
@@ -168,9 +168,13 @@ class FractionallySizedBoxModifierSpecTween
 
   @override
   FractionallySizedBoxModifierSpec lerp(double t) {
-    if (begin == null && end == null)
+    if (begin == null && end == null) {
       return const FractionallySizedBoxModifierSpec();
-    if (begin == null) return end!;
+    }
+
+    if (begin == null) {
+      return end!;
+    }
 
     return begin!.lerp(end!, t);
   }

--- a/packages/mix/lib/src/modifiers/internal/render_widget_modifier.dart
+++ b/packages/mix/lib/src/modifiers/internal/render_widget_modifier.dart
@@ -90,12 +90,14 @@ class RenderModifiers extends StatelessWidget {
   const RenderModifiers({
     required this.child,
     this.modifiers = const [],
-    @Deprecated("Use modifiers parameter") this.mix,
+    this.mix,
     required this.orderOfModifiers,
     super.key,
   });
 
   final Widget child;
+
+  /// TODO: remove this parameter in the future
   final MixData? mix;
   final List<Type> orderOfModifiers;
   final List<WidgetModifierSpec<dynamic>> modifiers;
@@ -130,11 +132,12 @@ class _RenderModifiers extends StatelessWidget {
 class RenderAnimatedModifiers extends StatelessWidget {
   const RenderAnimatedModifiers({
     super.key,
-    //TODO Should be required in the next version
     this.modifiers = const [],
     required this.child,
     required this.duration,
-    @Deprecated("Use modifiers parameter") this.mix,
+
+    /// TODO: Remove this parameter in the future
+    this.mix,
     required this.orderOfModifiers,
     this.curve = Curves.linear,
     this.onEnd,

--- a/packages/mix/lib/src/modifiers/intrinsic_widget_modifier.dart
+++ b/packages/mix/lib/src/modifiers/intrinsic_widget_modifier.dart
@@ -6,7 +6,6 @@ import 'package:mix_annotations/mix_annotations.dart';
 
 import '../core/attribute.dart';
 import '../core/factory/mix_data.dart';
-import '../core/factory/mix_provider.dart';
 import '../core/modifier.dart';
 import '../core/utility.dart';
 

--- a/packages/mix/lib/src/modifiers/intrinsic_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/intrinsic_widget_modifier.g.dart
@@ -8,35 +8,11 @@ part of 'intrinsic_widget_modifier.dart';
 
 mixin _$IntrinsicHeightModifierSpec
     on WidgetModifierSpec<IntrinsicHeightModifierSpec> {
-  static IntrinsicHeightModifierSpec from(MixData mix) {
-    return mix
-            .attributeOf<IntrinsicHeightModifierSpecAttribute>()
-            ?.resolve(mix) ??
-        const IntrinsicHeightModifierSpec();
-  }
-
-  /// {@template intrinsic_height_modifier_spec_of}
-  /// Retrieves the [IntrinsicHeightModifierSpec] from the nearest [Mix] ancestor in the widget tree.
-  ///
-  /// This method uses [Mix.of] to obtain the [Mix] instance associated with the
-  /// given [BuildContext], and then retrieves the [IntrinsicHeightModifierSpec] from that [Mix].
-  /// If no ancestor [Mix] is found, this method returns an empty [IntrinsicHeightModifierSpec].
-  ///
-  /// Example:
-  ///
-  /// ```dart
-  /// final intrinsicHeightModifierSpec = IntrinsicHeightModifierSpec.of(context);
-  /// ```
-  /// {@endtemplate}
-  static IntrinsicHeightModifierSpec of(BuildContext context) {
-    return _$IntrinsicHeightModifierSpec.from(Mix.of(context));
-  }
-
   /// Creates a copy of this [IntrinsicHeightModifierSpec] but with the given fields
   /// replaced with the new values.
   @override
   IntrinsicHeightModifierSpec copyWith() {
-    return IntrinsicHeightModifierSpec();
+    return const IntrinsicHeightModifierSpec();
   }
 
   /// Linearly interpolates between this [IntrinsicHeightModifierSpec] and another [IntrinsicHeightModifierSpec] based on the given parameter [t].
@@ -62,7 +38,7 @@ mixin _$IntrinsicHeightModifierSpec
       IntrinsicHeightModifierSpec? other, double t) {
     if (other == null) return _$this;
 
-    return IntrinsicHeightModifierSpec();
+    return const IntrinsicHeightModifierSpec();
   }
 
   /// The list of properties that constitute the state of this [IntrinsicHeightModifierSpec].
@@ -99,7 +75,7 @@ final class IntrinsicHeightModifierSpecAttribute
   /// ```
   @override
   IntrinsicHeightModifierSpec resolve(MixData mix) {
-    return IntrinsicHeightModifierSpec();
+    return const IntrinsicHeightModifierSpec();
   }
 
   /// Merges the properties of this [IntrinsicHeightModifierSpecAttribute] with the properties of [other].
@@ -144,8 +120,9 @@ class IntrinsicHeightModifierSpecTween
 
   @override
   IntrinsicHeightModifierSpec lerp(double t) {
-    if (begin == null && end == null)
+    if (begin == null && end == null) {
       return const IntrinsicHeightModifierSpec();
+    }
     if (begin == null) return end!;
 
     return begin!.lerp(end!, t);
@@ -154,35 +131,11 @@ class IntrinsicHeightModifierSpecTween
 
 mixin _$IntrinsicWidthModifierSpec
     on WidgetModifierSpec<IntrinsicWidthModifierSpec> {
-  static IntrinsicWidthModifierSpec from(MixData mix) {
-    return mix
-            .attributeOf<IntrinsicWidthModifierSpecAttribute>()
-            ?.resolve(mix) ??
-        const IntrinsicWidthModifierSpec();
-  }
-
-  /// {@template intrinsic_width_modifier_spec_of}
-  /// Retrieves the [IntrinsicWidthModifierSpec] from the nearest [Mix] ancestor in the widget tree.
-  ///
-  /// This method uses [Mix.of] to obtain the [Mix] instance associated with the
-  /// given [BuildContext], and then retrieves the [IntrinsicWidthModifierSpec] from that [Mix].
-  /// If no ancestor [Mix] is found, this method returns an empty [IntrinsicWidthModifierSpec].
-  ///
-  /// Example:
-  ///
-  /// ```dart
-  /// final intrinsicWidthModifierSpec = IntrinsicWidthModifierSpec.of(context);
-  /// ```
-  /// {@endtemplate}
-  static IntrinsicWidthModifierSpec of(BuildContext context) {
-    return _$IntrinsicWidthModifierSpec.from(Mix.of(context));
-  }
-
   /// Creates a copy of this [IntrinsicWidthModifierSpec] but with the given fields
   /// replaced with the new values.
   @override
   IntrinsicWidthModifierSpec copyWith() {
-    return IntrinsicWidthModifierSpec();
+    return const IntrinsicWidthModifierSpec();
   }
 
   /// Linearly interpolates between this [IntrinsicWidthModifierSpec] and another [IntrinsicWidthModifierSpec] based on the given parameter [t].
@@ -207,7 +160,7 @@ mixin _$IntrinsicWidthModifierSpec
   IntrinsicWidthModifierSpec lerp(IntrinsicWidthModifierSpec? other, double t) {
     if (other == null) return _$this;
 
-    return IntrinsicWidthModifierSpec();
+    return const IntrinsicWidthModifierSpec();
   }
 
   /// The list of properties that constitute the state of this [IntrinsicWidthModifierSpec].
@@ -244,7 +197,7 @@ final class IntrinsicWidthModifierSpecAttribute
   /// ```
   @override
   IntrinsicWidthModifierSpec resolve(MixData mix) {
-    return IntrinsicWidthModifierSpec();
+    return const IntrinsicWidthModifierSpec();
   }
 
   /// Merges the properties of this [IntrinsicWidthModifierSpecAttribute] with the properties of [other].

--- a/packages/mix/lib/src/modifiers/intrinsic_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/intrinsic_widget_modifier.g.dart
@@ -12,7 +12,7 @@ mixin _$IntrinsicHeightModifierSpec
   /// replaced with the new values.
   @override
   IntrinsicHeightModifierSpec copyWith() {
-    return const IntrinsicHeightModifierSpec();
+    return IntrinsicHeightModifierSpec();
   }
 
   /// Linearly interpolates between this [IntrinsicHeightModifierSpec] and another [IntrinsicHeightModifierSpec] based on the given parameter [t].
@@ -38,7 +38,7 @@ mixin _$IntrinsicHeightModifierSpec
       IntrinsicHeightModifierSpec? other, double t) {
     if (other == null) return _$this;
 
-    return const IntrinsicHeightModifierSpec();
+    return IntrinsicHeightModifierSpec();
   }
 
   /// The list of properties that constitute the state of this [IntrinsicHeightModifierSpec].
@@ -75,7 +75,7 @@ final class IntrinsicHeightModifierSpecAttribute
   /// ```
   @override
   IntrinsicHeightModifierSpec resolve(MixData mix) {
-    return const IntrinsicHeightModifierSpec();
+    return IntrinsicHeightModifierSpec();
   }
 
   /// Merges the properties of this [IntrinsicHeightModifierSpecAttribute] with the properties of [other].
@@ -120,9 +120,8 @@ class IntrinsicHeightModifierSpecTween
 
   @override
   IntrinsicHeightModifierSpec lerp(double t) {
-    if (begin == null && end == null) {
+    if (begin == null && end == null)
       return const IntrinsicHeightModifierSpec();
-    }
     if (begin == null) return end!;
 
     return begin!.lerp(end!, t);
@@ -135,7 +134,7 @@ mixin _$IntrinsicWidthModifierSpec
   /// replaced with the new values.
   @override
   IntrinsicWidthModifierSpec copyWith() {
-    return const IntrinsicWidthModifierSpec();
+    return IntrinsicWidthModifierSpec();
   }
 
   /// Linearly interpolates between this [IntrinsicWidthModifierSpec] and another [IntrinsicWidthModifierSpec] based on the given parameter [t].
@@ -160,7 +159,7 @@ mixin _$IntrinsicWidthModifierSpec
   IntrinsicWidthModifierSpec lerp(IntrinsicWidthModifierSpec? other, double t) {
     if (other == null) return _$this;
 
-    return const IntrinsicWidthModifierSpec();
+    return IntrinsicWidthModifierSpec();
   }
 
   /// The list of properties that constitute the state of this [IntrinsicWidthModifierSpec].
@@ -197,7 +196,7 @@ final class IntrinsicWidthModifierSpecAttribute
   /// ```
   @override
   IntrinsicWidthModifierSpec resolve(MixData mix) {
-    return const IntrinsicWidthModifierSpec();
+    return IntrinsicWidthModifierSpec();
   }
 
   /// Merges the properties of this [IntrinsicWidthModifierSpecAttribute] with the properties of [other].

--- a/packages/mix/lib/src/modifiers/intrinsic_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/intrinsic_widget_modifier.g.dart
@@ -12,7 +12,7 @@ mixin _$IntrinsicHeightModifierSpec
   /// replaced with the new values.
   @override
   IntrinsicHeightModifierSpec copyWith() {
-    return IntrinsicHeightModifierSpec();
+    return const IntrinsicHeightModifierSpec();
   }
 
   /// Linearly interpolates between this [IntrinsicHeightModifierSpec] and another [IntrinsicHeightModifierSpec] based on the given parameter [t].
@@ -38,7 +38,7 @@ mixin _$IntrinsicHeightModifierSpec
       IntrinsicHeightModifierSpec? other, double t) {
     if (other == null) return _$this;
 
-    return IntrinsicHeightModifierSpec();
+    return const IntrinsicHeightModifierSpec();
   }
 
   /// The list of properties that constitute the state of this [IntrinsicHeightModifierSpec].
@@ -75,6 +75,7 @@ final class IntrinsicHeightModifierSpecAttribute
   /// ```
   @override
   IntrinsicHeightModifierSpec resolve(MixData mix) {
+    // ignore: prefer_const_constructors
     return IntrinsicHeightModifierSpec();
   }
 
@@ -120,9 +121,13 @@ class IntrinsicHeightModifierSpecTween
 
   @override
   IntrinsicHeightModifierSpec lerp(double t) {
-    if (begin == null && end == null)
+    if (begin == null && end == null) {
       return const IntrinsicHeightModifierSpec();
-    if (begin == null) return end!;
+    }
+
+    if (begin == null) {
+      return end!;
+    }
 
     return begin!.lerp(end!, t);
   }
@@ -134,7 +139,7 @@ mixin _$IntrinsicWidthModifierSpec
   /// replaced with the new values.
   @override
   IntrinsicWidthModifierSpec copyWith() {
-    return IntrinsicWidthModifierSpec();
+    return const IntrinsicWidthModifierSpec();
   }
 
   /// Linearly interpolates between this [IntrinsicWidthModifierSpec] and another [IntrinsicWidthModifierSpec] based on the given parameter [t].
@@ -159,7 +164,7 @@ mixin _$IntrinsicWidthModifierSpec
   IntrinsicWidthModifierSpec lerp(IntrinsicWidthModifierSpec? other, double t) {
     if (other == null) return _$this;
 
-    return IntrinsicWidthModifierSpec();
+    return const IntrinsicWidthModifierSpec();
   }
 
   /// The list of properties that constitute the state of this [IntrinsicWidthModifierSpec].
@@ -196,6 +201,7 @@ final class IntrinsicWidthModifierSpecAttribute
   /// ```
   @override
   IntrinsicWidthModifierSpec resolve(MixData mix) {
+    // ignore: prefer_const_constructors
     return IntrinsicWidthModifierSpec();
   }
 
@@ -241,8 +247,13 @@ class IntrinsicWidthModifierSpecTween
 
   @override
   IntrinsicWidthModifierSpec lerp(double t) {
-    if (begin == null && end == null) return const IntrinsicWidthModifierSpec();
-    if (begin == null) return end!;
+    if (begin == null && end == null) {
+      return const IntrinsicWidthModifierSpec();
+    }
+
+    if (begin == null) {
+      return end!;
+    }
 
     return begin!.lerp(end!, t);
   }

--- a/packages/mix/lib/src/modifiers/intrinsic_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/intrinsic_widget_modifier.g.dart
@@ -6,8 +6,6 @@ part of 'intrinsic_widget_modifier.dart';
 // MixableSpecGenerator
 // **************************************************************************
 
-// ignore_for_file: deprecated_member_use_from_same_package
-
 mixin _$IntrinsicHeightModifierSpec
     on WidgetModifierSpec<IntrinsicHeightModifierSpec> {
   static IntrinsicHeightModifierSpec from(MixData mix) {
@@ -153,8 +151,6 @@ class IntrinsicHeightModifierSpecTween
     return begin!.lerp(end!, t);
   }
 }
-
-// ignore_for_file: deprecated_member_use_from_same_package
 
 mixin _$IntrinsicWidthModifierSpec
     on WidgetModifierSpec<IntrinsicWidthModifierSpec> {

--- a/packages/mix/lib/src/modifiers/opacity_widget_modifier.dart
+++ b/packages/mix/lib/src/modifiers/opacity_widget_modifier.dart
@@ -6,7 +6,6 @@ import 'package:mix_annotations/mix_annotations.dart';
 
 import '../core/attribute.dart';
 import '../core/factory/mix_data.dart';
-import '../core/factory/mix_provider.dart';
 import '../core/helpers.dart';
 import '../core/modifier.dart';
 import '../core/utility.dart';

--- a/packages/mix/lib/src/modifiers/opacity_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/opacity_widget_modifier.g.dart
@@ -6,8 +6,6 @@ part of 'opacity_widget_modifier.dart';
 // MixableSpecGenerator
 // **************************************************************************
 
-// ignore_for_file: deprecated_member_use_from_same_package
-
 mixin _$OpacityModifierSpec on WidgetModifierSpec<OpacityModifierSpec> {
   static OpacityModifierSpec from(MixData mix) {
     return mix.attributeOf<OpacityModifierSpecAttribute>()?.resolve(mix) ??

--- a/packages/mix/lib/src/modifiers/opacity_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/opacity_widget_modifier.g.dart
@@ -7,28 +7,6 @@ part of 'opacity_widget_modifier.dart';
 // **************************************************************************
 
 mixin _$OpacityModifierSpec on WidgetModifierSpec<OpacityModifierSpec> {
-  static OpacityModifierSpec from(MixData mix) {
-    return mix.attributeOf<OpacityModifierSpecAttribute>()?.resolve(mix) ??
-        const OpacityModifierSpec();
-  }
-
-  /// {@template opacity_modifier_spec_of}
-  /// Retrieves the [OpacityModifierSpec] from the nearest [Mix] ancestor in the widget tree.
-  ///
-  /// This method uses [Mix.of] to obtain the [Mix] instance associated with the
-  /// given [BuildContext], and then retrieves the [OpacityModifierSpec] from that [Mix].
-  /// If no ancestor [Mix] is found, this method returns an empty [OpacityModifierSpec].
-  ///
-  /// Example:
-  ///
-  /// ```dart
-  /// final opacityModifierSpec = OpacityModifierSpec.of(context);
-  /// ```
-  /// {@endtemplate}
-  static OpacityModifierSpec of(BuildContext context) {
-    return _$OpacityModifierSpec.from(Mix.of(context));
-  }
-
   /// Creates a copy of this [OpacityModifierSpec] but with the given fields
   /// replaced with the new values.
   @override

--- a/packages/mix/lib/src/modifiers/opacity_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/opacity_widget_modifier.g.dart
@@ -138,8 +138,13 @@ class OpacityModifierSpecTween extends Tween<OpacityModifierSpec?> {
 
   @override
   OpacityModifierSpec lerp(double t) {
-    if (begin == null && end == null) return const OpacityModifierSpec();
-    if (begin == null) return end!;
+    if (begin == null && end == null) {
+      return const OpacityModifierSpec();
+    }
+
+    if (begin == null) {
+      return end!;
+    }
 
     return begin!.lerp(end!, t);
   }

--- a/packages/mix/lib/src/modifiers/padding_widget_modifier.dart
+++ b/packages/mix/lib/src/modifiers/padding_widget_modifier.dart
@@ -8,7 +8,6 @@ import '../attributes/spacing/edge_insets_dto.dart';
 import '../attributes/spacing/spacing_util.dart';
 import '../core/attribute.dart';
 import '../core/factory/mix_data.dart';
-import '../core/factory/mix_provider.dart';
 import '../core/modifier.dart';
 import '../core/spec.dart';
 

--- a/packages/mix/lib/src/modifiers/padding_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/padding_widget_modifier.g.dart
@@ -6,8 +6,6 @@ part of 'padding_widget_modifier.dart';
 // MixableSpecGenerator
 // **************************************************************************
 
-// ignore_for_file: deprecated_member_use_from_same_package
-
 mixin _$PaddingModifierSpec on WidgetModifierSpec<PaddingModifierSpec> {
   static PaddingModifierSpec from(MixData mix) {
     return mix.attributeOf<PaddingModifierSpecAttribute>()?.resolve(mix) ??

--- a/packages/mix/lib/src/modifiers/padding_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/padding_widget_modifier.g.dart
@@ -7,28 +7,6 @@ part of 'padding_widget_modifier.dart';
 // **************************************************************************
 
 mixin _$PaddingModifierSpec on WidgetModifierSpec<PaddingModifierSpec> {
-  static PaddingModifierSpec from(MixData mix) {
-    return mix.attributeOf<PaddingModifierSpecAttribute>()?.resolve(mix) ??
-        const PaddingModifierSpec();
-  }
-
-  /// {@template padding_modifier_spec_of}
-  /// Retrieves the [PaddingModifierSpec] from the nearest [Mix] ancestor in the widget tree.
-  ///
-  /// This method uses [Mix.of] to obtain the [Mix] instance associated with the
-  /// given [BuildContext], and then retrieves the [PaddingModifierSpec] from that [Mix].
-  /// If no ancestor [Mix] is found, this method returns an empty [PaddingModifierSpec].
-  ///
-  /// Example:
-  ///
-  /// ```dart
-  /// final paddingModifierSpec = PaddingModifierSpec.of(context);
-  /// ```
-  /// {@endtemplate}
-  static PaddingModifierSpec of(BuildContext context) {
-    return _$PaddingModifierSpec.from(Mix.of(context));
-  }
-
   /// Creates a copy of this [PaddingModifierSpec] but with the given fields
   /// replaced with the new values.
   @override

--- a/packages/mix/lib/src/modifiers/padding_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/padding_widget_modifier.g.dart
@@ -162,8 +162,13 @@ class PaddingModifierSpecTween extends Tween<PaddingModifierSpec?> {
 
   @override
   PaddingModifierSpec lerp(double t) {
-    if (begin == null && end == null) return const PaddingModifierSpec();
-    if (begin == null) return end!;
+    if (begin == null && end == null) {
+      return const PaddingModifierSpec();
+    }
+
+    if (begin == null) {
+      return end!;
+    }
 
     return begin!.lerp(end!, t);
   }

--- a/packages/mix/lib/src/modifiers/rotated_box_widget_modifier.dart
+++ b/packages/mix/lib/src/modifiers/rotated_box_widget_modifier.dart
@@ -6,7 +6,6 @@ import 'package:mix_annotations/mix_annotations.dart';
 
 import '../core/attribute.dart';
 import '../core/factory/mix_data.dart';
-import '../core/factory/mix_provider.dart';
 import '../core/helpers.dart';
 import '../core/modifier.dart';
 import '../core/utility.dart';

--- a/packages/mix/lib/src/modifiers/rotated_box_widget_modifier.dart
+++ b/packages/mix/lib/src/modifiers/rotated_box_widget_modifier.dart
@@ -23,7 +23,9 @@ final class RotatedBoxModifierSpec
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    
     super.debugFillProperties(properties);
+
     _debugFillProperties(properties);
   }
 

--- a/packages/mix/lib/src/modifiers/rotated_box_widget_modifier.dart
+++ b/packages/mix/lib/src/modifiers/rotated_box_widget_modifier.dart
@@ -22,7 +22,6 @@ final class RotatedBoxModifierSpec
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    
     super.debugFillProperties(properties);
 
     _debugFillProperties(properties);

--- a/packages/mix/lib/src/modifiers/rotated_box_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/rotated_box_widget_modifier.g.dart
@@ -111,8 +111,13 @@ class RotatedBoxModifierSpecTween extends Tween<RotatedBoxModifierSpec?> {
 
   @override
   RotatedBoxModifierSpec lerp(double t) {
-    if (begin == null && end == null) return const RotatedBoxModifierSpec();
-    if (begin == null) return end!;
+    if (begin == null && end == null) {
+      return const RotatedBoxModifierSpec();
+    }
+
+    if (begin == null) {
+      return end!;
+    }
 
     return begin!.lerp(end!, t);
   }

--- a/packages/mix/lib/src/modifiers/rotated_box_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/rotated_box_widget_modifier.g.dart
@@ -7,28 +7,6 @@ part of 'rotated_box_widget_modifier.dart';
 // **************************************************************************
 
 mixin _$RotatedBoxModifierSpec on WidgetModifierSpec<RotatedBoxModifierSpec> {
-  static RotatedBoxModifierSpec from(MixData mix) {
-    return mix.attributeOf<RotatedBoxModifierSpecAttribute>()?.resolve(mix) ??
-        const RotatedBoxModifierSpec();
-  }
-
-  /// {@template rotated_box_modifier_spec_of}
-  /// Retrieves the [RotatedBoxModifierSpec] from the nearest [Mix] ancestor in the widget tree.
-  ///
-  /// This method uses [Mix.of] to obtain the [Mix] instance associated with the
-  /// given [BuildContext], and then retrieves the [RotatedBoxModifierSpec] from that [Mix].
-  /// If no ancestor [Mix] is found, this method returns an empty [RotatedBoxModifierSpec].
-  ///
-  /// Example:
-  ///
-  /// ```dart
-  /// final rotatedBoxModifierSpec = RotatedBoxModifierSpec.of(context);
-  /// ```
-  /// {@endtemplate}
-  static RotatedBoxModifierSpec of(BuildContext context) {
-    return _$RotatedBoxModifierSpec.from(Mix.of(context));
-  }
-
   /// Creates a copy of this [RotatedBoxModifierSpec] but with the given fields
   /// replaced with the new values.
   @override

--- a/packages/mix/lib/src/modifiers/rotated_box_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/rotated_box_widget_modifier.g.dart
@@ -6,8 +6,6 @@ part of 'rotated_box_widget_modifier.dart';
 // MixableSpecGenerator
 // **************************************************************************
 
-// ignore_for_file: deprecated_member_use_from_same_package
-
 mixin _$RotatedBoxModifierSpec on WidgetModifierSpec<RotatedBoxModifierSpec> {
   static RotatedBoxModifierSpec from(MixData mix) {
     return mix.attributeOf<RotatedBoxModifierSpecAttribute>()?.resolve(mix) ??

--- a/packages/mix/lib/src/modifiers/sized_box_widget_modifier.dart
+++ b/packages/mix/lib/src/modifiers/sized_box_widget_modifier.dart
@@ -6,7 +6,6 @@ import 'package:mix_annotations/mix_annotations.dart';
 
 import '../core/attribute.dart';
 import '../core/factory/mix_data.dart';
-import '../core/factory/mix_provider.dart';
 import '../core/helpers.dart';
 import '../core/modifier.dart';
 import '../core/utility.dart';

--- a/packages/mix/lib/src/modifiers/sized_box_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/sized_box_widget_modifier.g.dart
@@ -6,8 +6,6 @@ part of 'sized_box_widget_modifier.dart';
 // MixableSpecGenerator
 // **************************************************************************
 
-// ignore_for_file: deprecated_member_use_from_same_package
-
 mixin _$SizedBoxModifierSpec on WidgetModifierSpec<SizedBoxModifierSpec> {
   static SizedBoxModifierSpec from(MixData mix) {
     return mix.attributeOf<SizedBoxModifierSpecAttribute>()?.resolve(mix) ??

--- a/packages/mix/lib/src/modifiers/sized_box_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/sized_box_widget_modifier.g.dart
@@ -7,28 +7,6 @@ part of 'sized_box_widget_modifier.dart';
 // **************************************************************************
 
 mixin _$SizedBoxModifierSpec on WidgetModifierSpec<SizedBoxModifierSpec> {
-  static SizedBoxModifierSpec from(MixData mix) {
-    return mix.attributeOf<SizedBoxModifierSpecAttribute>()?.resolve(mix) ??
-        const SizedBoxModifierSpec();
-  }
-
-  /// {@template sized_box_modifier_spec_of}
-  /// Retrieves the [SizedBoxModifierSpec] from the nearest [Mix] ancestor in the widget tree.
-  ///
-  /// This method uses [Mix.of] to obtain the [Mix] instance associated with the
-  /// given [BuildContext], and then retrieves the [SizedBoxModifierSpec] from that [Mix].
-  /// If no ancestor [Mix] is found, this method returns an empty [SizedBoxModifierSpec].
-  ///
-  /// Example:
-  ///
-  /// ```dart
-  /// final sizedBoxModifierSpec = SizedBoxModifierSpec.of(context);
-  /// ```
-  /// {@endtemplate}
-  static SizedBoxModifierSpec of(BuildContext context) {
-    return _$SizedBoxModifierSpec.from(Mix.of(context));
-  }
-
   /// Creates a copy of this [SizedBoxModifierSpec] but with the given fields
   /// replaced with the new values.
   @override

--- a/packages/mix/lib/src/modifiers/sized_box_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/sized_box_widget_modifier.g.dart
@@ -149,8 +149,13 @@ class SizedBoxModifierSpecTween extends Tween<SizedBoxModifierSpec?> {
 
   @override
   SizedBoxModifierSpec lerp(double t) {
-    if (begin == null && end == null) return const SizedBoxModifierSpec();
-    if (begin == null) return end!;
+    if (begin == null && end == null) {
+      return const SizedBoxModifierSpec();
+    }
+
+    if (begin == null) {
+      return end!;
+    }
 
     return begin!.lerp(end!, t);
   }

--- a/packages/mix/lib/src/modifiers/transform_widget_modifier.dart
+++ b/packages/mix/lib/src/modifiers/transform_widget_modifier.dart
@@ -6,7 +6,6 @@ import 'package:mix_annotations/mix_annotations.dart';
 
 import '../core/attribute.dart';
 import '../core/factory/mix_data.dart';
-import '../core/factory/mix_provider.dart';
 import '../core/helpers.dart';
 import '../core/modifier.dart';
 import '../core/utility.dart';

--- a/packages/mix/lib/src/modifiers/transform_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/transform_widget_modifier.g.dart
@@ -7,28 +7,6 @@ part of 'transform_widget_modifier.dart';
 // **************************************************************************
 
 mixin _$TransformModifierSpec on WidgetModifierSpec<TransformModifierSpec> {
-  static TransformModifierSpec from(MixData mix) {
-    return mix.attributeOf<TransformModifierSpecAttribute>()?.resolve(mix) ??
-        const TransformModifierSpec();
-  }
-
-  /// {@template transform_modifier_spec_of}
-  /// Retrieves the [TransformModifierSpec] from the nearest [Mix] ancestor in the widget tree.
-  ///
-  /// This method uses [Mix.of] to obtain the [Mix] instance associated with the
-  /// given [BuildContext], and then retrieves the [TransformModifierSpec] from that [Mix].
-  /// If no ancestor [Mix] is found, this method returns an empty [TransformModifierSpec].
-  ///
-  /// Example:
-  ///
-  /// ```dart
-  /// final transformModifierSpec = TransformModifierSpec.of(context);
-  /// ```
-  /// {@endtemplate}
-  static TransformModifierSpec of(BuildContext context) {
-    return _$TransformModifierSpec.from(Mix.of(context));
-  }
-
   /// Creates a copy of this [TransformModifierSpec] but with the given fields
   /// replaced with the new values.
   @override

--- a/packages/mix/lib/src/modifiers/transform_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/transform_widget_modifier.g.dart
@@ -150,8 +150,13 @@ class TransformModifierSpecTween extends Tween<TransformModifierSpec?> {
 
   @override
   TransformModifierSpec lerp(double t) {
-    if (begin == null && end == null) return const TransformModifierSpec();
-    if (begin == null) return end!;
+    if (begin == null && end == null) {
+      return const TransformModifierSpec();
+    }
+
+    if (begin == null) {
+      return end!;
+    }
 
     return begin!.lerp(end!, t);
   }

--- a/packages/mix/lib/src/modifiers/transform_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/transform_widget_modifier.g.dart
@@ -6,8 +6,6 @@ part of 'transform_widget_modifier.dart';
 // MixableSpecGenerator
 // **************************************************************************
 
-// ignore_for_file: deprecated_member_use_from_same_package
-
 mixin _$TransformModifierSpec on WidgetModifierSpec<TransformModifierSpec> {
   static TransformModifierSpec from(MixData mix) {
     return mix.attributeOf<TransformModifierSpecAttribute>()?.resolve(mix) ??

--- a/packages/mix/lib/src/modifiers/visibility_widget_modifier.dart
+++ b/packages/mix/lib/src/modifiers/visibility_widget_modifier.dart
@@ -6,7 +6,6 @@ import 'package:mix_annotations/mix_annotations.dart';
 
 import '../core/attribute.dart';
 import '../core/factory/mix_data.dart';
-import '../core/factory/mix_provider.dart';
 import '../core/modifier.dart';
 import '../core/utility.dart';
 

--- a/packages/mix/lib/src/modifiers/visibility_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/visibility_widget_modifier.g.dart
@@ -6,8 +6,6 @@ part of 'visibility_widget_modifier.dart';
 // MixableSpecGenerator
 // **************************************************************************
 
-// ignore_for_file: deprecated_member_use_from_same_package
-
 mixin _$VisibilityModifierSpec on WidgetModifierSpec<VisibilityModifierSpec> {
   static VisibilityModifierSpec from(MixData mix) {
     return mix.attributeOf<VisibilityModifierSpecAttribute>()?.resolve(mix) ??

--- a/packages/mix/lib/src/modifiers/visibility_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/visibility_widget_modifier.g.dart
@@ -138,8 +138,13 @@ class VisibilityModifierSpecTween extends Tween<VisibilityModifierSpec?> {
 
   @override
   VisibilityModifierSpec lerp(double t) {
-    if (begin == null && end == null) return const VisibilityModifierSpec();
-    if (begin == null) return end!;
+    if (begin == null && end == null) {
+      return const VisibilityModifierSpec();
+    }
+
+    if (begin == null) {
+      return end!;
+    }
 
     return begin!.lerp(end!, t);
   }

--- a/packages/mix/lib/src/modifiers/visibility_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/visibility_widget_modifier.g.dart
@@ -7,28 +7,6 @@ part of 'visibility_widget_modifier.dart';
 // **************************************************************************
 
 mixin _$VisibilityModifierSpec on WidgetModifierSpec<VisibilityModifierSpec> {
-  static VisibilityModifierSpec from(MixData mix) {
-    return mix.attributeOf<VisibilityModifierSpecAttribute>()?.resolve(mix) ??
-        const VisibilityModifierSpec();
-  }
-
-  /// {@template visibility_modifier_spec_of}
-  /// Retrieves the [VisibilityModifierSpec] from the nearest [Mix] ancestor in the widget tree.
-  ///
-  /// This method uses [Mix.of] to obtain the [Mix] instance associated with the
-  /// given [BuildContext], and then retrieves the [VisibilityModifierSpec] from that [Mix].
-  /// If no ancestor [Mix] is found, this method returns an empty [VisibilityModifierSpec].
-  ///
-  /// Example:
-  ///
-  /// ```dart
-  /// final visibilityModifierSpec = VisibilityModifierSpec.of(context);
-  /// ```
-  /// {@endtemplate}
-  static VisibilityModifierSpec of(BuildContext context) {
-    return _$VisibilityModifierSpec.from(Mix.of(context));
-  }
-
   /// Creates a copy of this [VisibilityModifierSpec] but with the given fields
   /// replaced with the new values.
   @override

--- a/packages/mix/lib/src/specs/box/box_spec.g.dart
+++ b/packages/mix/lib/src/specs/box/box_spec.g.dart
@@ -6,8 +6,6 @@ part of 'box_spec.dart';
 // MixableSpecGenerator
 // **************************************************************************
 
-// ignore_for_file: deprecated_member_use_from_same_package
-
 mixin _$BoxSpec on Spec<BoxSpec> {
   static BoxSpec from(MixData mix) {
     return mix.attributeOf<BoxSpecAttribute>()?.resolve(mix) ?? const BoxSpec();

--- a/packages/mix/lib/src/specs/box/box_spec.g.dart
+++ b/packages/mix/lib/src/specs/box/box_spec.g.dart
@@ -443,8 +443,13 @@ class BoxSpecTween extends Tween<BoxSpec?> {
 
   @override
   BoxSpec lerp(double t) {
-    if (begin == null && end == null) return const BoxSpec();
-    if (begin == null) return end!;
+    if (begin == null && end == null) {
+      return const BoxSpec();
+    }
+
+    if (begin == null) {
+      return end!;
+    }
 
     return begin!.lerp(end!, t);
   }

--- a/packages/mix/lib/src/specs/flex/flex_spec.g.dart
+++ b/packages/mix/lib/src/specs/flex/flex_spec.g.dart
@@ -6,8 +6,6 @@ part of 'flex_spec.dart';
 // MixableSpecGenerator
 // **************************************************************************
 
-// ignore_for_file: deprecated_member_use_from_same_package
-
 mixin _$FlexSpec on Spec<FlexSpec> {
   static FlexSpec from(MixData mix) {
     return mix.attributeOf<FlexSpecAttribute>()?.resolve(mix) ??

--- a/packages/mix/lib/src/specs/flex/flex_spec.g.dart
+++ b/packages/mix/lib/src/specs/flex/flex_spec.g.dart
@@ -358,8 +358,13 @@ class FlexSpecTween extends Tween<FlexSpec?> {
 
   @override
   FlexSpec lerp(double t) {
-    if (begin == null && end == null) return const FlexSpec();
-    if (begin == null) return end!;
+    if (begin == null && end == null) {
+      return const FlexSpec();
+    }
+
+    if (begin == null) {
+      return end!;
+    }
 
     return begin!.lerp(end!, t);
   }

--- a/packages/mix/lib/src/specs/icon/icon_spec.g.dart
+++ b/packages/mix/lib/src/specs/icon/icon_spec.g.dart
@@ -346,8 +346,13 @@ class IconSpecTween extends Tween<IconSpec?> {
 
   @override
   IconSpec lerp(double t) {
-    if (begin == null && end == null) return const IconSpec();
-    if (begin == null) return end!;
+    if (begin == null && end == null) {
+      return const IconSpec();
+    }
+
+    if (begin == null) {
+      return end!;
+    }
 
     return begin!.lerp(end!, t);
   }

--- a/packages/mix/lib/src/specs/icon/icon_spec.g.dart
+++ b/packages/mix/lib/src/specs/icon/icon_spec.g.dart
@@ -6,8 +6,6 @@ part of 'icon_spec.dart';
 // MixableSpecGenerator
 // **************************************************************************
 
-// ignore_for_file: deprecated_member_use_from_same_package
-
 mixin _$IconSpec on Spec<IconSpec> {
   static IconSpec from(MixData mix) {
     return mix.attributeOf<IconSpecAttribute>()?.resolve(mix) ??

--- a/packages/mix/lib/src/specs/image/image_spec.g.dart
+++ b/packages/mix/lib/src/specs/image/image_spec.g.dart
@@ -6,8 +6,6 @@ part of 'image_spec.dart';
 // MixableSpecGenerator
 // **************************************************************************
 
-// ignore_for_file: deprecated_member_use_from_same_package
-
 mixin _$ImageSpec on Spec<ImageSpec> {
   static ImageSpec from(MixData mix) {
     return mix.attributeOf<ImageSpecAttribute>()?.resolve(mix) ??

--- a/packages/mix/lib/src/specs/image/image_spec.g.dart
+++ b/packages/mix/lib/src/specs/image/image_spec.g.dart
@@ -346,8 +346,13 @@ class ImageSpecTween extends Tween<ImageSpec?> {
 
   @override
   ImageSpec lerp(double t) {
-    if (begin == null && end == null) return const ImageSpec();
-    if (begin == null) return end!;
+    if (begin == null && end == null) {
+      return const ImageSpec();
+    }
+
+    if (begin == null) {
+      return end!;
+    }
 
     return begin!.lerp(end!, t);
   }

--- a/packages/mix/lib/src/specs/stack/stack_spec.g.dart
+++ b/packages/mix/lib/src/specs/stack/stack_spec.g.dart
@@ -262,8 +262,13 @@ class StackSpecTween extends Tween<StackSpec?> {
 
   @override
   StackSpec lerp(double t) {
-    if (begin == null && end == null) return const StackSpec();
-    if (begin == null) return end!;
+    if (begin == null && end == null) {
+      return const StackSpec();
+    }
+
+    if (begin == null) {
+      return end!;
+    }
 
     return begin!.lerp(end!, t);
   }

--- a/packages/mix/lib/src/specs/stack/stack_spec.g.dart
+++ b/packages/mix/lib/src/specs/stack/stack_spec.g.dart
@@ -6,8 +6,6 @@ part of 'stack_spec.dart';
 // MixableSpecGenerator
 // **************************************************************************
 
-// ignore_for_file: deprecated_member_use_from_same_package
-
 mixin _$StackSpec on Spec<StackSpec> {
   static StackSpec from(MixData mix) {
     return mix.attributeOf<StackSpecAttribute>()?.resolve(mix) ??

--- a/packages/mix/lib/src/specs/text/text_spec.g.dart
+++ b/packages/mix/lib/src/specs/text/text_spec.g.dart
@@ -418,8 +418,13 @@ class TextSpecTween extends Tween<TextSpec?> {
 
   @override
   TextSpec lerp(double t) {
-    if (begin == null && end == null) return const TextSpec();
-    if (begin == null) return end!;
+    if (begin == null && end == null) {
+      return const TextSpec();
+    }
+
+    if (begin == null) {
+      return end!;
+    }
 
     return begin!.lerp(end!, t);
   }

--- a/packages/mix/lib/src/specs/text/text_spec.g.dart
+++ b/packages/mix/lib/src/specs/text/text_spec.g.dart
@@ -6,6 +6,7 @@ part of 'text_spec.dart';
 // MixableSpecGenerator
 // **************************************************************************
 
+// ignore_for_file: deprecated_member_use_from_same_package
 mixin _$TextSpec on Spec<TextSpec> {
   static TextSpec from(MixData mix) {
     return mix.attributeOf<TextSpecAttribute>()?.resolve(mix) ??

--- a/packages/mix/lib/src/specs/text/text_spec.g.dart
+++ b/packages/mix/lib/src/specs/text/text_spec.g.dart
@@ -6,8 +6,6 @@ part of 'text_spec.dart';
 // MixableSpecGenerator
 // **************************************************************************
 
-// ignore_for_file: deprecated_member_use_from_same_package
-
 mixin _$TextSpec on Spec<TextSpec> {
   static TextSpec from(MixData mix) {
     return mix.attributeOf<TextSpecAttribute>()?.resolve(mix) ??

--- a/packages/mix/lib/src/specs/text/text_spec.g.dart
+++ b/packages/mix/lib/src/specs/text/text_spec.g.dart
@@ -7,6 +7,7 @@ part of 'text_spec.dart';
 // **************************************************************************
 
 // ignore_for_file: deprecated_member_use_from_same_package
+
 mixin _$TextSpec on Spec<TextSpec> {
   static TextSpec from(MixData mix) {
     return mix.attributeOf<TextSpecAttribute>()?.resolve(mix) ??

--- a/packages/mix/test/helpers/testing_utils.dart
+++ b/packages/mix/test/helpers/testing_utils.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mix/mix.dart';
 import 'package:mix/src/core/widget_state/internal/mix_widget_state_builder.dart';
-import 'package:mix/src/core/widget_state/widget_state_controller.dart';
 
 export 'package:mix/src/internal/values_ext.dart';
 

--- a/packages/mix/test/src/core/styled_widget_test.dart
+++ b/packages/mix/test/src/core/styled_widget_test.dart
@@ -3,7 +3,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mix/mix.dart';
 import 'package:mix/src/core/widget_state/internal/interactive_mix_state.dart';
 import 'package:mix/src/core/widget_state/internal/mouse_region_mix_state.dart';
-import 'package:mix/src/core/widget_state/widget_state_controller.dart';
 import 'package:mix/src/modifiers/internal/render_widget_modifier.dart';
 
 import '../../helpers/testing_utils.dart';

--- a/packages/mix/test/src/modifiers/padding_widget_modifier_test.dart
+++ b/packages/mix/test/src/modifiers/padding_widget_modifier_test.dart
@@ -29,7 +29,6 @@ void main() {
       final lerp2 = spec.lerp(spec2, 0.5);
       final lerp3 = spec.lerp(spec3, 0.5);
 
-      final insets1 = EdgeInsets.lerp(padding, null, 0.5);
       final insets2 = EdgeInsets.lerp(padding, padding2, 0.5);
       final insets3 = EdgeInsets.lerp(padding, padding3, 0.5);
 

--- a/packages/mix_generator/lib/src/builders/method_copy_with.dart
+++ b/packages/mix_generator/lib/src/builders/method_copy_with.dart
@@ -18,12 +18,14 @@ String copyWithMethodBuilder(ClassInfo instance) {
 
   final copyWithParams = fields.isEmpty ? '' : '{$optionalParams}';
 
+  final shouldAddConst = fields.isEmpty && instance.isConst;
+
   return '''
   /// Creates a copy of this [$className] but with the given fields
   /// replaced with the new values.
   @override
   $className copyWith($copyWithParams) {
-     return ${instance.writeConstructor()}($fieldStatements);
+     return ${shouldAddConst ? 'const' : ''} ${instance.writeConstructor()}($fieldStatements);
   }
 ''';
 }

--- a/packages/mix_generator/lib/src/builders/method_lerp_builder.dart
+++ b/packages/mix_generator/lib/src/builders/method_lerp_builder.dart
@@ -26,6 +26,8 @@ String lerpMethodBuilder(
     }
   }
 
+  final shouldAddConst = fields.isEmpty && instance.isConst;
+
   final lerpStatements = buildConstructorParams(fields, (ParameterInfo field) {
     return _getLerpExpression(field, isInternalRef);
   });
@@ -55,7 +57,7 @@ ${lerpMethods.entries.map((entry) => '/// - [${entry.key}] for ${entry.value.map
   $className lerp($className? other, double t) {
     if (other == null) return $thisRef;
 
-    return ${instance.writeConstructor()}($lerpStatements);
+    return ${shouldAddConst ? 'const' : ''} ${instance.writeConstructor()}($lerpStatements);
   }
 ''';
 }

--- a/packages/mix_generator/lib/src/builders/method_resolve.dart
+++ b/packages/mix_generator/lib/src/builders/method_resolve.dart
@@ -33,6 +33,9 @@ String resolveMethodBuilder(
     return '$fieldName $fallbackExpression';
   });
 
+  final ignoreLabel =
+      fields.isEmpty ? '// ignore: prefer_const_constructors' : '';
+
   return '''
   /// Resolves to [$resolvedName] using the provided [MixData].
   /// 
@@ -44,6 +47,7 @@ String resolveMethodBuilder(
   /// ```
   @override
   $resolvedName resolve(MixData mix) {
+    $ignoreLabel
     return $resolvedName$resolvedConstructor(
       $resolveStatements
     );

--- a/packages/mix_generator/lib/src/builders/spec/class_tween_spec.dart
+++ b/packages/mix_generator/lib/src/builders/spec/class_tween_spec.dart
@@ -18,8 +18,13 @@ class ${className}Tween extends Tween<$className?> {
 
   @override
   $className lerp(double t) {
-    if (begin == null && end == null) return $constIndicator $className$constructorRef();
-    if (begin == null) return end!;
+    if (begin == null && end == null) {
+      return $constIndicator $className$constructorRef();
+    }
+    
+    if (begin == null) {
+      return end!;
+    }
     
     return begin!.lerp(end!, t);
   }

--- a/packages/mix_generator/lib/src/builders/spec/mixin_spec.dart
+++ b/packages/mix_generator/lib/src/builders/spec/mixin_spec.dart
@@ -4,6 +4,7 @@ import 'package:mix_generator/src/builders/method_copy_with.dart';
 import 'package:mix_generator/src/builders/method_debug_fill_properties.dart';
 import 'package:mix_generator/src/builders/method_equality.dart';
 import 'package:mix_generator/src/builders/method_lerp_builder.dart';
+import 'package:mix_generator/src/helpers/builder_utils.dart';
 import 'package:mix_generator/src/helpers/field_info.dart';
 import 'package:mix_generator/src/helpers/helpers.dart';
 
@@ -19,6 +20,8 @@ String specMixin(ClassBuilderContext<MixableSpec> context) {
   final mixinName = context.generatedName;
   final specType = context.specType;
 
+  final generateStaticMethods = !context.classElement.isWidgetModifier;
+
   final hasCopyWith =
       context.classElement.methods.any((e) => e.name == 'copyWith');
   final hasLerp = context.classElement.methods.any((e) => e.name == 'lerp');
@@ -31,12 +34,14 @@ String specMixin(ClassBuilderContext<MixableSpec> context) {
 
   final selfGetter = getterSelfBuilder(specClass);
 
-  final staticMethodFrom = _staticMethodFromBuilder(context);
-
   final debugFillProperties =
       hasDiagnosticable ? methodDebugFillProperties(specClass) : '';
 
-  final staticMethodOf = _staticMethodOfBuilder(context);
+  final staticMethodFrom =
+      generateStaticMethods ? _staticMethodFromBuilder(context) : '';
+
+  final staticMethodOf =
+      generateStaticMethods ? _staticMethodOfBuilder(context) : '';
 
   return '''
  mixin $mixinName on $specType<$specClassName> {

--- a/packages/mix_generator/lib/src/helpers/field_info.dart
+++ b/packages/mix_generator/lib/src/helpers/field_info.dart
@@ -20,12 +20,15 @@ class FieldInfo {
     required this.documentationComment,
     required this.annotation,
     required this.nullable,
+    required this.hasDeprecated,
   });
 
   /// Parameter / field type.
   final String name;
 
   final DartType dartType;
+
+  final bool hasDeprecated;
 
   final MixableProperty annotation;
 
@@ -74,6 +77,7 @@ class FieldInfo {
       dartType: element.type,
       type: element.type.getTypeAsString(),
       nullable: element.type.isNullableType,
+      hasDeprecated: element.hasDeprecated,
       annotation: readMixableProperty(element),
       documentationComment: element.documentationComment,
     );
@@ -90,6 +94,7 @@ class ParameterInfo extends FieldInfo {
     required super.dartType,
     required super.annotation,
     required super.documentationComment,
+    required super.hasDeprecated,
     required this.isRequiredNamed,
     required this.isRequiredPositional,
   });
@@ -113,6 +118,8 @@ class ParameterInfo extends FieldInfo {
 
     return ParameterInfo(
       name: element.name,
+      hasDeprecated:
+          (fieldInfo?.hasDeprecated ?? false) || element.hasDeprecated,
       dartType: element.type,
       type: element.type.getDisplayString(withNullability: false),
       nullable: fieldInfo?.nullable ?? isNullable,
@@ -279,6 +286,7 @@ FieldInfo? getFieldInfoFromParameter(
     type: field.type.getDisplayString(withNullability: false),
     dartType: field.type,
     nullable: field.type.isNullableType,
+    hasDeprecated: field.hasDeprecated,
     annotation: annotation,
     documentationComment: field.documentationComment,
   );

--- a/packages/mix_generator/lib/src/mixable_spec_generator.dart
+++ b/packages/mix_generator/lib/src/mixable_spec_generator.dart
@@ -24,9 +24,6 @@ class MixableSpecGenerator extends GeneratorForAnnotation<MixableSpec> {
     final context = await _loadContext(element);
 
     final output = '''
-
-    // ignore_for_file: deprecated_member_use_from_same_package
-
     ${specMixin(context)}
 
     ${specAttributeClass(context)}

--- a/packages/mix_generator/lib/src/mixable_spec_generator.dart
+++ b/packages/mix_generator/lib/src/mixable_spec_generator.dart
@@ -23,7 +23,13 @@ class MixableSpecGenerator extends GeneratorForAnnotation<MixableSpec> {
   ) async {
     final context = await _loadContext(element);
 
+    final deprecatedRule = context.fields.any((e) => e.hasDeprecated)
+        ? '// ignore_for_file: deprecated_member_use_from_same_package'
+        : '';
+
     final output = '''
+    $deprecatedRule
+    
     ${specMixin(context)}
 
     ${specAttributeClass(context)}


### PR DESCRIPTION
This fixes some inconsistent linting issues that code generation might produce, including deprecated and unused static imports.