### PR TITLE
feat: Add parameter onEnd for AnimatedStyle

### DIFF
--- a/packages/mix/lib/src/attributes/animated/animated_data.dart
+++ b/packages/mix/lib/src/attributes/animated/animated_data.dart
@@ -1,18 +1,25 @@
 import 'package:flutter/animation.dart';
+import 'package:flutter/widgets.dart';
 
 import '../../internal/constants.dart';
 import 'animated_data_dto.dart';
 
 class AnimatedData {
+  final VoidCallback? _onEnd;
   final Curve? _curve;
   final Duration? _duration;
-  const AnimatedData({required Duration? duration, required Curve? curve})
-      : _curve = curve,
-        _duration = duration;
+  const AnimatedData({
+    required Duration? duration,
+    required Curve? curve,
+    VoidCallback? onEnd,
+  })  : _curve = curve,
+        _duration = duration,
+        _onEnd = onEnd;
 
   const AnimatedData.withDefaults()
       : _duration = kDefaultAnimationDuration,
-        _curve = Curves.linear;
+        _curve = Curves.linear,
+        _onEnd = null;
 
   // Se default in case is not set
   Duration get duration => _duration ?? kDefaultAnimationDuration;
@@ -20,8 +27,10 @@ class AnimatedData {
   // set default in case its not set
   Curve get curve => _curve ?? Curves.linear;
 
+  VoidCallback? get onEnd => _onEnd;
+
   AnimatedDataDto toDto() {
-    return AnimatedDataDto(duration: duration, curve: curve);
+    return AnimatedDataDto(duration: duration, curve: curve, onEnd: _onEnd);
   }
 
   @override

--- a/packages/mix/lib/src/attributes/animated/animated_data_dto.dart
+++ b/packages/mix/lib/src/attributes/animated/animated_data_dto.dart
@@ -8,16 +8,22 @@ import 'animated_data.dart';
 class AnimatedDataDto extends Dto<AnimatedData> {
   final Duration? duration;
   final Curve? curve;
+  final VoidCallback? onEnd;
 
-  const AnimatedDataDto({required this.duration, required this.curve});
+  const AnimatedDataDto({
+    required this.duration,
+    required this.curve,
+    this.onEnd,
+  });
 
   const AnimatedDataDto.withDefaults()
       : duration = kDefaultAnimationDuration,
-        curve = Curves.linear;
+        curve = Curves.linear,
+        onEnd = null;
 
   @override
   AnimatedData resolve(MixData mix) {
-    return AnimatedData(duration: duration, curve: curve);
+    return AnimatedData(duration: duration, curve: curve, onEnd: onEnd);
   }
 
   @override

--- a/packages/mix/lib/src/core/factory/style_mix.dart
+++ b/packages/mix/lib/src/core/factory/style_mix.dart
@@ -176,11 +176,15 @@ class Style with EqualityMixin {
   MixData of(BuildContext context) => MixData.create(context, this);
 
   /// Returns a `AnimatedStyle` from this `Style` with the provided [duration] and [curve].
-  AnimatedStyle animate({Duration? duration, Curve? curve}) {
+  AnimatedStyle animate({
+    Duration? duration,
+    Curve? curve,
+    VoidCallback? onEnd,
+  }) {
     return AnimatedStyle._(
       styles: styles,
       variants: variants,
-      animated: AnimatedData(duration: duration, curve: curve),
+      animated: AnimatedData(duration: duration, curve: curve, onEnd: onEnd),
     );
   }
 
@@ -352,11 +356,12 @@ class AnimatedStyle extends Style {
     Style style, {
     required Duration duration,
     required Curve curve,
+    VoidCallback? onEnd,
   }) {
     return AnimatedStyle._(
       styles: style.styles,
       variants: style.variants,
-      animated: AnimatedData(duration: duration, curve: curve),
+      animated: AnimatedData(duration: duration, curve: curve, onEnd: onEnd),
     );
   }
 

--- a/packages/mix/lib/src/core/spec.dart
+++ b/packages/mix/lib/src/core/spec.dart
@@ -14,7 +14,10 @@ import 'utility.dart';
 abstract class Spec<T extends Spec<T>> with EqualityMixin {
   final AnimatedData? animated;
 
-  @MixableProperty(utilities: [MixableUtility(alias: 'wrap')])
+  @MixableProperty(
+    utilities: [MixableUtility(alias: 'wrap')],
+    isLerpable: false,
+  )
   final WidgetModifiersData? modifiers;
 
   const Spec({this.animated, this.modifiers});

--- a/packages/mix/lib/src/specs/box/box_spec.dart
+++ b/packages/mix/lib/src/specs/box/box_spec.dart
@@ -125,6 +125,7 @@ final class BoxSpec extends Spec<BoxSpec> with _$BoxSpec, Diagnosticable {
             spec: this,
             duration: animated!.duration,
             curve: animated!.curve,
+            onEnd: animated?.onEnd,
             orderOfModifiers: orderOfModifiers,
             child: child,
           )

--- a/packages/mix/lib/src/specs/box/box_spec.g.dart
+++ b/packages/mix/lib/src/specs/box/box_spec.g.dart
@@ -106,7 +106,7 @@ mixin _$BoxSpec on Spec<BoxSpec> {
       clipBehavior: t < 0.5 ? _$this.clipBehavior : other.clipBehavior,
       width: MixHelpers.lerpDouble(_$this.width, other.width, t),
       height: MixHelpers.lerpDouble(_$this.height, other.height, t),
-      modifiers: t < 0.5 ? _$this.modifiers : other.modifiers,
+      modifiers: other.modifiers,
       animated: t < 0.5 ? _$this.animated : other.animated,
     );
   }

--- a/packages/mix/lib/src/specs/flex/flex_spec.g.dart
+++ b/packages/mix/lib/src/specs/flex/flex_spec.g.dart
@@ -97,7 +97,7 @@ mixin _$FlexSpec on Spec<FlexSpec> {
       clipBehavior: t < 0.5 ? _$this.clipBehavior : other.clipBehavior,
       gap: MixHelpers.lerpDouble(_$this.gap, other.gap, t),
       animated: t < 0.5 ? _$this.animated : other.animated,
-      modifiers: t < 0.5 ? _$this.modifiers : other.modifiers,
+      modifiers: other.modifiers,
     );
   }
 

--- a/packages/mix/lib/src/specs/icon/icon_spec.g.dart
+++ b/packages/mix/lib/src/specs/icon/icon_spec.g.dart
@@ -98,7 +98,7 @@ mixin _$IconSpec on Spec<IconSpec> {
           t < 0.5 ? _$this.applyTextScaling : other.applyTextScaling,
       fill: MixHelpers.lerpDouble(_$this.fill, other.fill, t),
       animated: t < 0.5 ? _$this.animated : other.animated,
-      modifiers: t < 0.5 ? _$this.modifiers : other.modifiers,
+      modifiers: other.modifiers,
     );
   }
 

--- a/packages/mix/lib/src/specs/image/image_spec.g.dart
+++ b/packages/mix/lib/src/specs/image/image_spec.g.dart
@@ -97,7 +97,7 @@ mixin _$ImageSpec on Spec<ImageSpec> {
       filterQuality: t < 0.5 ? _$this.filterQuality : other.filterQuality,
       colorBlendMode: t < 0.5 ? _$this.colorBlendMode : other.colorBlendMode,
       animated: t < 0.5 ? _$this.animated : other.animated,
-      modifiers: t < 0.5 ? _$this.modifiers : other.modifiers,
+      modifiers: other.modifiers,
     );
   }
 

--- a/packages/mix/lib/src/specs/stack/stack_spec.g.dart
+++ b/packages/mix/lib/src/specs/stack/stack_spec.g.dart
@@ -79,7 +79,7 @@ mixin _$StackSpec on Spec<StackSpec> {
       textDirection: t < 0.5 ? _$this.textDirection : other.textDirection,
       clipBehavior: t < 0.5 ? _$this.clipBehavior : other.clipBehavior,
       animated: t < 0.5 ? _$this.animated : other.animated,
-      modifiers: t < 0.5 ? _$this.modifiers : other.modifiers,
+      modifiers: other.modifiers,
     );
   }
 

--- a/packages/mix/lib/src/specs/text/text_spec.g.dart
+++ b/packages/mix/lib/src/specs/text/text_spec.g.dart
@@ -110,7 +110,7 @@ mixin _$TextSpec on Spec<TextSpec> {
       softWrap: t < 0.5 ? _$this.softWrap : other.softWrap,
       directive: t < 0.5 ? _$this.directive : other.directive,
       animated: t < 0.5 ? _$this.animated : other.animated,
-      modifiers: t < 0.5 ? _$this.modifiers : other.modifiers,
+      modifiers: other.modifiers,
     );
   }
 

