### PR TITLE
fix: FlexSpecWidget prioritizes the direction in spec

### DIFF
--- a/packages/mix/lib/src/specs/flex/flex_widget.dart
+++ b/packages/mix/lib/src/specs/flex/flex_widget.dart
@@ -62,6 +62,8 @@ class FlexSpecWidget extends StatelessWidget {
   final FlexSpec? spec;
   final List<Type> orderOfModifiers;
 
+  Axis get _definitiveDirection => spec?.direction ?? direction;
+
   List<Widget> _buildChildren(double? gap) {
     if (gap == null) return children;
 
@@ -70,7 +72,7 @@ class FlexSpecWidget extends StatelessWidget {
     return List.generate(children.length + children.length - 1, (index) {
       if (index.isEven) return children[index ~/ 2];
 
-      return direction == Axis.horizontal
+      return _definitiveDirection == Axis.horizontal
           ? SizedBox(width: gap)
           : SizedBox(height: gap);
     });
@@ -80,7 +82,7 @@ class FlexSpecWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     final gap = spec?.gap;
     final flexWidget = Flex(
-      direction: direction,
+      direction: _definitiveDirection,
       mainAxisAlignment:
           spec?.mainAxisAlignment ?? _defaultFlex.mainAxisAlignment,
       mainAxisSize: spec?.mainAxisSize ?? _defaultFlex.mainAxisSize,

--- a/packages/mix/test/src/specs/flex/flex_widget_test.dart
+++ b/packages/mix/test/src/specs/flex/flex_widget_test.dart
@@ -6,6 +6,47 @@ import '../../../helpers/override_modifiers_order.dart';
 import '../../../helpers/testing_utils.dart';
 
 void main() {
+  group('FlexSpecWidget', () {
+    testWidgets('prioritizes the direction in spec', (tester) async {
+      await tester.pumpMaterialApp(
+        const Center(
+          child: FlexSpecWidget(
+            direction: Axis.horizontal,
+            spec: FlexSpec(
+              direction: Axis.vertical,
+            ),
+            children: [
+              StyledText('test'),
+              StyledText('case'),
+            ],
+          ),
+        ),
+      );
+
+      final flex = tester.widget<Flex>(find.byType(Flex));
+      expect(flex.direction, Axis.vertical);
+    });
+
+    testWidgets('changes its gap direction when direction is modified',
+        (tester) async {
+      await tester.pumpMaterialApp(
+        const Center(
+          child: FlexSpecWidget(
+            direction: Axis.horizontal,
+            spec: FlexSpec(direction: Axis.vertical, gap: 16),
+            children: [
+              StyledText('test'),
+              StyledText('case'),
+            ],
+          ),
+        ),
+      );
+
+      final sizedBox = tester.widget<SizedBox>(find.byType(SizedBox));
+      expect(sizedBox.height, 16);
+    });
+  });
+
   testWidgets(
     'HBox with gap() rendered correctly in complex widget tree',
     (tester) async {


### PR DESCRIPTION
### Description

This PR makes `FlexSpecWidget` prioritize the direction specified in the `FlexSpec`.

### Changes

- Prioritize `direction` in `FlexSpec` instead of the parameter.

### Additional Information (optional)

- This PR changes this behavior in all `Flex` alternatives.
