### PR TITLE
fix: Pressable disposes controller only if it creates it

### DIFF
--- a/packages/mix/lib/src/widgets/pressable_widget.dart
+++ b/packages/mix/lib/src/widgets/pressable_widget.dart
@@ -165,7 +165,7 @@ class PressableWidgetState extends State<Pressable> {
 
   @override
   void dispose() {
-    _controller.dispose();
+    if (widget.controller == null) _controller.dispose();
     super.dispose();
   }
 

--- a/packages/mix/test/src/widgets/pressable/pressable_widget_test.dart
+++ b/packages/mix/test/src/widgets/pressable/pressable_widget_test.dart
@@ -63,6 +63,10 @@ void main() {
           reason: 'Third Pressable should not have disabled state');
     });
 
+    testWidgets('is disposing the controller correcly', (widgetTester) async {
+      await widgetTester.pumpWidget(_DisposalPressable());
+    });
+
     testWidgets(
       'must be clickable when enabled is setted to true',
       (tester) async {
@@ -641,4 +645,35 @@ Future<void> pumpTestCase({
   expect(newValue, finalExpectedOpacity);
 
   await tester.pumpAndSettle(const Duration(milliseconds: 250));
+}
+
+class _DisposalPressable extends StatefulWidget {
+  const _DisposalPressable({Key? key}) : super(key: key);
+
+  @override
+  _DisposalPressableState createState() => _DisposalPressableState();
+}
+
+class _DisposalPressableState extends State<_DisposalPressable> {
+  late final MixWidgetStateController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = MixWidgetStateController();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Pressable(
+      controller: _controller,
+      child: Box(),
+    );
+  }
 }


### PR DESCRIPTION
### Description

- Pressable was disposing the MixWidgetStateController, even when Pressable wasn't the instantiator.

### Changes

- Add a conditional to verify if the Pressable was the one who instantiated.

**Review Checklist**

- [ ] **Testing**: Have you tested your changes, including unit tests and integration tests for affected code?
- [ ] **Breaking Changes**: Does this change introduce breaking changes affecting existing code or users?
- [ ] **Documentation Updates**: Are all relevant documentation files (e.g. README, API docs) updated to reflect the changes in this PR?
- [ ] **Website Updates**: Is the website containing the updates you make on documentation?