--- a/packages/mix/test/src/specs/box/box_spec_test.dart
+++ b/packages/mix/test/src/specs/box/box_spec_test.dart
@@ -116,6 +116,10 @@ void main() {
         clipBehavior: Clip.none,
         width: 300,
         height: 200,
+        modifiers: const WidgetModifiersData([
+          OpacityModifierSpec(0.5),
+          SizedBoxModifierSpec(height: 10, width: 10),
+        ]),
       );
 
       final spec2 = BoxSpec(
@@ -130,6 +134,10 @@ void main() {
         transformAlignment: Alignment.center,
         width: 400,
         height: 300,
+        modifiers: const WidgetModifiersData([
+          OpacityModifierSpec(1),
+          SizedBoxModifierSpec(height: 100, width: 100),
+        ]),
       );
 
       const t = 0.5;
@@ -188,6 +196,52 @@ void main() {
             .lerp(t),
       );
       expect(lerpedSpec.clipBehavior, t < 0.5 ? Clip.none : Clip.antiAlias);
+    });
+
+    test('lerp modifiers', () {
+      const spec1 = BoxSpec(
+        modifiers: WidgetModifiersData([
+          OpacityModifierSpec(0.5),
+          SizedBoxModifierSpec(height: 10, width: 10),
+        ]),
+      );
+
+      const spec2 = BoxSpec(
+        modifiers: WidgetModifiersData([
+          OpacityModifierSpec(1),
+          SizedBoxModifierSpec(height: 100, width: 100),
+        ]),
+      );
+
+      final lerpedSpecStart = spec1.lerp(spec2, 0.0);
+
+      expect(
+        lerpedSpecStart.modifiers,
+        const WidgetModifiersData([
+          OpacityModifierSpec(1),
+          SizedBoxModifierSpec(height: 100, width: 100),
+        ]),
+      );
+
+      final lerpedSpecMid = spec1.lerp(spec2, 0.5);
+
+      expect(
+        lerpedSpecMid.modifiers,
+        const WidgetModifiersData([
+          OpacityModifierSpec(1),
+          SizedBoxModifierSpec(height: 100, width: 100),
+        ]),
+      );
+
+      final lerpedSpecEnd = spec1.lerp(spec2, 0.5);
+
+      expect(
+        lerpedSpecEnd.modifiers,
+        const WidgetModifiersData([
+          OpacityModifierSpec(1),
+          SizedBoxModifierSpec(height: 100, width: 100),
+        ]),
+      );
     });
 
     // equality

