### PR TITLE
fix: clear modifiers and directives when using fluentAPI

### DIFF
--- a/packages/mix/lib/src/attributes/color/color_directives_impl.dart
+++ b/packages/mix/lib/src/attributes/color/color_directives_impl.dart
@@ -1,6 +1,18 @@
 import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
+
 import 'color_directives.dart';
+
+class CleanerDirective extends ColorDirective {
+  const CleanerDirective();
+
+  @override
+  Color modify(Color color) => color;
+
+  @override
+  List<Object?> get props => [];
+}
 
 @immutable
 class OpacityColorDirective extends NumberBasedColorDirective<double> {

--- a/packages/mix/lib/src/attributes/color/color_util.dart
+++ b/packages/mix/lib/src/attributes/color/color_util.dart
@@ -3,8 +3,8 @@ import 'package:flutter/material.dart';
 import '../../core/attribute.dart';
 import '../../core/utility.dart';
 import '../../theme/tokens/color_token.dart';
-import 'color_directives_impl.dart';
 import 'color_directives.dart';
+import 'color_directives_impl.dart';
 import 'color_dto.dart';
 import 'material_colors_util.dart';
 
@@ -106,7 +106,7 @@ base mixin ColorDirectiveMixin<T extends Attribute> on BaseColorUtility<T> {
   T tint(int percentage) => directive(TintColorDirective(percentage));
   T shade(int percentage) => directive(ShadeColorDirective(percentage));
   T brighten(int percentage) => directive(BrightenColorDirective(percentage));
-  T clearDirectives() => builder(ColorDto.cleaner());
+  T clearDirectives() => directive(CleanerDirective());
 
   T withSaturation(double saturation) => directive(
         SaturationColorDirective(saturation),

--- a/packages/mix/lib/src/attributes/modifiers/widget_modifiers_data_dto.dart
+++ b/packages/mix/lib/src/attributes/modifiers/widget_modifiers_data_dto.dart
@@ -4,26 +4,27 @@ import '../../core/attributes_map.dart';
 import '../../core/dto.dart';
 import '../../core/factory/mix_data.dart';
 import '../../core/modifier.dart';
+import '../../modifiers/internal/cleaner_modifier.dart';
 import 'widget_modifiers_data.dart';
-
-class _WidgetModifiersDataDtoCleaner extends WidgetModifiersDataDto {
-  const _WidgetModifiersDataDtoCleaner() : super(const []);
-}
 
 class WidgetModifiersDataDto extends Dto<WidgetModifiersData>
     with Diagnosticable {
   final List<WidgetModifierSpecAttribute> value;
 
   const WidgetModifiersDataDto(this.value);
-  factory WidgetModifiersDataDto.cleaner() {
-    return const _WidgetModifiersDataDtoCleaner();
-  }
 
   @override
   WidgetModifiersDataDto merge(WidgetModifiersDataDto? other) {
     if (other == null) return this;
-    if (other is _WidgetModifiersDataDtoCleaner) return other;
     final thisMap = AttributeMap(value);
+
+    final cleanerIndex =
+        other.value.lastIndexWhere((e) => e is CleanerModifierSpecAttribute);
+
+    if (cleanerIndex != -1) {
+      return WidgetModifiersDataDto(other.value.sublist(cleanerIndex));
+    }
+
     final otherMap = AttributeMap(other.value);
     final mergedMap = thisMap.merge(otherMap).values;
 

--- a/packages/mix/lib/src/attributes/modifiers/widget_modifiers_util.dart
+++ b/packages/mix/lib/src/attributes/modifiers/widget_modifiers_util.dart
@@ -7,8 +7,6 @@ final class SpecModifierUtility<T extends Attribute>
     extends ModifierUtility<T, WidgetModifiersDataDto> {
   SpecModifierUtility(super.builder);
 
-  T clearModifiers() => builder(WidgetModifiersDataDto.cleaner());
-
   @override
   T only(WidgetModifierSpecAttribute attribute) {
     return builder(WidgetModifiersDataDto([attribute]));

--- a/packages/mix/lib/src/modifiers/internal/cleaner_modifier.dart
+++ b/packages/mix/lib/src/modifiers/internal/cleaner_modifier.dart
@@ -1,0 +1,38 @@
+// ignore_for_file: prefer-named-boolean-parameters
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:mix_annotations/mix_annotations.dart';
+
+import '../../core/attribute.dart';
+import '../../core/factory/mix_data.dart';
+import '../../core/modifier.dart';
+import '../../core/utility.dart';
+import '../aspect_ratio_widget_modifier.dart';
+
+part 'cleaner_modifier.g.dart';
+
+@MixableSpec(skipUtility: true)
+final class CleanerModifierSpec extends WidgetModifierSpec<CleanerModifierSpec>
+    with _$CleanerModifierSpec, Diagnosticable {
+  const CleanerModifierSpec();
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    _debugFillProperties(properties);
+  }
+
+  @override
+  Widget build(Widget child) {
+    return child;
+  }
+}
+
+final class CleanerModifierSpecUtility<T extends Attribute>
+    extends MixUtility<T, CleanerModifierSpecAttribute> {
+  const CleanerModifierSpecUtility(super.builder);
+  T call() {
+    return builder(CleanerModifierSpecAttribute());
+  }
+}

--- a/packages/mix/lib/src/modifiers/internal/cleaner_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/internal/cleaner_modifier.g.dart
@@ -1,0 +1,130 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'cleaner_modifier.dart';
+
+// **************************************************************************
+// MixableSpecGenerator
+// **************************************************************************
+
+mixin _$CleanerModifierSpec on WidgetModifierSpec<CleanerModifierSpec> {
+  /// Creates a copy of this [CleanerModifierSpec] but with the given fields
+  /// replaced with the new values.
+  @override
+  CleanerModifierSpec copyWith() {
+    return const CleanerModifierSpec();
+  }
+
+  /// Linearly interpolates between this [CleanerModifierSpec] and another [CleanerModifierSpec] based on the given parameter [t].
+  ///
+  /// The parameter [t] represents the interpolation factor, typically ranging from 0.0 to 1.0.
+  /// When [t] is 0.0, the current [CleanerModifierSpec] is returned. When [t] is 1.0, the [other] [CleanerModifierSpec] is returned.
+  /// For values of [t] between 0.0 and 1.0, an interpolated [CleanerModifierSpec] is returned.
+  ///
+  /// If [other] is null, this method returns the current [CleanerModifierSpec] instance.
+  ///
+  /// The interpolation is performed on each property of the [CleanerModifierSpec] using the appropriate
+  /// interpolation method:
+  ///
+
+  /// For , the interpolation is performed using a step function.
+  /// If [t] is less than 0.5, the value from the current [CleanerModifierSpec] is used. Otherwise, the value
+  /// from the [other] [CleanerModifierSpec] is used.
+  ///
+  /// This method is typically used in animations to smoothly transition between
+  /// different [CleanerModifierSpec] configurations.
+  @override
+  CleanerModifierSpec lerp(CleanerModifierSpec? other, double t) {
+    if (other == null) return _$this;
+
+    return const CleanerModifierSpec();
+  }
+
+  /// The list of properties that constitute the state of this [CleanerModifierSpec].
+  ///
+  /// This property is used by the [==] operator and the [hashCode] getter to
+  /// compare two [CleanerModifierSpec] instances for equality.
+  @override
+  List<Object?> get props => [];
+
+  CleanerModifierSpec get _$this => this as CleanerModifierSpec;
+
+  void _debugFillProperties(DiagnosticPropertiesBuilder properties) {}
+}
+
+/// Represents the attributes of a [CleanerModifierSpec].
+///
+/// This class encapsulates properties defining the layout and
+/// appearance of a [CleanerModifierSpec].
+///
+/// Use this class to configure the attributes of a [CleanerModifierSpec] and pass it to
+/// the [CleanerModifierSpec] constructor.
+final class CleanerModifierSpecAttribute
+    extends WidgetModifierSpecAttribute<CleanerModifierSpec>
+    with Diagnosticable {
+  const CleanerModifierSpecAttribute();
+
+  /// Resolves to [CleanerModifierSpec] using the provided [MixData].
+  ///
+  /// If a property is null in the [MixData], it falls back to the
+  /// default value defined in the `defaultValue` for that property.
+  ///
+  /// ```dart
+  /// final cleanerModifierSpec = CleanerModifierSpecAttribute(...).resolve(mix);
+  /// ```
+  @override
+  CleanerModifierSpec resolve(MixData mix) {
+    // ignore: prefer_const_constructors
+    return CleanerModifierSpec();
+  }
+
+  /// Merges the properties of this [CleanerModifierSpecAttribute] with the properties of [other].
+  ///
+  /// If [other] is null, returns this instance unchanged. Otherwise, returns a new
+  /// [CleanerModifierSpecAttribute] with the properties of [other] taking precedence over
+  /// the corresponding properties of this instance.
+  ///
+  /// Properties from [other] that are null will fall back
+  /// to the values from this instance.
+  @override
+  CleanerModifierSpecAttribute merge(CleanerModifierSpecAttribute? other) {
+    if (other == null) return this;
+
+    return other;
+  }
+
+  /// The list of properties that constitute the state of this [CleanerModifierSpecAttribute].
+  ///
+  /// This property is used by the [==] operator and the [hashCode] getter to
+  /// compare two [CleanerModifierSpecAttribute] instances for equality.
+  @override
+  List<Object?> get props => [];
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+  }
+}
+
+/// A tween that interpolates between two [CleanerModifierSpec] instances.
+///
+/// This class can be used in animations to smoothly transition between
+/// different [CleanerModifierSpec] specifications.
+class CleanerModifierSpecTween extends Tween<CleanerModifierSpec?> {
+  CleanerModifierSpecTween({
+    super.begin,
+    super.end,
+  });
+
+  @override
+  CleanerModifierSpec lerp(double t) {
+    if (begin == null && end == null) {
+      return const CleanerModifierSpec();
+    }
+
+    if (begin == null) {
+      return end!;
+    }
+
+    return begin!.lerp(end!, t);
+  }
+}

--- a/packages/mix/lib/src/modifiers/widget_modifiers_util.dart
+++ b/packages/mix/lib/src/modifiers/widget_modifiers_util.dart
@@ -1,5 +1,3 @@
-import 'mouse_cursor_modifier.dart';
-
 import '../core/attribute.dart';
 import '../core/modifier.dart';
 import '../core/utility.dart';
@@ -8,7 +6,9 @@ import 'aspect_ratio_widget_modifier.dart';
 import 'clip_widget_modifier.dart';
 import 'flexible_widget_modifier.dart';
 import 'fractionally_sized_box_widget_modifier.dart';
+import 'internal/cleaner_modifier.dart';
 import 'intrinsic_widget_modifier.dart';
+import 'mouse_cursor_modifier.dart';
 import 'opacity_widget_modifier.dart';
 import 'padding_widget_modifier.dart';
 import 'rotated_box_widget_modifier.dart';
@@ -31,6 +31,7 @@ abstract class ModifierUtility<T extends Attribute, Value>
   late final visibility = VisibilityModifierSpecUtility(only);
   late final show = visibility.on;
   late final hide = visibility.off;
+  late final clearModifiers = CleanerModifierSpecUtility(only);
   late final aspectRatio = AspectRatioModifierSpecUtility(only);
   late final flexible = FlexibleModifierSpecUtility(only);
   late final expanded = flexible.expanded;

--- a/packages/mix/test/src/attributes/color/color_dto_test.dart
+++ b/packages/mix/test/src/attributes/color/color_dto_test.dart
@@ -74,7 +74,7 @@ void main() {
         DarkenColorDirective(10),
       ]);
 
-      colorDto = colorDto.merge(ColorDto.cleaner());
+      colorDto = colorDto.merge(ColorDto.directive(CleanerDirective()));
       expect(
         Colors.red,
         colorDto.resolve(
@@ -85,7 +85,8 @@ void main() {
         ),
       );
 
-      colorDto = colorDto.merge(const ColorDto.raw(value: Colors.red, directives: [
+      colorDto =
+          colorDto.merge(const ColorDto.raw(value: Colors.red, directives: [
         DarkenColorDirective(20),
       ]));
 
@@ -99,7 +100,7 @@ void main() {
         ),
       );
 
-      colorDto = colorDto.merge(ColorDto.cleaner());
+      colorDto = colorDto.merge(ColorDto.directive(CleanerDirective()));
 
       colorDto = colorDto.merge(ColorDto.directive(
         const SaturateColorDirective(20),

--- a/packages/mix/test/src/attributes/modifiers/widget_modifiers_data_dto_test.dart
+++ b/packages/mix/test/src/attributes/modifiers/widget_modifiers_data_dto_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mix/mix.dart';
+import 'package:mix/src/modifiers/internal/cleaner_modifier.dart';
 
 import '../../../helpers/testing_utils.dart';
 
@@ -32,7 +33,9 @@ void main() {
         TransformModifierSpecAttribute(transform: Matrix4.identity()),
       ]);
 
-      final cleaner = WidgetModifiersDataDto.cleaner();
+      final cleaner = WidgetModifiersDataDto([
+        CleanerModifierSpecAttribute(),
+      ]);
 
       const dto2 = WidgetModifiersDataDto([
         OpacityModifierSpecAttribute(opacity: 0.5),
@@ -40,10 +43,14 @@ void main() {
 
       final merged = dto1.merge(cleaner).merge(dto2);
 
-      expect(merged.value.length, 1);
+      expect(merged.value.length, 2);
 
       expect(
         merged.value[0].resolve(EmptyMixData),
+        const CleanerModifierSpec(),
+      );
+      expect(
+        merged.value[1].resolve(EmptyMixData),
         const OpacityModifierSpec(0.5),
       );
     });


### PR DESCRIPTION
### Description

- When using the `clear` methods with fluent API they were with some bugs

### Changes

- Change the way ColorDTO and Modifiers merge.

**Review Checklist**

- [ ] **Testing**: Have you tested your changes, including unit tests and integration tests for affected code?
- [ ] **Breaking Changes**: Does this change introduce breaking changes affecting existing code or users?
- [ ] **Documentation Updates**: Are all relevant documentation files (e.g. README, API docs) updated to reflect the changes in this PR?
- [ ] **Website Updates**: Is the website containing the updates you make on documentation?

### Additional Information (optional)

Is there any additional context or documentation that might be helpful for reviewers?
