### PR TITLE
feat: Add more directives to Colors

### DIFF
--- a/packages/mix/lib/mix.dart
+++ b/packages/mix/lib/mix.dart
@@ -28,6 +28,7 @@ export 'src/attributes/border/border_radius_util.dart';
 export 'src/attributes/border/border_util.dart';
 export 'src/attributes/border/shape_border_dto.dart';
 export 'src/attributes/color/color_directives.dart';
+export 'src/attributes/color/color_directives_impl.dart';
 export 'src/attributes/color/color_dto.dart';
 export 'src/attributes/color/color_util.dart';
 export 'src/attributes/color/material_colors_util.dart';

--- a/packages/mix/lib/src/attributes/color/color_directives.dart
+++ b/packages/mix/lib/src/attributes/color/color_directives.dart
@@ -8,3 +8,24 @@ abstract class ColorDirective with EqualityMixin {
 
   Color modify(Color color);
 }
+
+@immutable
+abstract class NumberBasedColorDirective<T extends num> extends ColorDirective {
+  final T value;
+
+  const NumberBasedColorDirective(this.value);
+
+  @override
+  get props => [value];
+}
+
+@immutable
+abstract class HSLColorDirective extends NumberBasedColorDirective<double> {
+  const HSLColorDirective(super.value);
+
+  HSLColor transformer(HSLColor color, double value);
+
+  @override
+  Color modify(Color color) =>
+      transformer(HSLColor.fromColor(color), value).toColor();
+}

