### PR TITLE
feat: Fold MixThemeData into single root

### DIFF
--- a/packages/mix/lib/src/theme/mix/mix_theme.dart
+++ b/packages/mix/lib/src/theme/mix/mix_theme.dart
@@ -132,6 +132,13 @@ class MixThemeData {
     );
   }
 
+  /// Merge all [themes] into a single [MixThemeData] root.
+  static MixThemeData fold(Iterable<MixThemeData> themes) {
+    if (themes.isEmpty) return const MixThemeData.empty();
+    return themes.fold(
+        const MixThemeData.empty(), (previous, theme) => previous.merge(theme));
+  }
+
   @override
   operator ==(Object other) {
     if (identical(this, other)) return true;

--- a/packages/mix/lib/src/theme/mix/mix_theme.dart
+++ b/packages/mix/lib/src/theme/mix/mix_theme.dart
@@ -132,8 +132,8 @@ class MixThemeData {
     );
   }
 
-  /// Merge all [themes] into a single [MixThemeData] root.
-  static MixThemeData fold(Iterable<MixThemeData> themes) {
+  /// Combine all [themes] into a single [MixThemeData] root.
+  static MixThemeData combine(Iterable<MixThemeData> themes) {
     if (themes.isEmpty) return const MixThemeData.empty();
     return themes.fold(
         const MixThemeData.empty(), (previous, theme) => previous.merge(theme));


### PR DESCRIPTION
There are two ways to do that.

``` dart
instance.fold([themes...]) // require an existing instance.
MixThemeData.fold([themes...]) // auto instanciation
```

I found the second less intrusive but we can have both 
we just need to decide on good naming.