### PR TITLE
fix: HitTestBehavior when there is a Interectable in the tree

### DIFF
--- a/packages/mix/lib/src/widgets/pressable_widget.dart
+++ b/packages/mix/lib/src/widgets/pressable_widget.dart
@@ -204,18 +204,18 @@ class PressableWidgetState extends State<Pressable> {
       excludeFromSemantics: widget.excludeFromSemantics,
       hitTestBehavior: widget.hitTestBehavior,
       unpressDelay: widget.unpressDelay,
-      child: MouseRegionMixStateWidget(
-        child: InteractiveMixStateWidget(
-          enabled: widget.enabled,
-          onFocusChange: widget.onFocusChange,
-          autofocus: widget.autofocus,
-          focusNode: widget.focusNode,
-          onKey: widget.onKey,
-          onKeyEvent: widget.onKeyEvent,
-          canRequestFocus: widget.canRequestFocus,
-          mouseCursor: mouseCursor,
-          controller: _controller,
-          actions: actions,
+      child: InteractiveMixStateWidget(
+        enabled: widget.enabled,
+        onFocusChange: widget.onFocusChange,
+        autofocus: widget.autofocus,
+        focusNode: widget.focusNode,
+        onKey: widget.onKey,
+        onKeyEvent: widget.onKeyEvent,
+        canRequestFocus: widget.canRequestFocus,
+        mouseCursor: mouseCursor,
+        controller: _controller,
+        actions: actions,
+        child: MouseRegionMixStateWidget(
           child: MixWidgetStateBuilder(
             controller: _controller,
             builder: (_) => widget.child,
@@ -307,21 +307,21 @@ class _InteractableState extends State<Interactable> {
 
   @override
   Widget build(BuildContext context) {
-    return MouseRegionMixStateWidget(
-      child: InteractiveMixStateWidget(
-        enabled: widget.enabled,
-        onFocusChange: widget.onFocusChange,
-        autofocus: widget.autofocus,
-        focusNode: widget.focusNode,
-        onKey: widget.onKey,
-        onShowFocusHighlight: widget.onShowFocusHighlight,
-        onShowHoverHighlight: widget.onShowHoverHighlight,
-        onKeyEvent: widget.onKeyEvent,
-        canRequestFocus: widget.canRequestFocus,
-        mouseCursor: widget.mouseCursor,
-        shortcuts: widget.shortcuts,
-        controller: _controller,
-        actions: widget.actions,
+    return InteractiveMixStateWidget(
+      enabled: widget.enabled,
+      onFocusChange: widget.onFocusChange,
+      autofocus: widget.autofocus,
+      focusNode: widget.focusNode,
+      onKey: widget.onKey,
+      onShowFocusHighlight: widget.onShowFocusHighlight,
+      onShowHoverHighlight: widget.onShowHoverHighlight,
+      onKeyEvent: widget.onKeyEvent,
+      canRequestFocus: widget.canRequestFocus,
+      mouseCursor: widget.mouseCursor,
+      shortcuts: widget.shortcuts,
+      controller: _controller,
+      actions: widget.actions,
+      child: MouseRegionMixStateWidget(
         child: MixWidgetStateBuilder(
           controller: _controller,
           builder: (context) => widget.child,

--- a/packages/mix/test/src/widgets/pressable/pressable_widget_test.dart
+++ b/packages/mix/test/src/widgets/pressable/pressable_widget_test.dart
@@ -162,6 +162,32 @@ void main() {
         expect(onTapCalled, isTrue);
       },
     );
+
+    testWidgets('GestureDetector as parent should not affected by Pressable',
+        (tester) async {
+      bool onTapCalled = false;
+
+      await tester.pumpWidget(
+        GestureDetector(
+          onTap: () {
+            onTapCalled = true;
+          },
+          child: PressableBox(
+            style: Style(
+              $box.color.red(),
+              $on.hover(
+                $box.color.blue(),
+              ),
+            ),
+            child: Box(),
+          ),
+        ),
+      );
+      expect(find.byType(Pressable), findsOneWidget);
+      await tester.tap(find.byType(GestureDetector).first);
+
+      expect(onTapCalled, isTrue);
+    });
   });
 
   testWidgets('Pressable cancel timer on dispose', (WidgetTester tester) async {
@@ -583,6 +609,35 @@ void main() {
 
       final pressableState = tester.state<PressableWidgetState>(finder);
       expect(pressableState.mouseCursor, equals(MouseCursor.defer));
+    });
+  });
+
+  group('Interactable', () {
+    testWidgets('GestureDetector as parent should not affected by Interactable',
+        (tester) async {
+      bool onTapCalled = false;
+
+      await tester.pumpWidget(
+        GestureDetector(
+          onTap: () {
+            onTapCalled = true;
+          },
+          child: Box(
+            style: Style(
+              $box.color.red(),
+              $on.hover(
+                $box.color.blue(),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(Interactable), findsOneWidget);
+
+      await tester.tap(find.byType(GestureDetector));
+
+      expect(onTapCalled, isTrue);
     });
   });
 }


### PR DESCRIPTION
### Description

- The `MouseRegion` inside `Interactable` was causing side effects on `HitTestBehavior`

### Changes

- Change the order of `MouseRegionMixStateWidget` on the tree.

**Review Checklist**

- [x] **Testing**: Have you tested your changes, including unit tests and integration tests for affected code?
- [ ] **Breaking Changes**: Does this change introduce breaking changes affecting existing code or users?
- [ ] **Documentation Updates**: Are all relevant documentation files (e.g. README, API docs) updated to reflect the changes in this PR?
- [ ] **Website Updates**: Is the website containing the updates you make on documentation?