--- a/packages/mix/lib/src/attributes/color/color_directives_impl.dart
+++ b/packages/mix/lib/src/attributes/color/color_directives_impl.dart
@@ -7,12 +7,12 @@ class OpacityColorDirective extends NumberBasedColorDirective<double> {
   const OpacityColorDirective(super.value);
 
   @override
-  Color modify(Color color) => color.withOpacity(super.value);
+  Color modify(Color color) => color.withOpacity(value);
 }
 
 @immutable
 class ColorDirectiveCleaner extends ColorDirective {
-  const ColorDirectiveCleaner() : super();
+  const ColorDirectiveCleaner();
 
   @override
   Color modify(Color color) {

--- a/packages/mix/lib/src/attributes/color/color_directives_impl.dart
+++ b/packages/mix/lib/src/attributes/color/color_directives_impl.dart
@@ -1,0 +1,212 @@
+import 'dart:math' as math;
+import 'package:flutter/material.dart';
+import 'color_directives.dart';
+
+@immutable
+class OpacityColorDirective extends NumberBasedColorDirective<double> {
+  const OpacityColorDirective(super.value);
+
+  @override
+  Color modify(Color color) => color.withOpacity(super.value);
+}
+
+@immutable
+class ColorDirectiveCleaner extends ColorDirective {
+  const ColorDirectiveCleaner() : super();
+
+  @override
+  Color modify(Color color) {
+    return color;
+  }
+
+  @override
+  List<Object?> get props => [];
+}
+
+@immutable
+class ValueColorDirective extends NumberBasedColorDirective<double> {
+  const ValueColorDirective(super.value);
+
+  @override
+  Color modify(Color color) =>
+      HSVColor.fromColor(color).withValue(value).toColor();
+}
+
+@immutable
+class SaturationColorDirective extends HSLColorDirective {
+  const SaturationColorDirective(super.value);
+
+  @override
+  HSLColor transformer(HSLColor color, double value) {
+    return color.withSaturation(value);
+  }
+}
+
+@immutable
+class HueColorDirective extends HSLColorDirective {
+  const HueColorDirective(super.value);
+
+  @override
+  HSLColor transformer(HSLColor color, double value) {
+    return color.withHue(value);
+  }
+}
+
+@immutable
+class LightnessColorDirective extends HSLColorDirective {
+  const LightnessColorDirective(super.value);
+
+  @override
+  HSLColor transformer(HSLColor color, double value) {
+    return color.withLightness(value);
+  }
+}
+
+@immutable
+class AlphaColorDirective extends NumberBasedColorDirective<int> {
+  const AlphaColorDirective(super.value);
+
+  @override
+  Color modify(Color color) => color.withAlpha(value);
+}
+
+@immutable
+class DarkenColorDirective extends NumberBasedColorDirective<int> {
+  const DarkenColorDirective(super.value);
+
+  @override
+  Color modify(Color color) => color.darken(value);
+}
+
+@immutable
+class LightenColorDirective extends NumberBasedColorDirective<int> {
+  const LightenColorDirective(super.value);
+
+  @override
+  Color modify(Color color) => color.lighten(value);
+}
+
+@immutable
+class SaturateColorDirective extends NumberBasedColorDirective<int> {
+  const SaturateColorDirective(super.value);
+
+  @override
+  Color modify(Color color) => color.saturate(value);
+}
+
+@immutable
+class DesaturateColorDirective extends NumberBasedColorDirective<int> {
+  const DesaturateColorDirective(super.value);
+
+  @override
+  Color modify(Color color) => color.desaturate(value);
+}
+
+@immutable
+class TintColorDirective extends NumberBasedColorDirective<int> {
+  const TintColorDirective(super.value);
+
+  @override
+  Color modify(Color color) => color.tint(value);
+}
+
+@immutable
+class ShadeColorDirective extends NumberBasedColorDirective<int> {
+  const ShadeColorDirective(super.value);
+
+  @override
+  Color modify(Color color) => color.shade(value);
+}
+
+@immutable
+class BrightenColorDirective extends NumberBasedColorDirective<int> {
+  const BrightenColorDirective(super.value);
+
+  @override
+  Color modify(Color color) => color.brighten(value);
+}
+
+extension ColorExtUtilities on Color {
+  Color mix(Color toColor, [int amount = 50]) {
+    final p = RangeError.checkValueInInterval(amount, 0, 100, 'amount') / 100;
+
+    return Color.fromARGB(
+      ((toColor.alpha - alpha) * p + alpha).round(),
+      ((toColor.red - red) * p + red).round(),
+      ((toColor.green - green) * p + green).round(),
+      ((toColor.blue - blue) * p + blue).round(),
+    );
+  }
+
+  Color lighten([int amount = 10]) {
+    final p = RangeError.checkValueInInterval(amount, 0, 100, 'amount') / 100;
+    final hsl = HSLColor.fromColor(this);
+    final lightness = _clamp(hsl.lightness + p);
+
+    return hsl.withLightness(lightness).toColor();
+  }
+
+  Color brighten([int amount = 10]) {
+    final p = RangeError.checkValueInInterval(amount, 0, 100, 'amount') / 100;
+
+    return Color.fromARGB(
+      alpha,
+      math.max(0, math.min(255, red - (255 * -p).round())),
+      math.max(0, math.min(255, green - (255 * -p).round())),
+      math.max(0, math.min(255, blue - (255 * -p).round())),
+    );
+  }
+
+  Color contrast([int amount = 100]) {
+    final p = RangeError.checkValueInInterval(amount, 0, 100, 'amount') / 100;
+
+    final luminance = computeLuminance();
+
+    return luminance > 0.5 ? darken((p).round()) : brighten((p).round());
+  }
+
+  Color darken([int amount = 10]) {
+    final p = RangeError.checkValueInInterval(amount, 0, 100, 'amount') / 100;
+    final hsl = HSLColor.fromColor(this);
+    final lightness = _clamp(hsl.lightness - p);
+
+    return hsl.withLightness(lightness).toColor();
+  }
+
+  Color tint([int amount = 10]) => mix(
+        const Color.fromRGBO(255, 255, 255, 1.0),
+        amount,
+      );
+
+  Color shade([int amount = 10]) => mix(
+        const Color.fromRGBO(0, 0, 0, 1.0),
+        amount,
+      );
+
+  Color desaturate([int amount = 10]) {
+    final p = RangeError.checkValueInInterval(amount, 0, 100, 'amount') / 100;
+    final hsl = HSLColor.fromColor(this);
+    final saturation = _clamp(hsl.saturation - p);
+
+    return hsl.withSaturation(saturation).toColor();
+  }
+
+  Color saturate([int amount = 10]) {
+    final p = RangeError.checkValueInInterval(amount, 0, 100, 'amount') / 100;
+    final hsl = HSLColor.fromColor(this);
+    final saturation = _clamp(hsl.saturation + p);
+
+    return hsl.withSaturation(saturation).toColor();
+  }
+
+  Color greyscale() => desaturate(100);
+
+  Color complement() {
+    final hsl = HSLColor.fromColor(this);
+    final hue = (hsl.hue + 180) % 360;
+
+    return hsl.withHue(hue).toColor();
+  }
+}
+
+double _clamp(double val) => math.min(1.0, math.max(0.0, val));

--- a/packages/mix/lib/src/attributes/color/color_directives_impl.dart
+++ b/packages/mix/lib/src/attributes/color/color_directives_impl.dart
@@ -11,19 +11,6 @@ class OpacityColorDirective extends NumberBasedColorDirective<double> {
 }
 
 @immutable
-class ColorDirectiveCleaner extends ColorDirective {
-  const ColorDirectiveCleaner();
-
-  @override
-  Color modify(Color color) {
-    return color;
-  }
-
-  @override
-  List<Object?> get props => [];
-}
-
-@immutable
 class ValueColorDirective extends NumberBasedColorDirective<double> {
   const ValueColorDirective(super.value);
 

--- a/packages/mix/lib/src/attributes/color/color_dto.dart
+++ b/packages/mix/lib/src/attributes/color/color_dto.dart
@@ -5,7 +5,6 @@ import '../../core/dto.dart';
 import '../../core/factory/mix_data.dart';
 import '../../theme/tokens/color_token.dart';
 import 'color_directives.dart';
-import 'color_directives_impl.dart';
 
 /// A Data transfer object that represents a [Color] value.
 ///

--- a/packages/mix/lib/src/attributes/color/color_dto.dart
+++ b/packages/mix/lib/src/attributes/color/color_dto.dart
@@ -5,6 +5,7 @@ import '../../core/dto.dart';
 import '../../core/factory/mix_data.dart';
 import '../../theme/tokens/color_token.dart';
 import 'color_directives.dart';
+import 'color_directives_impl.dart';
 
 /// A Data transfer object that represents a [Color] value.
 ///
@@ -44,12 +45,27 @@ class ColorDto extends Dto<Color> with Diagnosticable {
 
   @override
   ColorDto merge(ColorDto? other) {
-    return other == null
-        ? this
-        : ColorDto.raw(
-            value: other.value ?? value,
-            directives: [...directives, ...other.directives],
-          );
+    if (other == null) {
+      return this;
+    }
+
+    return ColorDto.raw(
+      value: other.value ?? value,
+      directives: cleanDirectivesIfNeeded(other),
+    );
+  }
+
+  List<ColorDirective> cleanDirectivesIfNeeded(ColorDto other) {
+    var resultDirectives = [...directives, ...other.directives];
+
+    final indexCleaner =
+        resultDirectives.indexWhere((e) => e is ColorDirectiveCleaner);
+
+    if (indexCleaner != -1) {
+      resultDirectives = resultDirectives.sublist(indexCleaner);
+      resultDirectives.removeAt(0);
+    }
+    return resultDirectives;
   }
 
   @override

--- a/packages/mix/lib/src/attributes/color/color_dto.dart
+++ b/packages/mix/lib/src/attributes/color/color_dto.dart
@@ -22,25 +22,12 @@ class ColorDto extends Dto<Color> with Diagnosticable {
   final List<ColorDirective> directives;
 
   const ColorDto.raw({this.value, this.directives = const []});
-
   const ColorDto(Color value) : this.raw(value: value);
+
+  factory ColorDto.cleaner() => const _ColorDtoCleaner();
 
   ColorDto.directive(ColorDirective directive)
       : this.raw(directives: [directive]);
-
-  List<ColorDirective> _cleanDirectivesIfNeeded(ColorDto other) {
-    var resultDirectives = [...directives, ...other.directives];
-
-    final indexCleaner =
-        resultDirectives.indexWhere((e) => e is ColorDirectiveCleaner);
-
-    if (indexCleaner != -1) {
-      resultDirectives = resultDirectives.sublist(indexCleaner);
-      resultDirectives.removeAt(0);
-    }
-
-    return resultDirectives;
-  }
 
   @override
   Color resolve(MixData mix) {
@@ -59,13 +46,12 @@ class ColorDto extends Dto<Color> with Diagnosticable {
 
   @override
   ColorDto merge(ColorDto? other) {
-    if (other == null) {
-      return this;
-    }
+    if (other == null) return this;
+    if (other is _ColorDtoCleaner) return ColorDto.raw(value: value);
 
     return ColorDto.raw(
       value: other.value ?? value,
-      directives: _cleanDirectivesIfNeeded(other),
+      directives: [...directives, ...other.directives],
     );
   }
 
@@ -91,4 +77,8 @@ class ColorDto extends Dto<Color> with Diagnosticable {
 
 extension ColorExt on Color {
   ColorDto toDto() => ColorDto(this);
+}
+
+class _ColorDtoCleaner extends ColorDto {
+  const _ColorDtoCleaner() : super.raw();
 }

--- a/packages/mix/lib/src/attributes/color/color_dto.dart
+++ b/packages/mix/lib/src/attributes/color/color_dto.dart
@@ -28,6 +28,20 @@ class ColorDto extends Dto<Color> with Diagnosticable {
   ColorDto.directive(ColorDirective directive)
       : this.raw(directives: [directive]);
 
+  List<ColorDirective> _cleanDirectivesIfNeeded(ColorDto other) {
+    var resultDirectives = [...directives, ...other.directives];
+
+    final indexCleaner =
+        resultDirectives.indexWhere((e) => e is ColorDirectiveCleaner);
+
+    if (indexCleaner != -1) {
+      resultDirectives = resultDirectives.sublist(indexCleaner);
+      resultDirectives.removeAt(0);
+    }
+
+    return resultDirectives;
+  }
+
   @override
   Color resolve(MixData mix) {
     Color color = value ?? defaultValue;
@@ -51,21 +65,8 @@ class ColorDto extends Dto<Color> with Diagnosticable {
 
     return ColorDto.raw(
       value: other.value ?? value,
-      directives: cleanDirectivesIfNeeded(other),
+      directives: _cleanDirectivesIfNeeded(other),
     );
-  }
-
-  List<ColorDirective> cleanDirectivesIfNeeded(ColorDto other) {
-    var resultDirectives = [...directives, ...other.directives];
-
-    final indexCleaner =
-        resultDirectives.indexWhere((e) => e is ColorDirectiveCleaner);
-
-    if (indexCleaner != -1) {
-      resultDirectives = resultDirectives.sublist(indexCleaner);
-      resultDirectives.removeAt(0);
-    }
-    return resultDirectives;
   }
 
   @override

--- a/packages/mix/lib/src/attributes/color/color_util.dart
+++ b/packages/mix/lib/src/attributes/color/color_util.dart
@@ -106,7 +106,7 @@ base mixin ColorDirectiveMixin<T extends Attribute> on BaseColorUtility<T> {
   T tint(int percentage) => directive(TintColorDirective(percentage));
   T shade(int percentage) => directive(ShadeColorDirective(percentage));
   T brighten(int percentage) => directive(BrightenColorDirective(percentage));
-  T removeDirectives() => directive(ColorDirectiveCleaner());
+  T clearDirectives() => builder(ColorDto.cleaner());
 
   T withSaturation(double saturation) => directive(
         SaturationColorDirective(saturation),

--- a/packages/mix/lib/src/attributes/color/color_util.dart
+++ b/packages/mix/lib/src/attributes/color/color_util.dart
@@ -1,10 +1,9 @@
-import 'dart:math' as math;
-
 import 'package:flutter/material.dart';
 
 import '../../core/attribute.dart';
 import '../../core/utility.dart';
 import '../../theme/tokens/color_token.dart';
+import 'color_directives_impl.dart';
 import 'color_directives.dart';
 import 'color_dto.dart';
 import 'material_colors_util.dart';
@@ -107,197 +106,15 @@ base mixin ColorDirectiveMixin<T extends Attribute> on BaseColorUtility<T> {
   T tint(int percentage) => directive(TintColorDirective(percentage));
   T shade(int percentage) => directive(ShadeColorDirective(percentage));
   T brighten(int percentage) => directive(BrightenColorDirective(percentage));
-}
+  T removeDirectives() => directive(ColorDirectiveCleaner());
 
-@immutable
-class OpacityColorDirective extends ColorDirective {
-  final double opacity;
-  const OpacityColorDirective(this.opacity);
-
-  @override
-  Color modify(Color color) => color.withOpacity(opacity);
-
-  @override
-  get props => [opacity];
-}
-
-@immutable
-class AlphaColorDirective extends ColorDirective {
-  final int alpha;
-  const AlphaColorDirective(this.alpha);
-
-  @override
-  Color modify(Color color) => color.withAlpha(alpha);
-
-  @override
-  get props => [alpha];
-}
-
-@immutable
-class DarkenColorDirective extends ColorDirective {
-  final int percentage;
-  const DarkenColorDirective(this.percentage);
-
-  @override
-  Color modify(Color color) => color.darken(percentage);
-
-  @override
-  get props => [percentage];
-}
-
-@immutable
-class LightenColorDirective extends ColorDirective {
-  final int percentage;
-  const LightenColorDirective(this.percentage);
-
-  @override
-  Color modify(Color color) => color.lighten(percentage);
-
-  @override
-  get props => [percentage];
-}
-
-@immutable
-class SaturateColorDirective extends ColorDirective {
-  final int percentage;
-  const SaturateColorDirective(this.percentage);
-
-  @override
-  Color modify(Color color) => color.saturate(percentage);
-
-  @override
-  get props => [percentage];
-}
-
-@immutable
-class DesaturateColorDirective extends ColorDirective {
-  final int percentage;
-  const DesaturateColorDirective(this.percentage);
-
-  @override
-  Color modify(Color color) => color.desaturate(percentage);
-
-  @override
-  get props => [percentage];
-}
-
-@immutable
-class TintColorDirective extends ColorDirective {
-  final int percentage;
-  const TintColorDirective(this.percentage);
-
-  @override
-  Color modify(Color color) => color.tint(percentage);
-
-  @override
-  get props => [percentage];
-}
-
-@immutable
-class ShadeColorDirective extends ColorDirective {
-  final int percentage;
-  const ShadeColorDirective(this.percentage);
-
-  @override
-  Color modify(Color color) => color.shade(percentage);
-
-  @override
-  get props => [percentage];
-}
-
-@immutable
-class BrightenColorDirective extends ColorDirective {
-  final int percentage;
-  const BrightenColorDirective(this.percentage);
-
-  @override
-  Color modify(Color color) => color.brighten(percentage);
-
-  @override
-  get props => [percentage];
-}
-
-extension ColorExtUtilities on Color {
-  Color mix(Color toColor, [int amount = 50]) {
-    final p = RangeError.checkValueInInterval(amount, 0, 100, 'amount') / 100;
-
-    return Color.fromARGB(
-      ((toColor.alpha - alpha) * p + alpha).round(),
-      ((toColor.red - red) * p + red).round(),
-      ((toColor.green - green) * p + green).round(),
-      ((toColor.blue - blue) * p + blue).round(),
-    );
-  }
-
-  Color lighten([int amount = 10]) {
-    final p = RangeError.checkValueInInterval(amount, 0, 100, 'amount') / 100;
-    final hsl = HSLColor.fromColor(this);
-    final lightness = _clamp(hsl.lightness + p);
-
-    return hsl.withLightness(lightness).toColor();
-  }
-
-  Color brighten([int amount = 10]) {
-    final p = RangeError.checkValueInInterval(amount, 0, 100, 'amount') / 100;
-
-    return Color.fromARGB(
-      alpha,
-      math.max(0, math.min(255, red - (255 * -p).round())),
-      math.max(0, math.min(255, green - (255 * -p).round())),
-      math.max(0, math.min(255, blue - (255 * -p).round())),
-    );
-  }
-
-  Color contrast([int amount = 100]) {
-    final p = RangeError.checkValueInInterval(amount, 0, 100, 'amount') / 100;
-
-    final luminance = computeLuminance();
-
-    return luminance > 0.5 ? darken((p).round()) : brighten((p).round());
-  }
-
-  Color darken([int amount = 10]) {
-    final p = RangeError.checkValueInInterval(amount, 0, 100, 'amount') / 100;
-    final hsl = HSLColor.fromColor(this);
-    final lightness = _clamp(hsl.lightness - p);
-
-    return hsl.withLightness(lightness).toColor();
-  }
-
-  Color tint([int amount = 10]) => mix(
-        const Color.fromRGBO(255, 255, 255, 1.0),
-        amount,
+  T withSaturation(double saturation) => directive(
+        SaturationColorDirective(saturation),
       );
 
-  Color shade([int amount = 10]) => mix(
-        const Color.fromRGBO(0, 0, 0, 1.0),
-        amount,
+  T withLightness(double lightness) => directive(
+        LightnessColorDirective(lightness),
       );
-
-  Color desaturate([int amount = 10]) {
-    final p = RangeError.checkValueInInterval(amount, 0, 100, 'amount') / 100;
-    final hsl = HSLColor.fromColor(this);
-    final saturation = _clamp(hsl.saturation - p);
-
-    return hsl.withSaturation(saturation).toColor();
-  }
-
-  Color saturate([int amount = 10]) {
-    final p = RangeError.checkValueInInterval(amount, 0, 100, 'amount') / 100;
-    final hsl = HSLColor.fromColor(this);
-    final saturation = _clamp(hsl.saturation + p);
-
-    return hsl.withSaturation(saturation).toColor();
-  }
-
-  Color greyscale() => desaturate(100);
-
-  Color complement() {
-    final hsl = HSLColor.fromColor(this);
-    final hue = (hsl.hue + 180) % 360;
-
-    return hsl.withHue(hue).toColor();
-  }
+  T withHue(double hue) => directive(HueColorDirective(hue));
+  T withValue(double value) => directive(ValueColorDirective(value));
 }
-
-double _clamp(double val) => math.min(1.0, math.max(0.0, val));

--- a/packages/mix/lib/src/modifiers/scroll_view_widget_modifier.dart
+++ b/packages/mix/lib/src/modifiers/scroll_view_widget_modifier.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
+import 'package:mix_annotations/mix_annotations.dart';
+
 import '../attributes/enum/enum_util.dart';
 import '../attributes/spacing/edge_insets_dto.dart';
 import '../attributes/spacing/spacing_util.dart';
 import '../core/attribute.dart';
 import '../core/factory/mix_data.dart';
 import '../core/modifier.dart';
-import 'package:mix_annotations/mix_annotations.dart';
-
 import '../core/utility.dart';
 
 part 'scroll_view_widget_modifier.g.dart';

--- a/packages/mix/test/src/attributes/color/color_directives_impl_test.dart
+++ b/packages/mix/test/src/attributes/color/color_directives_impl_test.dart
@@ -12,12 +12,6 @@ void main() {
       expect(directive.modify(color), equals(const Color(0x80FF0000)));
     });
 
-    test('ColorDirectiveCleaner returns the same color', () {
-      const color = Color(0xFF00FF00);
-      const directive = ColorDirectiveCleaner();
-      expect(directive.modify(color), equals(color));
-    });
-
     test('ValueColorDirective modifies color value', () {
       const color = Color(0xFFFF0000);
       const directive = ValueColorDirective(0.5);

--- a/packages/mix/test/src/attributes/color/color_directives_impl_test.dart
+++ b/packages/mix/test/src/attributes/color/color_directives_impl_test.dart
@@ -1,0 +1,295 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mix/mix.dart';
+
+import '../../../helpers/testing_utils.dart';
+
+void main() {
+  group('ColorDirectives', () {
+    test('OpacityColorDirective modifies color opacity', () {
+      const color = Color(0xFFFF0000);
+      const directive = OpacityColorDirective(0.5);
+      expect(directive.modify(color), equals(const Color(0x80FF0000)));
+    });
+
+    test('ColorDirectiveCleaner returns the same color', () {
+      const color = Color(0xFF00FF00);
+      const directive = ColorDirectiveCleaner();
+      expect(directive.modify(color), equals(color));
+    });
+
+    test('ValueColorDirective modifies color value', () {
+      const color = Color(0xFFFF0000);
+      const directive = ValueColorDirective(0.5);
+      expect(directive.modify(color), equals(const Color(0xFF800000)));
+    });
+
+    test('SaturationColorDirective modifies color saturation', () {
+      const color = Color(0xFFFF0000);
+      const directive = SaturationColorDirective(0.5);
+      expect(directive.modify(color), equals(const Color(0xFFBF4040)));
+    });
+
+    test('HueColorDirective modifies color hue', () {
+      const color = Color(0xFFFF0000);
+      const directive = HueColorDirective(120);
+      expect(directive.modify(color), equals(const Color(0xFF00FF00)));
+    });
+
+    test('LightnessColorDirective modifies color lightness', () {
+      const color = Color(0xFFFF0000);
+      const directive = LightnessColorDirective(0.75);
+      expect(directive.modify(color), equals(const Color(0xFFFF8080)));
+    });
+
+    test('AlphaColorDirective modifies color alpha', () {
+      const color = Color(0xFFFF0000);
+      const directive = AlphaColorDirective(128);
+      expect(directive.modify(color), equals(const Color(0x80FF0000)));
+    });
+  });
+
+  group('ColorExtUtilities', () {
+    test('mix blends two colors', () {
+      const color1 = Color(0xFFFF0000);
+      const color2 = Color(0xFF0000FF);
+      expect(color1.mix(color2), equals(const Color(0xFF800080)));
+    });
+
+    test('lighten increases color lightness', () {
+      const color = Color(0xFF800000);
+      expect(color.lighten(20), equals(const Color(0xffe60000)));
+    });
+
+    test('brighten increases color brightness', () {
+      const color = Color(0xFF800000);
+      expect(color.brighten(20), equals(const Color(0xffb33333)));
+    });
+
+    test('contrast returns lighter color for dark input', () {
+      const color = Color(0xFF200000);
+      expect(color.contrast(), equals(const Color(0xff230303)));
+    });
+
+    test('contrast returns darker color for light input', () {
+      const color = Color(0xFFE00000);
+      expect(color.contrast(), equals(const Color(0xffe30303)));
+    });
+
+    test('darken decreases color lightness', () {
+      const color = Color(0xFFFF0000);
+      expect(color.darken(20), equals(const Color(0xff990000)));
+    });
+
+    test('tint mixes color with white', () {
+      const color = Color(0xFF800000);
+      expect(color.tint(20), equals(const Color(0xFF993333)));
+    });
+
+    test('shade mixes color with black', () {
+      const color = Color(0xFF800000);
+      expect(color.shade(20), equals(const Color(0xFF660000)));
+    });
+
+    test('desaturate decreases color saturation', () {
+      const color = Color(0xFFFF0000);
+      expect(color.desaturate(50), equals(const Color(0xFFBF4040)));
+    });
+
+    test('saturate increases color saturation', () {
+      const color = Color(0xFFBF4040);
+      expect(color.saturate(50), equals(const Color(0xFFFF0000)));
+    });
+
+    test('greyscale fully desaturates color', () {
+      const color = Color(0xFFFF0000);
+      expect(color.greyscale(), equals(const Color(0xff808080)));
+    });
+
+    test('complement returns opposite hue', () {
+      const color = Color(0xFFFF0000);
+      expect(color.complement(), equals(const Color(0xFF00FFFF)));
+    });
+  });
+
+  group('Merges', () {
+    test('LightnessColorDirective', () {
+      const colorDto = ColorDto.raw(value: Colors.black, directives: [
+        LightnessColorDirective(0.5),
+        LightnessColorDirective(0.5),
+      ]);
+
+      final color = colorDto.resolve(
+        MixData.create(
+          MockBuildContext(),
+          Style(),
+        ),
+      );
+
+      expect(0.5, HSLColor.fromColor(color).lightness);
+    });
+
+    test('SaturationColorDirective', () {
+      const colorDto = ColorDto.raw(value: Colors.red, directives: [
+        SaturationColorDirective(0.6),
+        SaturationColorDirective(0.6),
+      ]);
+
+      final color = colorDto.resolve(
+        MixData.create(
+          MockBuildContext(),
+          Style(),
+        ),
+      );
+
+      expect(
+        0.6.toString(),
+        HSLColor.fromColor(color).saturation.toStringAsFixed(1),
+      );
+    });
+
+    test('HueColorDirective', () {
+      const colorDto = ColorDto.raw(value: Colors.red, directives: [
+        HueColorDirective(180),
+        HueColorDirective(180),
+      ]);
+
+      final color = colorDto.resolve(
+        MixData.create(
+          MockBuildContext(),
+          Style(),
+        ),
+      );
+
+      expect(180, HSLColor.fromColor(color).hue);
+    });
+
+    test('OpacityColorDirective', () {
+      const colorDto = ColorDto.raw(value: Colors.red, directives: [
+        OpacityColorDirective(0.5),
+        OpacityColorDirective(0.5),
+      ]);
+
+      final color = colorDto.resolve(
+        MixData.create(
+          MockBuildContext(),
+          Style(),
+        ),
+      );
+
+      expect(0.5.toString(), color.opacity.toStringAsFixed(1));
+    });
+
+    test('TintColorDirective', () {
+      const colorDto = ColorDto.raw(value: Color(0xFF800000), directives: [
+        TintColorDirective(10),
+        TintColorDirective(10),
+      ]);
+
+      final color = colorDto.resolve(
+        MixData.create(
+          MockBuildContext(),
+          Style(),
+        ),
+      );
+
+      expect(Color(0xff983131), color);
+    });
+
+    test('ShadeColorDirective', () {
+      const colorDto = ColorDto.raw(value: Colors.red, directives: [
+        ShadeColorDirective(10),
+        ShadeColorDirective(10),
+      ]);
+
+      final color = colorDto.resolve(
+        MixData.create(
+          MockBuildContext(),
+          Style(),
+        ),
+      );
+
+      expect(Color(0xffc6362c), color);
+    });
+
+    test('DesaturateColorDirective', () {
+      const colorDto = ColorDto.raw(value: Colors.red, directives: [
+        DesaturateColorDirective(10),
+        DesaturateColorDirective(10),
+      ]);
+
+      final color = colorDto.resolve(
+        MixData.create(
+          MockBuildContext(),
+          Style(),
+        ),
+      );
+
+      expect(Color(0xffde554c), color);
+    });
+
+    test('SaturateColorDirective', () {
+      const colorDto = ColorDto.raw(value: Color(0xffcc3333), directives: [
+        SaturateColorDirective(10),
+        SaturateColorDirective(10),
+      ]);
+
+      final color = colorDto.resolve(
+        MixData.create(
+          MockBuildContext(),
+          Style(),
+        ),
+      );
+
+      expect(Color(0xffe61919), color);
+    });
+
+    test('DarkenColorDirective', () {
+      const colorDto = ColorDto.raw(value: Colors.red, directives: [
+        DarkenColorDirective(10),
+        DarkenColorDirective(10),
+      ]);
+
+      final color = colorDto.resolve(
+        MixData.create(
+          MockBuildContext(),
+          Style(),
+        ),
+      );
+
+      expect(Color(0xffba160a), color);
+    });
+
+    test('BrightenColorDirective', () {
+      const colorDto = ColorDto.raw(value: Colors.red, directives: [
+        BrightenColorDirective(10),
+        BrightenColorDirective(10),
+      ]);
+
+      final color = colorDto.resolve(
+        MixData.create(
+          MockBuildContext(),
+          Style(),
+        ),
+      );
+
+      expect(Color(0xffff776a), color);
+    });
+
+    test('LightenColorDirective', () {
+      const colorDto = ColorDto.raw(value: Colors.red, directives: [
+        LightenColorDirective(10),
+        LightenColorDirective(10),
+      ]);
+
+      final color = colorDto.resolve(
+        MixData.create(
+          MockBuildContext(),
+          Style(),
+        ),
+      );
+
+      expect(Color(0xfffa9d96), color);
+    });
+  });
+}

--- a/packages/mix/test/src/attributes/color/color_dto_test.dart
+++ b/packages/mix/test/src/attributes/color/color_dto_test.dart
@@ -74,8 +74,18 @@ void main() {
         DarkenColorDirective(10),
       ]);
 
+      colorDto = colorDto.merge(ColorDto.cleaner());
+      expect(
+        Colors.red,
+        colorDto.resolve(
+          MixData.create(
+            MockBuildContext(),
+            Style(),
+          ),
+        ),
+      );
+
       colorDto = colorDto.merge(ColorDto.raw(value: Colors.red, directives: [
-        ColorDirectiveCleaner(),
         DarkenColorDirective(20),
       ]));
 
@@ -89,10 +99,7 @@ void main() {
         ),
       );
 
-      colorDto = colorDto.merge(ColorDto.raw(
-        value: Colors.red,
-        directives: [ColorDirectiveCleaner()],
-      ));
+      colorDto = colorDto.merge(ColorDto.cleaner());
 
       colorDto = colorDto.merge(ColorDto.directive(
         SaturateColorDirective(20),

--- a/packages/mix/test/src/attributes/color/color_dto_test.dart
+++ b/packages/mix/test/src/attributes/color/color_dto_test.dart
@@ -69,6 +69,50 @@ void main() {
       expect(merged, same(colorDto));
     });
 
+    test('ColorDirectiveCleaner', () {
+      var colorDto = ColorDto.raw(value: Colors.red, directives: [
+        DarkenColorDirective(10),
+      ]);
+
+      colorDto = colorDto.merge(ColorDto.raw(value: Colors.red, directives: [
+        ColorDirectiveCleaner(),
+        DarkenColorDirective(20),
+      ]));
+
+      expect(
+        Colors.red.darken(20),
+        colorDto.resolve(
+          MixData.create(
+            MockBuildContext(),
+            Style(),
+          ),
+        ),
+      );
+
+      colorDto = colorDto.merge(ColorDto.raw(
+        value: Colors.red,
+        directives: [ColorDirectiveCleaner()],
+      ));
+
+      colorDto = colorDto.merge(ColorDto.directive(
+        SaturateColorDirective(20),
+      ));
+
+      colorDto = colorDto.merge(ColorDto.directive(
+        DarkenColorDirective(20),
+      ));
+
+      expect(
+        Colors.red.saturate(20).darken(20),
+        colorDto.resolve(
+          MixData.create(
+            MockBuildContext(),
+            Style(),
+          ),
+        ),
+      );
+    });
+
     // Test equality
     test('ColorDto.equals should return true for equal instances', () {
       const colorDto1 = ColorDto.raw(

--- a/packages/remix/demo/lib/components/select_use_case.dart
+++ b/packages/remix/demo/lib/components/select_use_case.dart
@@ -4,8 +4,6 @@ import 'package:remix/remix.dart';
 import 'package:widgetbook/widgetbook.dart';
 import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
 
-final _select = SelectSpecUtility.self;
-
 @widgetbook.UseCase(
   name: 'Select Component',
   type: XSelect,


### PR DESCRIPTION
### Description

- Add additional directives to customize colors, in addition to the capability to delete them.

### Changes
- Refactor directives implementation
- Add 5 extra directives: `clearDirectives`, `withHue`, `withLightness`, `withSaturation`, and `withValue`.
- Add tests to validate the new logic added to tests

**Review Checklist**

- [x] **Testing**: Have you tested your changes, including unit tests and integration tests for affected code?
- [ ] **Breaking Changes**: Does this change introduce breaking changes affecting existing code or users?
- [ ] **Documentation Updates**: Are all relevant documentation files (e.g. README, API docs) updated to reflect the changes in this PR?
- [ ] **Website Updates**: Is the website containing the updates you make on documentation?
