### PR TITLE
fix: Transform.rotate couldn't be applied as specModifiers

### DIFF
--- a/packages/mix/lib/src/modifiers/transform_widget_modifier.dart
+++ b/packages/mix/lib/src/modifiers/transform_widget_modifier.dart
@@ -42,9 +42,11 @@ final class TransformModifierSpec
 final class TransformModifierSpecUtility<T extends Attribute>
     extends MixUtility<T, TransformModifierSpecAttribute> {
   late final rotate = TransformRotateModifierSpecUtility(
-    (value) => TransformModifierSpecAttribute(
-      transform: value,
-      alignment: Alignment.center,
+    (value) => builder(
+      TransformModifierSpecAttribute(
+        transform: value,
+        alignment: Alignment.center,
+      ),
     ),
   );
 


### PR DESCRIPTION
### Description

- Transform.rotate was not able to be applied as a `specModifier`

### Changes

- Fix applying the modifier through the builder

**Review Checklist**

- [ ] **Testing**: Have you tested your changes, including unit tests and integration tests for affected code?
- [ ] **Breaking Changes**: Does this change introduce breaking changes affecting existing code or users?
- [ ] **Documentation Updates**: Are all relevant documentation files (e.g. README, API docs) updated to reflect the changes in this PR?
- [ ] **Website Updates**: Is the website containing the updates you make on documentation?
