### PR TITLE
feat: `OnEnd` callback for spec widgets

### DIFF
--- a/packages/mix/lib/src/core/styled_widget.dart
+++ b/packages/mix/lib/src/core/styled_widget.dart
@@ -52,10 +52,10 @@ abstract class StyledWidget extends StatelessWidget {
     Widget Function(BuildContext context) builder,
   ) {
     return SpecBuilder(
-      builder: builder,
+      orderOfModifiers: orderOfModifiers,
       style: style,
       inherit: inherit,
-      orderOfModifiers: orderOfModifiers,
+      builder: builder,
     );
   }
 
@@ -71,12 +71,12 @@ abstract class StyledWidget extends StatelessWidget {
 class SpecBuilder extends StatelessWidget {
   // Requires a builder function and accepts optional parameters
   const SpecBuilder({
-    required this.builder,
-    this.controller,
     super.key,
+    List<Type>? orderOfModifiers,
+    this.controller,
     this.style = const Style.empty(),
     this.inherit = false,
-    List<Type>? orderOfModifiers,
+    required this.builder,
   }) : orderOfModifiers = orderOfModifiers ?? const [];
 
   bool get _hasWidgetStateVariant => style.variants.values

--- a/packages/mix/lib/src/modifiers/internal/render_widget_modifier.dart
+++ b/packages/mix/lib/src/modifiers/internal/render_widget_modifier.dart
@@ -279,8 +279,8 @@ class RenderSpecModifiers extends StatelessWidget {
             modifiers: modifiers,
             duration: spec.animated!.duration,
             orderOfModifiers: orderOfModifiers,
-            curve: spec.animated!.curve,henAnimated,
-            child: child,
+            curve: spec.animated!.curve,
+            onEnd: onEndWhenAnimated,
             child: child,
           )
         : RenderModifiers(

--- a/packages/mix/lib/src/modifiers/internal/render_widget_modifier.dart
+++ b/packages/mix/lib/src/modifiers/internal/render_widget_modifier.dart
@@ -261,12 +261,14 @@ class RenderSpecModifiers extends StatelessWidget {
     required this.orderOfModifiers,
     required this.child,
     required this.spec,
+    this.onEndWhenAnimated,
     super.key,
   });
 
   final Widget child;
   final List<Type> orderOfModifiers;
   final Spec spec;
+  final void Function()? onEndWhenAnimated;
 
   @override
   Widget build(BuildContext context) {
@@ -277,7 +279,8 @@ class RenderSpecModifiers extends StatelessWidget {
             modifiers: modifiers,
             duration: spec.animated!.duration,
             orderOfModifiers: orderOfModifiers,
-            curve: spec.animated!.curve,
+            curve: spec.animated!.curve,henAnimated,
+            child: child,
             child: child,
           )
         : RenderModifiers(

--- a/packages/mix/lib/src/specs/box/box_widget.dart
+++ b/packages/mix/lib/src/specs/box/box_widget.dart
@@ -65,17 +65,22 @@ class BoxSpecWidget extends StatelessWidget {
     super.key,
     this.child,
     this.orderOfModifiers = const [],
+    this.onEndSpecModifiersAnimation,
   });
 
   final Widget? child;
   final BoxSpec? spec;
   final List<Type> orderOfModifiers;
 
+  /// Called when spec modifiers are animated and the animation is complete.
+  final void Function()? onEndSpecModifiersAnimation;
+
   @override
   Widget build(BuildContext context) {
     return RenderSpecModifiers(
       orderOfModifiers: orderOfModifiers,
       spec: spec ?? const BoxSpec(),
+      onEndWhenAnimated: onEndSpecModifiersAnimation,
       child: Container(
         alignment: spec?.alignment,
         padding: spec?.padding,
@@ -103,11 +108,15 @@ class AnimatedBoxSpecWidget extends ImplicitlyAnimatedWidget {
     super.curve = Curves.linear,
     super.onEnd,
     this.orderOfModifiers = const [],
+    this.onEndSpecModifiersAnimation,
   });
 
   final Widget? child;
   final BoxSpec spec;
   final List<Type> orderOfModifiers;
+
+  /// Called when spec modifiers are animated and the animation is complete.
+  final void Function()? onEndSpecModifiersAnimation;
 
   @override
   AnimatedWidgetBaseState<AnimatedBoxSpecWidget> createState() =>
@@ -133,6 +142,10 @@ class _AnimatedBoxSpecWidgetState
   Widget build(BuildContext context) {
     final spec = _boxSpec?.evaluate(animation);
 
-    return BoxSpecWidget(spec: spec, child: widget.child);
+    return BoxSpecWidget(
+      spec: spec,imation: widget.onEndSpecModifiersAnimation,
+      child: widget.child,
+      child: widget.child,
+    );
   }
 }

--- a/packages/mix/lib/src/specs/box/box_widget.dart
+++ b/packages/mix/lib/src/specs/box/box_widget.dart
@@ -143,8 +143,8 @@ class _AnimatedBoxSpecWidgetState
     final spec = _boxSpec?.evaluate(animation);
 
     return BoxSpecWidget(
-      spec: spec,imation: widget.onEndSpecModifiersAnimation,
-      child: widget.child,
+      spec: spec,
+      onEndSpecModifiersAnimation: widget.onEndSpecModifiersAnimation,
       child: widget.child,
     );
   }

--- a/packages/mix/lib/src/specs/flex/flex_widget.dart
+++ b/packages/mix/lib/src/specs/flex/flex_widget.dart
@@ -101,8 +101,8 @@ class FlexSpecWidget extends StatelessWidget {
         ? flexWidget
         : RenderSpecModifiers(
             orderOfModifiers: orderOfModifiers,
-            spec: spec!, onEndSpecModifiersAnimation,
-            child: flexWidget,
+            spec: spec!,
+            onEndWhenAnimated: onEndSpecModifiersAnimation,
             child: flexWidget,
           );
   }
@@ -153,8 +153,8 @@ class AnimatedFlexSpecWidgetState
     return FlexSpecWidget(
       spec: _specTween?.evaluate(animation),
       direction: widget.direction,
-      orderOfModifiers: widget.orderOfModifiers,n: widget.onEndSpecModifiersAnimation,
-      children: widget.children,
+      orderOfModifiers: widget.orderOfModifiers,
+      onEndSpecModifiersAnimation: widget.onEndSpecModifiersAnimation,
       children: widget.children,
     );
   }

--- a/packages/mix/lib/src/specs/flex/flex_widget.dart
+++ b/packages/mix/lib/src/specs/flex/flex_widget.dart
@@ -55,12 +55,16 @@ class FlexSpecWidget extends StatelessWidget {
     required this.children,
     required this.direction,
     this.orderOfModifiers = const [],
+    this.onEndSpecModifiersAnimation,
   });
 
   final List<Widget> children;
   final Axis direction;
   final FlexSpec? spec;
   final List<Type> orderOfModifiers;
+
+  /// Called when spec modifiers are animated and the animation is complete.
+  final void Function()? onEndSpecModifiersAnimation;
 
   Axis get _definitiveDirection => spec?.direction ?? direction;
 
@@ -97,7 +101,8 @@ class FlexSpecWidget extends StatelessWidget {
         ? flexWidget
         : RenderSpecModifiers(
             orderOfModifiers: orderOfModifiers,
-            spec: spec!,
+            spec: spec!, onEndSpecModifiersAnimation,
+            child: flexWidget,
             child: flexWidget,
           );
   }
@@ -110,6 +115,7 @@ class AnimatedFlexSpecWidget extends ImplicitlyAnimatedWidget {
     required this.children,
     required this.direction,
     this.orderOfModifiers = const [],
+    this.onEndSpecModifiersAnimation,
     super.curve,
     required super.duration,
     super.onEnd,
@@ -119,6 +125,9 @@ class AnimatedFlexSpecWidget extends ImplicitlyAnimatedWidget {
   final List<Widget> children;
   final Axis direction;
   final List<Type> orderOfModifiers;
+
+  /// Called when spec modifiers are animated and the animation is complete.
+  final void Function()? onEndSpecModifiersAnimation;
 
   @override
   AnimatedFlexSpecWidgetState createState() => AnimatedFlexSpecWidgetState();
@@ -144,7 +153,8 @@ class AnimatedFlexSpecWidgetState
     return FlexSpecWidget(
       spec: _specTween?.evaluate(animation),
       direction: widget.direction,
-      orderOfModifiers: widget.orderOfModifiers,
+      orderOfModifiers: widget.orderOfModifiers,n: widget.onEndSpecModifiersAnimation,
+      children: widget.children,
       children: widget.children,
     );
   }

--- a/packages/mix/lib/src/specs/icon/icon_widget.dart
+++ b/packages/mix/lib/src/specs/icon/icon_widget.dart
@@ -58,6 +58,7 @@ class IconSpecWidget extends StatelessWidget {
     this.semanticLabel,
     super.key,
     this.textDirection,
+    this.onEndSpecModifiersAnimation,
     @Deprecated('Use orderOfModifiers parameter instead')
     List<Type> modifierOrder = const <Type>[],
     List<Type> orderOfModifiers = const <Type>[],
@@ -72,11 +73,15 @@ class IconSpecWidget extends StatelessWidget {
   final TextDirection? textDirection;
   final List<Type> orderOfModifiers;
 
+  /// Called when spec modifiers are animated and the animation is complete.
+  final void Function()? onEndSpecModifiersAnimation;
+
   @override
   Widget build(BuildContext context) {
     return RenderSpecModifiers(
       orderOfModifiers: orderOfModifiers,
       spec: spec ?? const IconSpec(),
+      onEndWhenAnimated: onEndSpecModifiersAnimation,
       child: Icon(
         icon,
         size: spec?.size,
@@ -145,6 +150,7 @@ class AnimatedIconSpecWidget extends ImplicitlyAnimatedWidget {
     super.curve,
     required super.duration,
     super.onEnd,
+    this.onEndSpecModifiersAnimation,
     @Deprecated('Use orderOfModifiers parameter instead')
     List<Type> modifierOrder = const <Type>[],
     List<Type> orderOfModifiers = const <Type>[],
@@ -159,6 +165,9 @@ class AnimatedIconSpecWidget extends ImplicitlyAnimatedWidget {
   final String? semanticLabel;
   final TextDirection? textDirection;
   final List<Type> orderOfModifiers;
+
+  /// Called when spec modifiers are animated and the animation is complete.
+  final void Function()? onEndSpecModifiersAnimation;
 
   @override
   // ignore: library_private_types_in_public_api
@@ -189,6 +198,7 @@ class _AnimatedIconSpecState
       spec: spec,
       semanticLabel: widget.semanticLabel,
       textDirection: widget.textDirection,
+      onEndSpecModifiersAnimation: widget.onEndSpecModifiersAnimation,
       orderOfModifiers: widget.orderOfModifiers,
     );
   }

--- a/packages/mix/lib/src/specs/image/image_widget.dart
+++ b/packages/mix/lib/src/specs/image/image_widget.dart
@@ -87,6 +87,7 @@ class ImageSpecWidget extends StatelessWidget {
     this.isAntiAlias = false,
     this.opacity,
     this.matchTextDirection = false,
+    this.onEndSpecModifiersAnimation,
   });
 
   final ImageSpec? spec;
@@ -102,11 +103,15 @@ class ImageSpecWidget extends StatelessWidget {
   final bool matchTextDirection;
   final Animation<double>? opacity;
 
+  /// Called when spec modifiers are animated and the animation is complete.
+  final void Function()? onEndSpecModifiersAnimation;
+
   @override
   Widget build(BuildContext context) {
     return RenderSpecModifiers(
       orderOfModifiers: orderOfModifiers,
       spec: spec ?? const ImageSpec(),
+      onEndWhenAnimated: onEndSpecModifiersAnimation,
       child: Image(
         image: image,
         frameBuilder: frameBuilder,
@@ -149,6 +154,7 @@ class AnimatedImageSpecWidget extends ImplicitlyAnimatedWidget {
     this.isAntiAlias = false,
     this.matchTextDirection = false,
     this.opacity,
+    this.onEndSpecModifiersAnimation,
   });
 
   final ImageSpec? spec;
@@ -162,6 +168,9 @@ class AnimatedImageSpecWidget extends ImplicitlyAnimatedWidget {
   final bool isAntiAlias;
   final bool matchTextDirection;
   final Animation<double>? opacity;
+
+  /// Called when spec modifiers are animated and the animation is complete.
+  final void Function()? onEndSpecModifiersAnimation;
 
   @override
   AnimatedWidgetBaseState<AnimatedImageSpecWidget> createState() =>
@@ -200,6 +209,7 @@ class _AnimateImageSpecState
       isAntiAlias: widget.isAntiAlias,
       opacity: widget.opacity,
       matchTextDirection: widget.matchTextDirection,
+      onEndSpecModifiersAnimation: widget.onEndSpecModifiersAnimation,
     );
   }
 }

--- a/packages/mix/lib/src/specs/stack/stack_widget.dart
+++ b/packages/mix/lib/src/specs/stack/stack_widget.dart
@@ -45,6 +45,7 @@ class StackSpecWidget extends StatelessWidget {
     this.spec,
     this.children,
     this.orderOfModifiers = const [],
+    this.onEndSpecModifiersAnimation,
     super.key,
   });
 
@@ -52,12 +53,16 @@ class StackSpecWidget extends StatelessWidget {
   final StackSpec? spec;
   final List<Type> orderOfModifiers;
 
+  /// Called when spec modifiers are animated and the animation is complete.
+  final void Function()? onEndSpecModifiersAnimation;
+
   @override
   Widget build(BuildContext context) {
     // The Stack widget is used here, applying the resolved styles from StackSpec.
     return RenderSpecModifiers(
       orderOfModifiers: orderOfModifiers,
       spec: spec ?? const StackSpec(),
+      onEndWhenAnimated: onEndSpecModifiersAnimation,
       child: Stack(
         alignment: spec?.alignment ?? _defaultStack.alignment,
         textDirection: spec?.textDirection,
@@ -75,6 +80,7 @@ class AnimatedStackSpecWidget extends ImplicitlyAnimatedWidget {
     required this.spec,
     required this.children,
     this.orderOfModifiers = const [],
+    this.onEndSpecModifiersAnimation,
     super.curve,
     required super.duration,
     super.onEnd,
@@ -83,6 +89,9 @@ class AnimatedStackSpecWidget extends ImplicitlyAnimatedWidget {
   final StackSpec spec;
   final List<Widget> children;
   final List<Type> orderOfModifiers;
+
+  /// Called when spec modifiers are animated and the animation is complete.
+  final void Function()? onEndSpecModifiersAnimation;
 
   @override
   AnimatedStackSpecWidgetState createState() => AnimatedStackSpecWidgetState();
@@ -110,6 +119,7 @@ class AnimatedStackSpecWidgetState
     return StackSpecWidget(
       spec: spec,
       orderOfModifiers: widget.orderOfModifiers,
+      onEndSpecModifiersAnimation: widget.onEndSpecModifiersAnimation,
       children: widget.children,
     );
   }

--- a/packages/mix/lib/src/specs/text/text_widget.dart
+++ b/packages/mix/lib/src/specs/text/text_widget.dart
@@ -79,6 +79,7 @@ class TextSpecWidget extends StatelessWidget {
     this.semanticsLabel,
     this.locale,
     this.orderOfModifiers = const [],
+    this.onEndSpecModifiersAnimation,
     super.key,
   });
 
@@ -88,12 +89,16 @@ class TextSpecWidget extends StatelessWidget {
   final TextSpec? spec;
   final List<Type> orderOfModifiers;
 
+  /// Called when spec modifiers are animated and the animation is complete.
+  final void Function()? onEndSpecModifiersAnimation;
+
   @override
   Widget build(BuildContext context) {
     // The Text widget is used here, applying the resolved styles and properties from TextSpec.
     return RenderSpecModifiers(
       orderOfModifiers: const [],
       spec: spec ?? const TextSpec(),
+      onEndWhenAnimated: onEndSpecModifiersAnimation,
       child: Text(
         spec?.directive?.apply(text) ?? text,
         style: spec?.style,
@@ -121,6 +126,7 @@ class AnimatedTextSpecWidget extends ImplicitlyAnimatedWidget {
     this.spec,
     this.semanticsLabel,
     this.locale,
+    this.onEndSpecModifiersAnimation,
     super.key,
     required super.duration,
     super.curve = Curves.linear,
@@ -131,6 +137,9 @@ class AnimatedTextSpecWidget extends ImplicitlyAnimatedWidget {
   final String? semanticsLabel;
   final Locale? locale;
   final TextSpec? spec;
+
+  /// Called when spec modifiers are animated and the animation is complete.
+  final void Function()? onEndSpecModifiersAnimation;
 
   @override
   AnimatedWidgetBaseState<AnimatedTextSpecWidget> createState() =>
@@ -161,6 +170,7 @@ class _AnimatedTextSpecWidgetState
       spec: spec,
       semanticsLabel: widget.semanticsLabel,
       locale: widget.locale,
+      onEndSpecModifiersAnimation: widget.onEndSpecModifiersAnimation,
     );
   }
 }

--- a/packages/mix/test/src/specs/box/box_widget_test.dart
+++ b/packages/mix/test/src/specs/box/box_widget_test.dart
@@ -65,6 +65,46 @@ void main() {
       expect(find.byType(Align), findsOneWidget);
     },
   );
+
+  testWidgets('BoxSpec handles onEnd', (WidgetTester tester) async {
+    var countPressTime = 0;
+    var countOnEnd = 0;
+
+    await tester.pumpWidget(
+      PressableBox(
+        onPress: () {
+          countPressTime++;
+        },
+        child: SpecBuilder(
+          style: Style(
+            $box.height(50),
+            $box.width(50),
+            $box.wrap.transform.scale(1),
+            $on.press(
+              $box.wrap.transform.scale(1.5),
+            ),
+          ).animate(),
+          builder: (context) {
+            final spec = BoxSpec.of(context);
+
+            return BoxSpecWidget(
+              spec: spec,
+              onEndSpecModifiersAnimation: () => countOnEnd++,
+            );
+          },
+        ),
+      ),
+    );
+
+    final containerFinder = find.byType(Pressable);
+    await tester.tap(containerFinder);
+
+    await tester.pumpAndSettle();
+
+    expect(countPressTime, 1);
+    expect(countOnEnd, 1);
+  });
+
   testWidgets('BoxSpec properties should match Container properties',
       (WidgetTester tester) async {
     final boxSpec = BoxSpec(

--- a/packages/mix/test/src/specs/flex/flex_widget_test.dart
+++ b/packages/mix/test/src/specs/flex/flex_widget_test.dart
@@ -27,6 +27,51 @@ void main() {
       expect(flex.direction, Axis.vertical);
     });
 
+    testWidgets('FlexSpec handles onEnd', (WidgetTester tester) async {
+      var countPressTime = 0;
+      var countOnEnd = 0;
+
+      await tester.pumpMaterialApp(
+        PressableBox(
+          onPress: () {
+            countPressTime++;
+          },
+          child: SpecBuilder(
+            style: Style(
+              $flex.wrap.transform.scale(1),
+              $on.press(
+                $flex.wrap.transform.scale(1.5),
+              ),
+            ).animate(),
+            builder: (context) {
+              final spec = FlexSpec.of(context);
+
+              return FlexSpecWidget(
+                direction: Axis.horizontal,
+                spec: spec,
+                onEndSpecModifiersAnimation: () => countOnEnd++,
+                children: [
+                  Container(
+                    height: 50,
+                    width: 50,
+                    color: Colors.red,
+                  )
+                ],
+              );
+            },
+          ),
+        ),
+      );
+
+      final containerFinder = find.byType(Pressable);
+      await tester.tap(containerFinder);
+
+      await tester.pumpAndSettle();
+
+      expect(countPressTime, 1);
+      expect(countOnEnd, 1);
+    });
+
     testWidgets('changes its gap direction when direction is modified',
         (tester) async {
       await tester.pumpMaterialApp(

--- a/packages/mix/test/src/specs/icon/icon_widget_test.dart
+++ b/packages/mix/test/src/specs/icon/icon_widget_test.dart
@@ -43,6 +43,44 @@ void main() {
     },
   );
 
+  testWidgets('IconSpec handles onEnd', (WidgetTester tester) async {
+    var countPressTime = 0;
+    var countOnEnd = 0;
+
+    await tester.pumpMaterialApp(
+      PressableBox(
+        onPress: () {
+          countPressTime++;
+        },
+        child: SpecBuilder(
+          style: Style(
+            $icon.wrap.transform.scale(1),
+            $on.press(
+              $icon.wrap.transform.scale(1.5),
+            ),
+          ).animate(),
+          builder: (context) {
+            final spec = IconSpec.of(context);
+
+            return IconSpecWidget(
+              Icons.abc,
+              spec: spec,
+              onEndSpecModifiersAnimation: () => countOnEnd++,
+            );
+          },
+        ),
+      ),
+    );
+
+    final containerFinder = find.byType(Pressable);
+    await tester.tap(containerFinder);
+
+    await tester.pumpAndSettle();
+
+    expect(countPressTime, 1);
+    expect(countOnEnd, 1);
+  });
+
   testWidgets('StyledIcon should apply IconSpec properties', (tester) async {
     await tester.pumpMaterialApp(
       StyledIcon(

--- a/packages/mix/test/src/specs/image/image_widget_test.dart
+++ b/packages/mix/test/src/specs/image/image_widget_test.dart
@@ -68,6 +68,44 @@ void main() {
       expect(opacityWidget.opacity, 0.5);
     });
 
+    testWidgets('ImageSpec handles onEnd', (WidgetTester tester) async {
+      var countPressTime = 0;
+      var countOnEnd = 0;
+
+      await tester.pumpMaterialApp(
+        PressableBox(
+          onPress: () {
+            countPressTime++;
+          },
+          child: SpecBuilder(
+            style: Style(
+              $image.wrap.transform.scale(1),
+              $on.press(
+                $image.wrap.transform.scale(1.5),
+              ),
+            ).animate(),
+            builder: (context) {
+              final spec = ImageSpec.of(context);
+
+              return ImageSpecWidget(
+                image: FileImage(File('test_resources/logo.png')),
+                spec: spec,
+                onEndSpecModifiersAnimation: () => countOnEnd++,
+              );
+            },
+          ),
+        ),
+      );
+
+      final containerFinder = find.byType(Pressable);
+      await tester.tap(containerFinder);
+
+      await tester.pumpAndSettle();
+
+      expect(countPressTime, 1);
+      expect(countOnEnd, 1);
+    });
+
     testWidgets(
       'can inherit style from the parent StyledWidget',
       (WidgetTester tester) async {

--- a/packages/mix/test/src/specs/stack/stack_widget_test.dart
+++ b/packages/mix/test/src/specs/stack/stack_widget_test.dart
@@ -33,6 +33,50 @@ void main() {
     expect(stackWidget.textDirection, TextDirection.ltr);
   });
 
+  testWidgets('StackSpec handles onEnd', (WidgetTester tester) async {
+    var countPressTime = 0;
+    var countOnEnd = 0;
+
+    await tester.pumpMaterialApp(
+      PressableBox(
+        onPress: () {
+          countPressTime++;
+        },
+        child: SpecBuilder(
+          style: Style(
+            $stack.wrap.transform.scale(1),
+            $on.press(
+              $stack.wrap.transform.scale(1.5),
+            ),
+          ).animate(),
+          builder: (context) {
+            final spec = StackSpec.of(context);
+
+            return StackSpecWidget(
+              spec: spec,
+              onEndSpecModifiersAnimation: () => countOnEnd++,
+              children: [
+                Container(
+                  height: 50,
+                  width: 50,
+                  color: Colors.red,
+                )
+              ],
+            );
+          },
+        ),
+      ),
+    );
+
+    final containerFinder = find.byType(Pressable);
+    await tester.tap(containerFinder);
+
+    await tester.pumpAndSettle();
+
+    expect(countPressTime, 1);
+    expect(countOnEnd, 1);
+  });
+
   testWidgets('ZBox', (tester) async {
     final style = Style(
       $stack.fit.expand(),

--- a/packages/mix/test/src/specs/text/text_widget_test.dart
+++ b/packages/mix/test/src/specs/text/text_widget_test.dart
@@ -23,6 +23,44 @@ void main() {
     },
   );
 
+  testWidgets('TextSpec handles onEnd', (WidgetTester tester) async {
+    var countPressTime = 0;
+    var countOnEnd = 0;
+
+    await tester.pumpMaterialApp(
+      PressableBox(
+        onPress: () {
+          countPressTime++;
+        },
+        child: SpecBuilder(
+          style: Style(
+            $text.wrap.transform.scale(1),
+            $on.press(
+              $text.wrap.transform.scale(1.5),
+            ),
+          ).animate(),
+          builder: (context) {
+            final spec = TextSpec.of(context);
+
+            return TextSpecWidget(
+              'Test',
+              spec: spec,
+              onEndSpecModifiersAnimation: () => countOnEnd++,
+            );
+          },
+        ),
+      ),
+    );
+
+    final containerFinder = find.byType(Pressable);
+    await tester.tap(containerFinder);
+
+    await tester.pumpAndSettle();
+
+    expect(countPressTime, 1);
+    expect(countOnEnd, 1);
+  });
+
   testWidgets('TextSpec properties should match Text properties',
       (WidgetTester tester) async {
     const textSpec = TextSpec(


### PR DESCRIPTION
### Description

- Before this PR there was no way to listen for when the animation was completed, which is a crucial part of animation in more complex components.

### Changes

- Expose the API `onEnd`, which is called when the animation ends.

**Review Checklist**

- [x] **Testing**: Have you tested your changes, including unit tests and integration tests for affected code?
- [ ] **Breaking Changes**: Does this change introduce breaking changes affecting existing code or users?
- [ ] **Documentation Updates**: Are all relevant documentation files (e.g. README, API docs) updated to reflect the changes in this PR?
- [ ] **Website Updates**: Is the website containing the updates you make on documentation?
