### PR TITLE
feat: implement a way to clear inline modifiers

### DIFF
--- a/packages/mix/lib/src/attributes/modifiers/widget_modifiers_data_dto.dart
+++ b/packages/mix/lib/src/attributes/modifiers/widget_modifiers_data_dto.dart
@@ -6,15 +6,23 @@ import '../../core/factory/mix_data.dart';
 import '../../core/modifier.dart';
 import 'widget_modifiers_data.dart';
 
+class _WidgetModifiersDataDtoCleaner extends WidgetModifiersDataDto {
+  const _WidgetModifiersDataDtoCleaner() : super(const []);
+}
+
 class WidgetModifiersDataDto extends Dto<WidgetModifiersData>
     with Diagnosticable {
   final List<WidgetModifierSpecAttribute> value;
 
   const WidgetModifiersDataDto(this.value);
+  factory WidgetModifiersDataDto.cleaner() {
+    return const _WidgetModifiersDataDtoCleaner();
+  }
 
   @override
   WidgetModifiersDataDto merge(WidgetModifiersDataDto? other) {
     if (other == null) return this;
+    if (other is _WidgetModifiersDataDtoCleaner) return other;
     final thisMap = AttributeMap(value);
     final otherMap = AttributeMap(other.value);
     final mergedMap = thisMap.merge(otherMap).values;

--- a/packages/mix/lib/src/attributes/modifiers/widget_modifiers_util.dart
+++ b/packages/mix/lib/src/attributes/modifiers/widget_modifiers_util.dart
@@ -7,6 +7,8 @@ final class SpecModifierUtility<T extends Attribute>
     extends ModifierUtility<T, WidgetModifiersDataDto> {
   SpecModifierUtility(super.builder);
 
+  T clearModifiers() => builder(WidgetModifiersDataDto.cleaner());
+
   @override
   T only(WidgetModifierSpecAttribute attribute) {
     return builder(WidgetModifiersDataDto([attribute]));

--- a/packages/mix/lib/src/modifiers/scroll_view_widget_modifier.dart
+++ b/packages/mix/lib/src/modifiers/scroll_view_widget_modifier.dart
@@ -1,7 +1,13 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
-import '../../mix.dart';
+import '../attributes/enum/enum_util.dart';
+import '../attributes/spacing/edge_insets_dto.dart';
+import '../attributes/spacing/spacing_util.dart';
+import '../core/attribute.dart';
+import '../core/modifier.dart';
 import 'package:mix_annotations/mix_annotations.dart';
+
+import '../core/utility.dart';
 
 part 'scroll_view_widget_modifier.g.dart';
 

--- a/packages/mix/lib/src/modifiers/scroll_view_widget_modifier.dart
+++ b/packages/mix/lib/src/modifiers/scroll_view_widget_modifier.dart
@@ -4,6 +4,7 @@ import '../attributes/enum/enum_util.dart';
 import '../attributes/spacing/edge_insets_dto.dart';
 import '../attributes/spacing/spacing_util.dart';
 import '../core/attribute.dart';
+import '../core/factory/mix_data.dart';
 import '../core/modifier.dart';
 import 'package:mix_annotations/mix_annotations.dart';
 

--- a/packages/mix/test/src/attributes/modifiers/widget_modifiers_data_dto_test.dart
+++ b/packages/mix/test/src/attributes/modifiers/widget_modifiers_data_dto_test.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mix/mix.dart';
@@ -11,7 +10,7 @@ void main() {
       final dto1 = WidgetModifiersDataDto([
         TransformModifierSpecAttribute(transform: Matrix4.identity()),
       ]);
-      final dto2 = WidgetModifiersDataDto([
+      const dto2 = WidgetModifiersDataDto([
         OpacityModifierSpecAttribute(opacity: 0.5),
       ]);
 
@@ -24,7 +23,7 @@ void main() {
       );
       expect(
         merged.value[1].resolve(EmptyMixData),
-        OpacityModifierSpec(0.5),
+        const OpacityModifierSpec(0.5),
       );
     });
 
@@ -35,7 +34,7 @@ void main() {
 
       final cleaner = WidgetModifiersDataDto.cleaner();
 
-      final dto2 = WidgetModifiersDataDto([
+      const dto2 = WidgetModifiersDataDto([
         OpacityModifierSpecAttribute(opacity: 0.5),
       ]);
 
@@ -45,7 +44,7 @@ void main() {
 
       expect(
         merged.value[0].resolve(EmptyMixData),
-        OpacityModifierSpec(0.5),
+        const OpacityModifierSpec(0.5),
       );
     });
 
@@ -62,7 +61,7 @@ void main() {
     test('resolve creates WidgetModifiersData with resolved modifiers', () {
       final dto = WidgetModifiersDataDto([
         TransformModifierSpecAttribute(transform: Matrix4.identity()),
-        OpacityModifierSpecAttribute(opacity: 0.5),
+        const OpacityModifierSpecAttribute(opacity: 0.5),
       ]);
 
       final resolved = dto.resolve(EmptyMixData);
@@ -74,12 +73,12 @@ void main() {
       );
       expect(
         resolved.value[1],
-        OpacityModifierSpec(0.5),
+        const OpacityModifierSpec(0.5),
       );
     });
 
     test('defaultValue returns empty WidgetModifiersData', () {
-      final dto = WidgetModifiersDataDto([]);
+      const dto = WidgetModifiersDataDto([]);
 
       expect(dto.defaultValue.value, isEmpty);
     });
@@ -87,7 +86,7 @@ void main() {
     test('props returns list containing value', () {
       final List<WidgetModifierSpecAttribute> modifiers = [
         TransformModifierSpecAttribute(transform: Matrix4.identity()),
-        OpacityModifierSpecAttribute(opacity: 0.5),
+        const OpacityModifierSpecAttribute(opacity: 0.5),
       ];
       final dto = WidgetModifiersDataDto(modifiers);
 

--- a/packages/mix/test/src/attributes/modifiers/widget_modifiers_data_dto_test.dart
+++ b/packages/mix/test/src/attributes/modifiers/widget_modifiers_data_dto_test.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mix/mix.dart';
+
+import '../../../helpers/testing_utils.dart';
+
+void main() {
+  group('WidgetModifiersDataDto', () {
+    test('merge combines two WidgetModifiersDataDto instances correctly', () {
+      final dto1 = WidgetModifiersDataDto([
+        TransformModifierSpecAttribute(transform: Matrix4.identity()),
+      ]);
+      final dto2 = WidgetModifiersDataDto([
+        OpacityModifierSpecAttribute(opacity: 0.5),
+      ]);
+
+      final merged = dto1.merge(dto2);
+
+      expect(merged.value.length, 2);
+      expect(
+        merged.value[0].resolve(EmptyMixData),
+        TransformModifierSpec(transform: Matrix4.identity()),
+      );
+      expect(
+        merged.value[1].resolve(EmptyMixData),
+        OpacityModifierSpec(0.5),
+      );
+    });
+
+    test('merge with cleaner removes previous modifiers ', () {
+      final dto1 = WidgetModifiersDataDto([
+        TransformModifierSpecAttribute(transform: Matrix4.identity()),
+      ]);
+
+      final cleaner = WidgetModifiersDataDto.cleaner();
+
+      final dto2 = WidgetModifiersDataDto([
+        OpacityModifierSpecAttribute(opacity: 0.5),
+      ]);
+
+      final merged = dto1.merge(cleaner).merge(dto2);
+
+      expect(merged.value.length, 1);
+
+      expect(
+        merged.value[0].resolve(EmptyMixData),
+        OpacityModifierSpec(0.5),
+      );
+    });
+
+    test('merge returns the same instance when other is null', () {
+      final dto = WidgetModifiersDataDto([
+        TransformModifierSpecAttribute(transform: Matrix4.identity()),
+      ]);
+
+      final merged = dto.merge(null);
+
+      expect(identical(merged, dto), true);
+    });
+
+    test('resolve creates WidgetModifiersData with resolved modifiers', () {
+      final dto = WidgetModifiersDataDto([
+        TransformModifierSpecAttribute(transform: Matrix4.identity()),
+        OpacityModifierSpecAttribute(opacity: 0.5),
+      ]);
+
+      final resolved = dto.resolve(EmptyMixData);
+
+      expect(resolved.value.length, 2);
+      expect(
+        resolved.value[0],
+        TransformModifierSpec(transform: Matrix4.identity()),
+      );
+      expect(
+        resolved.value[1],
+        OpacityModifierSpec(0.5),
+      );
+    });
+
+    test('defaultValue returns empty WidgetModifiersData', () {
+      final dto = WidgetModifiersDataDto([]);
+
+      expect(dto.defaultValue.value, isEmpty);
+    });
+
+    test('props returns list containing value', () {
+      final List<WidgetModifierSpecAttribute> modifiers = [
+        TransformModifierSpecAttribute(transform: Matrix4.identity()),
+        OpacityModifierSpecAttribute(opacity: 0.5),
+      ];
+      final dto = WidgetModifiersDataDto(modifiers);
+
+      expect(dto.props, [modifiers]);
+    });
+  });
+}


### PR DESCRIPTION
### Description

Create a way to remove all previous inline modifiers

### Changes

- Create `_WidgetModifiersDataDtoCleaner` and modify the `merge` logic

**Review Checklist**

- [x] **Testing**: Have you tested your changes, including unit tests and integration tests for affected code?
- [ ] **Breaking Changes**: Does this change introduce breaking changes affecting existing code or users?
- [ ] **Documentation Updates**: Are all relevant documentation files (e.g. README, API docs) updated to reflect the changes in this PR?
- [ ] **Website Updates**: Is the website containing the updates you make on documentation?

