### PR TITLE
fix: SpecModifiers were taking a long time to animate.

### DIFF
--- a/packages/mix/lib/src/core/spec.dart
+++ b/packages/mix/lib/src/core/spec.dart
@@ -14,7 +14,10 @@ import 'utility.dart';
 abstract class Spec<T extends Spec<T>> with EqualityMixin {
   final AnimatedData? animated;
 
-  @MixableProperty(utilities: [MixableUtility(alias: 'wrap')])
+  @MixableProperty(
+    utilities: [MixableUtility(alias: 'wrap')],
+    isLerpable: false,
+  )
   final WidgetModifiersData? modifiers;
 
   const Spec({this.animated, this.modifiers});

--- a/packages/mix/lib/src/specs/box/box_spec.g.dart
+++ b/packages/mix/lib/src/specs/box/box_spec.g.dart
@@ -106,7 +106,7 @@ mixin _$BoxSpec on Spec<BoxSpec> {
       clipBehavior: t < 0.5 ? _$this.clipBehavior : other.clipBehavior,
       width: MixHelpers.lerpDouble(_$this.width, other.width, t),
       height: MixHelpers.lerpDouble(_$this.height, other.height, t),
-      modifiers: t < 0.5 ? _$this.modifiers : other.modifiers,
+      modifiers: other.modifiers,
       animated: t < 0.5 ? _$this.animated : other.animated,
     );
   }

--- a/packages/mix/lib/src/specs/flex/flex_spec.g.dart
+++ b/packages/mix/lib/src/specs/flex/flex_spec.g.dart
@@ -97,7 +97,7 @@ mixin _$FlexSpec on Spec<FlexSpec> {
       clipBehavior: t < 0.5 ? _$this.clipBehavior : other.clipBehavior,
       gap: MixHelpers.lerpDouble(_$this.gap, other.gap, t),
       animated: t < 0.5 ? _$this.animated : other.animated,
-      modifiers: t < 0.5 ? _$this.modifiers : other.modifiers,
+      modifiers: other.modifiers,
     );
   }
 

--- a/packages/mix/lib/src/specs/icon/icon_spec.g.dart
+++ b/packages/mix/lib/src/specs/icon/icon_spec.g.dart
@@ -98,7 +98,7 @@ mixin _$IconSpec on Spec<IconSpec> {
           t < 0.5 ? _$this.applyTextScaling : other.applyTextScaling,
       fill: MixHelpers.lerpDouble(_$this.fill, other.fill, t),
       animated: t < 0.5 ? _$this.animated : other.animated,
-      modifiers: t < 0.5 ? _$this.modifiers : other.modifiers,
+      modifiers: other.modifiers,
     );
   }
 

--- a/packages/mix/lib/src/specs/image/image_spec.g.dart
+++ b/packages/mix/lib/src/specs/image/image_spec.g.dart
@@ -97,7 +97,7 @@ mixin _$ImageSpec on Spec<ImageSpec> {
       filterQuality: t < 0.5 ? _$this.filterQuality : other.filterQuality,
       colorBlendMode: t < 0.5 ? _$this.colorBlendMode : other.colorBlendMode,
       animated: t < 0.5 ? _$this.animated : other.animated,
-      modifiers: t < 0.5 ? _$this.modifiers : other.modifiers,
+      modifiers: other.modifiers,
     );
   }
 

--- a/packages/mix/lib/src/specs/stack/stack_spec.g.dart
+++ b/packages/mix/lib/src/specs/stack/stack_spec.g.dart
@@ -79,7 +79,7 @@ mixin _$StackSpec on Spec<StackSpec> {
       textDirection: t < 0.5 ? _$this.textDirection : other.textDirection,
       clipBehavior: t < 0.5 ? _$this.clipBehavior : other.clipBehavior,
       animated: t < 0.5 ? _$this.animated : other.animated,
-      modifiers: t < 0.5 ? _$this.modifiers : other.modifiers,
+      modifiers: other.modifiers,
     );
   }
 

--- a/packages/mix/lib/src/specs/text/text_spec.g.dart
+++ b/packages/mix/lib/src/specs/text/text_spec.g.dart
@@ -110,7 +110,7 @@ mixin _$TextSpec on Spec<TextSpec> {
       softWrap: t < 0.5 ? _$this.softWrap : other.softWrap,
       directive: t < 0.5 ? _$this.directive : other.directive,
       animated: t < 0.5 ? _$this.animated : other.animated,
-      modifiers: t < 0.5 ? _$this.modifiers : other.modifiers,
+      modifiers: other.modifiers,
     );
   }
 

