### PR TITLE
fix(docs): Fix fn level docs for Style::applyVariants

### DIFF
--- a/packages/mix/lib/src/core/factory/style_mix.dart
+++ b/packages/mix/lib/src/core/factory/style_mix.dart
@@ -222,6 +222,7 @@ class Style with EqualityMixin {
   /// Otherwise, the method merges the attributes of the selected variants into a new `Style` instance.
   ///
   /// Example:
+  /// ```dart
   /// final outlinedVariant = Variant('outlined');
   /// final smallVariant = Variant('small');
   /// final style = Style(


### PR DESCRIPTION
fixes GitHub syntax highlight

#### Related issue

Is it related to any opened issue? No

### Description

Due to missing open code block in fn block, syntax highlight on github broken below this function

### Changes

fixes the above issue
