### PR TITLE
fix: Correct handling of individual border sides

### DIFF
--- a/packages/mix/lib/src/attributes/border/border_dto.dart
+++ b/packages/mix/lib/src/attributes/border/border_dto.dart
@@ -83,7 +83,7 @@ final class BorderDto extends BoxBorderDto<Border> with _$BorderDto {
   bool get isUniform => top == bottom && top == left && top == right;
 
   @override
-  Border get defaultValue => Border.all();
+  Border get defaultValue => const Border();
 }
 
 @MixableDto(generateUtility: false)

--- a/packages/mix/test/src/attributes/border/border_dto_test.dart
+++ b/packages/mix/test/src/attributes/border/border_dto_test.dart
@@ -66,6 +66,20 @@ void main() {
       expect(resolvedBorder.right, const BorderSide(width: 20.0));
     });
 
+    test('resolve() Border with default value', () {
+      const borderDto = BorderDto(
+        top: BorderSideDto(width: 5.0),
+        left: BorderSideDto(width: 15.0),
+      );
+
+      final resolvedBorder = borderDto.resolve(EmptyMixData);
+
+      expect(resolvedBorder.top, const BorderSide(width: 5.0));
+      expect(resolvedBorder.bottom, BorderSide.none);
+      expect(resolvedBorder.left, const BorderSide(width: 15.0));
+      expect(resolvedBorder.right, BorderSide.none);
+    });
+
     test('resolve() BorderDirectional', () {
       const borderDto = BorderDirectionalDto(
         top: BorderSideDto(width: 5.0),


### PR DESCRIPTION
### Description

The default value was changed causing this issue. This PR does a rollback, returning the BorderDTO's `defaultValue` to `const Border()`.

### Changes

- It changes the `default value`.

**Review Checklist**

- [x] **Testing**: Have you tested your changes, including unit tests and integration tests for affected code?
- [ ] **Breaking Changes**: Does this change introduce breaking changes affecting existing code or users?
- [ ] **Documentation Updates**: Are all relevant documentation files (e.g. README, API docs) updated to reflect the changes in this PR?
- [ ] **Website Updates**: Is the website containing the updates you make on documentation?

