### PR TITLE
fix: Style when merged with an AnimatedStyle should generate a AnimatedStyle

### DIFF
--- a/packages/mix/lib/src/core/factory/style_mix.dart
+++ b/packages/mix/lib/src/core/factory/style_mix.dart
@@ -213,6 +213,14 @@ class Style with EqualityMixin {
     final mergedStyles = styles.merge(style.styles);
     final mergedVariants = variants.merge(style.variants);
 
+    if (style is AnimatedStyle) {
+      return AnimatedStyle._(
+        styles: mergedStyles,
+        variants: mergedVariants,
+        animated: style.animated,
+      );
+    }
+
     return copyWith(styles: mergedStyles, variants: mergedVariants);
   }
 

--- a/packages/mix/test/src/factory/style_mix_test.dart
+++ b/packages/mix/test/src/factory/style_mix_test.dart
@@ -546,4 +546,52 @@ void main() {
       expect(sut, expectedStyle);
     });
   });
+
+  group('Style.merge', () {
+    test('Style + AnimatedStyle', () {
+      final animatedData = AnimatedData(
+        curve: Curves.linear,
+        duration: Durations.medium1,
+      );
+
+      final style = Style(
+        attribute1,
+        Style.asAttribute(attribute2),
+      );
+
+      final animatedStyle = AnimatedStyle(
+        Style(),
+        duration: animatedData.duration,
+        curve: animatedData.curve,
+      );
+
+      final result = style.merge(animatedStyle);
+
+      expect(result, isA<AnimatedStyle>());
+      expect((result as AnimatedStyle).animated, animatedData);
+    });
+
+    test('AnimatedStyle + Style', () {
+      final animatedData = AnimatedData(
+        curve: Curves.linear,
+        duration: Durations.medium1,
+      );
+
+      final animatedStyle = AnimatedStyle(
+        Style(),
+        duration: animatedData.duration,
+        curve: animatedData.curve,
+      );
+
+      final style = Style(
+        attribute1,
+        Style.asAttribute(attribute2),
+      );
+
+      final result = animatedStyle.merge(style);
+
+      expect(result, isA<AnimatedStyle>());
+      expect((result as AnimatedStyle).animated, animatedData);
+    });
+  });
 }

--- a/packages/mix/test/src/factory/style_mix_test.dart
+++ b/packages/mix/test/src/factory/style_mix_test.dart
@@ -549,7 +549,7 @@ void main() {
 
   group('Style.merge', () {
     test('Style + AnimatedStyle', () {
-      final animatedData = AnimatedData(
+      const animatedData = AnimatedData(
         curve: Curves.linear,
         duration: Durations.medium1,
       );
@@ -572,7 +572,7 @@ void main() {
     });
 
     test('AnimatedStyle + Style', () {
-      final animatedData = AnimatedData(
+      const animatedData = AnimatedData(
         curve: Curves.linear,
         duration: Durations.medium1,
       );


### PR DESCRIPTION
### Description

- When merge Style with an Animated style was not generating a AnimatedStyle 

### Changes

- Add a logic to return an AnimatedStyle when merging Style and AnimatedStyle

**Review Checklist**

- [x] **Testing**: Have you tested your changes, including unit tests and integration tests for affected code?
- [ ] **Breaking Changes**: Does this change introduce breaking changes affecting existing code or users?
- [ ] **Documentation Updates**: Are all relevant documentation files (e.g. README, API docs) updated to reflect the changes in this PR?
- [ ] **Website Updates**: Is the website containing the updates you make on documentation?