--- a/packages/mix/test/src/specs/box/box_widget_test.dart
+++ b/packages/mix/test/src/specs/box/box_widget_test.dart
@@ -65,6 +65,41 @@ void main() {
       expect(find.byType(Align), findsOneWidget);
     },
   );
+
+  testWidgets('Box handles onEnd', (WidgetTester tester) async {
+    var countPressTime = 0;
+    var countOnEnd = 0;
+
+    await tester.pumpWidget(
+      PressableBox(
+        onPress: () {
+          countPressTime++;
+        },
+        style: Style(
+          $box.height(50),
+          $box.width(50),
+          $box.wrap.transform.scale(1),
+          $on.press(
+            $box.wrap.transform.scale(1.5),
+          ),
+        ).animate(
+          onEnd: () {
+            countOnEnd++;
+          },
+        ),
+        child: const Box(),
+      ),
+    );
+
+    final containerFinder = find.byType(Pressable);
+    await tester.tap(containerFinder);
+
+    await tester.pumpAndSettle();
+
+    expect(countPressTime, 1);
+    expect(countOnEnd, 1);
+  });
+
   testWidgets('BoxSpec properties should match Container properties',
       (WidgetTester tester) async {
     final boxSpec = BoxSpec(

--- a/packages/mix_annotations/lib/src/annotations.dart
+++ b/packages/mix_annotations/lib/src/annotations.dart
@@ -104,9 +104,36 @@ class MixableProperty {
   /// corresponding paths and aliases.
   final List<MixableUtility>? utilities;
 
+  /// Determines whether the property can be linearly interpolated (lerped).
+  ///
+  /// If set to `false`, the property will be excluded from the lerp method,
+  /// and the generated code will not include this property in the lerp implementation.
+  /// If set to `true`, the property will be included in the lerp method.
+  ///
+  /// This flag affects the behavior of the generated `lerp` method:
+  ///
+  ///
+  /// @override
+  /// ExampleSpec lerp(ExampleSpec? other, double t) {
+  ///   if (other == null) return _$this;
+  ///
+  ///   return ExampleSpec(
+  ///     // When isLerpable is false:
+  ///     nonLerpableParameter: other.nonLerpableParameter,
+  ///     // When isLerpable is true:
+  ///     lerpableParameter: lerpableParameter.lerp(other.lerpableParameter, t),
+  ///   );
+  /// }
+  ///
+  ///
+  /// Setting `isLerpable` to `true` is particularly useful for properties
+  /// that represent continuous values (e.g., numbers, colors, or sizes)
+  /// which can be smoothly interpolated between two states.
+  final bool isLerpable;
+
   /// Creates a new instance of `MixableProperty` with the specified [dto] and
   /// [utilities].
-  const MixableProperty({this.dto, this.utilities});
+  const MixableProperty({this.dto, this.utilities, this.isLerpable = true});
 }
 
 /// An annotation class used to specify a mixable field DTO for code generation.

--- a/packages/mix_generator/lib/src/builders/method_lerp_builder.dart
+++ b/packages/mix_generator/lib/src/builders/method_lerp_builder.dart
@@ -87,6 +87,8 @@ String? _getLerpMethod(ParameterInfo field) {
 }
 
 String _getLerpExpression(ParameterInfo field, bool isInternalRef) {
+  if (!field.annotation.isLerpable) return 'other.${field.name}';
+
   final thisFieldName = isInternalRef ? field.asInternalRef : field.name;
   final otherFieldName = 'other.${field.name}';
   final force = field.nullable ? '' : '!';

--- a/packages/mix_generator/lib/src/helpers/annotation_helpers.dart
+++ b/packages/mix_generator/lib/src/helpers/annotation_helpers.dart
@@ -95,9 +95,12 @@ MixableProperty _getMixableProperty(ConstantReader reader) {
       .map((e) => _readMixableUtility(e))
       .toList();
 
+  final isLerpable = reader.peek('isLerpable')?.boolValue ?? true;
+
   return MixableProperty(
     dto: dto == null ? null : _getMixableDto(dto),
     utilities: utilities,
+    isLerpable: isLerpable,
   );
 }
 

--- a/packages/remix/lib/components/button/button.g.dart
+++ b/packages/remix/lib/components/button/button.g.dart
@@ -83,7 +83,7 @@ mixin _$ButtonSpec on Spec<ButtonSpec> {
       flex: _$this.flex.lerp(other.flex, t),
       icon: _$this.icon.lerp(other.icon, t),
       label: _$this.label.lerp(other.label, t),
-      modifiers: t < 0.5 ? _$this.modifiers : other.modifiers,
+      modifiers: other.modifiers,
       spinner: _$this.spinner.lerp(other.spinner, t),
       animated: t < 0.5 ? _$this.animated : other.animated,
     );

--- a/packages/remix/lib/components/callout/callout.g.dart
+++ b/packages/remix/lib/components/callout/callout.g.dart
@@ -81,7 +81,7 @@ mixin _$CalloutSpec on Spec<CalloutSpec> {
       flex: _$this.flex.lerp(other.flex, t),
       icon: _$this.icon.lerp(other.icon, t),
       text: _$this.text.lerp(other.text, t),
-      modifiers: t < 0.5 ? _$this.modifiers : other.modifiers,
+      modifiers: other.modifiers,
       animated: t < 0.5 ? _$this.animated : other.animated,
     );
   }

--- a/packages/remix/lib/components/card/card.g.dart
+++ b/packages/remix/lib/components/card/card.g.dart
@@ -73,7 +73,7 @@ mixin _$CardSpec on Spec<CardSpec> {
     return CardSpec(
       container: _$this.container.lerp(other.container, t),
       flex: _$this.flex.lerp(other.flex, t),
-      modifiers: t < 0.5 ? _$this.modifiers : other.modifiers,
+      modifiers: other.modifiers,
       animated: t < 0.5 ? _$this.animated : other.animated,
     );
   }

--- a/packages/remix/lib/components/checkbox/checkbox.g.dart
+++ b/packages/remix/lib/components/checkbox/checkbox.g.dart
@@ -73,7 +73,7 @@ mixin _$CheckboxSpec on Spec<CheckboxSpec> {
     return CheckboxSpec(
       container: _$this.container.lerp(other.container, t),
       indicator: _$this.indicator.lerp(other.indicator, t),
-      modifiers: t < 0.5 ? _$this.modifiers : other.modifiers,
+      modifiers: other.modifiers,
       animated: t < 0.5 ? _$this.animated : other.animated,
     );
   }

--- a/packages/remix/lib/components/progress/progress.g.dart
+++ b/packages/remix/lib/components/progress/progress.g.dart
@@ -79,7 +79,7 @@ mixin _$ProgressSpec on Spec<ProgressSpec> {
       fill: _$this.fill.lerp(other.fill, t),
       outerContainer: _$this.outerContainer.lerp(other.outerContainer, t),
       animated: t < 0.5 ? _$this.animated : other.animated,
-      modifiers: t < 0.5 ? _$this.modifiers : other.modifiers,
+      modifiers: other.modifiers,
     );
   }
 

--- a/packages/remix/lib/components/radio/radio.g.dart
+++ b/packages/remix/lib/components/radio/radio.g.dart
@@ -72,7 +72,7 @@ mixin _$RadioSpec on Spec<RadioSpec> {
     return RadioSpec(
       container: _$this.container.lerp(other.container, t),
       indicator: _$this.indicator.lerp(other.indicator, t),
-      modifiers: t < 0.5 ? _$this.modifiers : other.modifiers,
+      modifiers: other.modifiers,
       animated: t < 0.5 ? _$this.animated : other.animated,
     );
   }

--- a/packages/remix/lib/components/spinner/spinner.g.dart
+++ b/packages/remix/lib/components/spinner/spinner.g.dart
@@ -83,7 +83,7 @@ mixin _$SpinnerSpec on Spec<SpinnerSpec> {
       color: Color.lerp(_$this.color, other.color, t)!,
       duration: t < 0.5 ? _$this.duration : other.duration,
       style: t < 0.5 ? _$this.style : other.style,
-      modifiers: t < 0.5 ? _$this.modifiers : other.modifiers,
+      modifiers: other.modifiers,
       animated: t < 0.5 ? _$this.animated : other.animated,
     );
   }

--- a/packages/remix/lib/components/switch/switch.g.dart
+++ b/packages/remix/lib/components/switch/switch.g.dart
@@ -73,7 +73,7 @@ mixin _$SwitchSpec on Spec<SwitchSpec> {
       container: _$this.container.lerp(other.container, t),
       indicator: _$this.indicator.lerp(other.indicator, t),
       animated: t < 0.5 ? _$this.animated : other.animated,
-      modifiers: t < 0.5 ? _$this.modifiers : other.modifiers,
+      modifiers: other.modifiers,
     );
   }
 


### PR DESCRIPTION
### Description

- Before this PR there was no way to listen for when the animation was completed, which is a crucial part of animation in more complex components.

### Changes

- Create the API `onEnd` for `AnimatedStyle`, which is called when the animation ends.

**Review Checklist**

- [x] **Testing**: Have you tested your changes, including unit tests and integration tests for affected code?
- [ ] **Breaking Changes**: Does this change introduce breaking changes affecting existing code or users?
- [ ] **Documentation Updates**: Are all relevant documentation files (e.g. README, API docs) updated to reflect the changes in this PR?
- [ ] **Website Updates**: Is the website containing the updates you make on documentation?