--- a/packages/mix/test/src/specs/box/box_spec_test.dart
+++ b/packages/mix/test/src/specs/box/box_spec_test.dart
@@ -116,6 +116,10 @@ void main() {
         clipBehavior: Clip.none,
         width: 300,
         height: 200,
+        modifiers: const WidgetModifiersData([
+          OpacityModifierSpec(0.5),
+          SizedBoxModifierSpec(height: 10, width: 10),
+        ]),
       );
 
       final spec2 = BoxSpec(
@@ -130,6 +134,10 @@ void main() {
         transformAlignment: Alignment.center,
         width: 400,
         height: 300,
+        modifiers: const WidgetModifiersData([
+          OpacityModifierSpec(1),
+          SizedBoxModifierSpec(height: 100, width: 100),
+        ]),
       );
 
       const t = 0.5;
@@ -188,6 +196,52 @@ void main() {
             .lerp(t),
       );
       expect(lerpedSpec.clipBehavior, t < 0.5 ? Clip.none : Clip.antiAlias);
+    });
+
+    test('lerp modifiers', () {
+      const spec1 = BoxSpec(
+        modifiers: WidgetModifiersData([
+          OpacityModifierSpec(0.5),
+          SizedBoxModifierSpec(height: 10, width: 10),
+        ]),
+      );
+
+      const spec2 = BoxSpec(
+        modifiers: WidgetModifiersData([
+          OpacityModifierSpec(1),
+          SizedBoxModifierSpec(height: 100, width: 100),
+        ]),
+      );
+
+      final lerpedSpecStart = spec1.lerp(spec2, 0.0);
+
+      expect(
+        lerpedSpecStart.modifiers,
+        const WidgetModifiersData([
+          OpacityModifierSpec(1),
+          SizedBoxModifierSpec(height: 100, width: 100),
+        ]),
+      );
+
+      final lerpedSpecMid = spec1.lerp(spec2, 0.5);
+
+      expect(
+        lerpedSpecMid.modifiers,
+        const WidgetModifiersData([
+          OpacityModifierSpec(1),
+          SizedBoxModifierSpec(height: 100, width: 100),
+        ]),
+      );
+
+      final lerpedSpecEnd = spec1.lerp(spec2, 0.5);
+
+      expect(
+        lerpedSpecEnd.modifiers,
+        const WidgetModifiersData([
+          OpacityModifierSpec(1),
+          SizedBoxModifierSpec(height: 100, width: 100),
+        ]),
+      );
     });
 
     // equality

--- a/packages/mix_annotations/lib/src/annotations.dart
+++ b/packages/mix_annotations/lib/src/annotations.dart
@@ -104,9 +104,36 @@ class MixableProperty {
   /// corresponding paths and aliases.
   final List<MixableUtility>? utilities;
 
+  /// Determines whether the property can be linearly interpolated (lerped).
+  ///
+  /// If set to `false`, the property will be excluded from the lerp method,
+  /// and the generated code will not include this property in the lerp implementation.
+  /// If set to `true`, the property will be included in the lerp method.
+  ///
+  /// This flag affects the behavior of the generated `lerp` method:
+  ///
+  ///
+  /// @override
+  /// ExampleSpec lerp(ExampleSpec? other, double t) {
+  ///   if (other == null) return _$this;
+  ///
+  ///   return ExampleSpec(
+  ///     // When isLerpable is false:
+  ///     nonLerpableParameter: other.nonLerpableParameter,
+  ///     // When isLerpable is true:
+  ///     lerpableParameter: lerpableParameter.lerp(other.lerpableParameter, t),
+  ///   );
+  /// }
+  ///
+  ///
+  /// Setting `isLerpable` to `true` is particularly useful for properties
+  /// that represent continuous values (e.g., numbers, colors, or sizes)
+  /// which can be smoothly interpolated between two states.
+  final bool isLerpable;
+
   /// Creates a new instance of `MixableProperty` with the specified [dto] and
   /// [utilities].
-  const MixableProperty({this.dto, this.utilities});
+  const MixableProperty({this.dto, this.utilities, this.isLerpable = true});
 }
 
 /// An annotation class used to specify a mixable field DTO for code generation.

--- a/packages/mix_generator/lib/src/builders/method_lerp_builder.dart
+++ b/packages/mix_generator/lib/src/builders/method_lerp_builder.dart
@@ -87,6 +87,8 @@ String? _getLerpMethod(ParameterInfo field) {
 }
 
 String _getLerpExpression(ParameterInfo field, bool isInternalRef) {
+  if (!field.annotation.isLerpable) return 'other.${field.name}';
+
   final thisFieldName = isInternalRef ? field.asInternalRef : field.name;
   final otherFieldName = 'other.${field.name}';
   final force = field.nullable ? '' : '!';

--- a/packages/mix_generator/lib/src/helpers/annotation_helpers.dart
+++ b/packages/mix_generator/lib/src/helpers/annotation_helpers.dart
@@ -95,9 +95,12 @@ MixableProperty _getMixableProperty(ConstantReader reader) {
       .map((e) => _readMixableUtility(e))
       .toList();
 
+  final isLerpable = reader.peek('isLerpable')?.boolValue ?? true;
+
   return MixableProperty(
     dto: dto == null ? null : _getMixableDto(dto),
     utilities: utilities,
+    isLerpable: isLerpable,
   );
 }
 


### PR DESCRIPTION
### Description

- SpecModifiers were taking half of the animation time to start the animation.

### Changes

- Add the property `isLerpable` to the `@MixableProperty`
- Update the `mix_generator` to don't create any custom lerp when `isLerpable` is `false`

**Review Checklist**

- [x] **Testing**: Have you tested your changes, including unit tests and integration tests for affected code?
- [ ] **Breaking Changes**: Does this change introduce breaking changes affecting existing code or users?
- [ ] **Documentation Updates**: Are all relevant documentation files (e.g. README, API docs) updated to reflect the changes in this PR?
- [ ] **Website Updates**: Is the website containing the updates you make on documentation?

### Additional Information (optional)

#### Before
https://github.com/user-attachments/assets/b3ffd4ae-75ff-49b3-9a67-97b2e065aa15

#### After
https://github.com/user-attachments/assets/91561bf6-be06-4b49-88ee-733a61bb8cae


