### PR TITLE
chore: Removed base keyword from attributes

### DIFF
--- a/packages/mix/lib/src/core/attribute.dart
+++ b/packages/mix/lib/src/core/attribute.dart
@@ -4,7 +4,7 @@ import '../internal/compare_mixin.dart';
 import 'dto.dart';
 
 @immutable
-abstract base class Attribute with MergeableMixin, EqualityMixin {
+abstract class Attribute with MergeableMixin, EqualityMixin {
   const Attribute();
 
   // Used as the key to determine how
@@ -27,7 +27,7 @@ mixin MergeableMixin<T> {
 }
 
 @immutable
-abstract base class StyledAttribute extends Attribute {
+abstract class StyledAttribute extends Attribute {
   const StyledAttribute();
 
   @override

--- a/packages/mix/lib/src/core/deprecation_notices.dart
+++ b/packages/mix/lib/src/core/deprecation_notices.dart
@@ -46,7 +46,7 @@ class OnEnabledVariant extends OnDisabledVariant {
 typedef WidgetModifier<T extends WidgetModifierSpec<T>> = WidgetModifierSpec<T>;
 
 @Deprecated('Use `WidgetModifierSpecAttribute` instead.')
-abstract base class WidgetModifierAttribute<
+abstract class WidgetModifierAttribute<
         Self extends WidgetModifierSpecAttribute<Value>,
         Value extends WidgetModifierSpec<Value>>
     extends WidgetModifierSpecAttribute<Value> {

--- a/packages/mix/lib/src/core/modifier.dart
+++ b/packages/mix/lib/src/core/modifier.dart
@@ -8,7 +8,7 @@ import 'utility.dart';
 
 abstract class WidgetModifierSpec<Self extends WidgetModifierSpec<Self>>
     extends Spec<Self> {
-  const WidgetModifierSpec({super.animated});
+  const WidgetModifierSpec({super.animated}) : super(modifiers: null);
 
   static WidgetModifierSpec? lerpValue(
     WidgetModifierSpec? begin,
@@ -30,7 +30,7 @@ abstract class WidgetModifierSpec<Self extends WidgetModifierSpec<Self>>
   Widget build(Widget child);
 }
 
-abstract base class WidgetModifierSpecAttribute<
+abstract class WidgetModifierSpecAttribute<
         Value extends WidgetModifierSpec<Value>> extends SpecAttribute<Value>
     with Diagnosticable {
   const WidgetModifierSpecAttribute();
@@ -39,7 +39,7 @@ abstract base class WidgetModifierSpecAttribute<
   Value resolve(MixData mix);
 }
 
-abstract base class WidgetModifierUtility<
+abstract class WidgetModifierUtility<
     T extends Attribute,
     D extends WidgetModifierSpecAttribute<Value>,
     Value extends WidgetModifierSpec<Value>> extends MixUtility<T, D> {

--- a/packages/mix/lib/src/core/spec.dart
+++ b/packages/mix/lib/src/core/spec.dart
@@ -35,7 +35,7 @@ abstract class Spec<T extends Spec<T>> with EqualityMixin {
 ///
 /// This class extends the [StyledAttribute] class and provides a generic type [Self] and [Value].
 /// The [Self] type represents the concrete implementation of the attribute, while the [Value] type represents the resolvable value.
-abstract base class SpecAttribute<Value> extends StyledAttribute {
+abstract class SpecAttribute<Value> extends StyledAttribute {
   final AnimatedDataDto? animated;
   final WidgetModifiersDataDto? modifiers;
 

--- a/packages/mix/lib/src/variants/variant_attribute.dart
+++ b/packages/mix/lib/src/variants/variant_attribute.dart
@@ -5,7 +5,7 @@ import '../core/factory/style_mix.dart';
 import '../core/variant.dart';
 
 @immutable
-base class VariantAttribute<V extends IVariant> extends Attribute {
+class VariantAttribute<V extends IVariant> extends Attribute {
   final V variant;
   final Style _style;
   const VariantAttribute(this.variant, Style style) : _style = style;

--- a/packages/mix/test/helpers/testing_utils.dart
+++ b/packages/mix/test/helpers/testing_utils.dart
@@ -228,7 +228,7 @@ final class MockBooleanScalarAttribute
   const MockBooleanScalarAttribute(super.value);
 }
 
-abstract base class _MockSpecAttribute<T> extends SpecAttribute<T> {
+abstract class _MockSpecAttribute<T> extends SpecAttribute<T> {
   final T _value;
   const _MockSpecAttribute(this._value);
 
@@ -379,7 +379,7 @@ class WidgetWithTestableBuild extends StyledWidget {
   }
 }
 
-abstract base class TestScalarAttribute<
+abstract class TestScalarAttribute<
     Self extends TestScalarAttribute<Self, Value>,
     Value> extends StyledAttribute {
   final Value value;


### PR DESCRIPTION
Removed the `base` keyword from attributes for more flexibility on code gen.