### PR TITLE
feat: Add state error on MixWidgetState

### DIFF
--- a/examples/todo_list/.gitignore
+++ b/examples/todo_list/.gitignore
@@ -5,9 +5,11 @@
 *.swp
 .DS_Store
 .atom/
+.build/
 .buildlog/
 .history
 .svn/
+.swiftpm/
 migrate_working_dir/
 
 # IntelliJ related

--- a/packages/mix/lib/src/core/widget_state/internal/mix_widget_state_builder.dart
+++ b/packages/mix/lib/src/core/widget_state/internal/mix_widget_state_builder.dart
@@ -25,6 +25,7 @@ class MixWidgetStateBuilder extends StatelessWidget {
           pressed: controller.pressed,
           dragged: controller.dragged,
           selected: controller.selected,
+          error: controller.error,
           longPressed: controller.longPressed,
           child: Builder(builder: builder),
         );
@@ -42,6 +43,7 @@ class MixWidgetStateModel extends InheritedModel<MixWidgetState> {
     required this.pressed,
     required this.dragged,
     required this.selected,
+    required this.error,
     required this.longPressed,
     required super.child,
   });
@@ -70,6 +72,7 @@ class MixWidgetStateModel extends InheritedModel<MixWidgetState> {
       MixWidgetState.dragged => model.dragged,
       MixWidgetState.selected => model.selected,
       MixWidgetState.longPressed => model.longPressed,
+      MixWidgetState.error => model.error,
     };
   }
 
@@ -77,9 +80,10 @@ class MixWidgetStateModel extends InheritedModel<MixWidgetState> {
   final bool hovered;
   final bool focused;
   final bool pressed;
+  final bool longPressed;
   final bool dragged;
   final bool selected;
-  final bool longPressed;
+  final bool error;
 
   @override
   bool updateShouldNotify(MixWidgetStateModel oldWidget) {
@@ -89,7 +93,8 @@ class MixWidgetStateModel extends InheritedModel<MixWidgetState> {
         oldWidget.pressed != pressed ||
         oldWidget.dragged != dragged ||
         oldWidget.selected != selected ||
-        oldWidget.longPressed != longPressed;
+        oldWidget.longPressed != longPressed ||
+        oldWidget.error != error;
   }
 
   @override
@@ -110,6 +115,7 @@ class MixWidgetStateModel extends InheritedModel<MixWidgetState> {
         oldWidget.selected != selected &&
             dependencies.contains(MixWidgetState.selected) ||
         oldWidget.longPressed != longPressed &&
-            dependencies.contains(MixWidgetState.longPressed);
+            dependencies.contains(MixWidgetState.longPressed) ||
+        oldWidget.error != error && dependencies.contains(MixWidgetState.error);
   }
 }

--- a/packages/mix/lib/src/core/widget_state/widget_state_controller.dart
+++ b/packages/mix/lib/src/core/widget_state/widget_state_controller.dart
@@ -9,6 +9,7 @@ enum MixWidgetState {
   dragged,
   selected,
   disabled,
+  error,
   longPressed;
 
   static const of = MixWidgetStateModel.of;
@@ -49,6 +50,9 @@ class MixWidgetStateController extends ChangeNotifier {
   /// Whether the widget is currently in the selected state.
   bool get selected => value.contains(MixWidgetState.selected);
 
+  /// Whether the widget is currently in the error state.
+  bool get error => value.contains(MixWidgetState.error);
+
   /// Whether the widget is currently being long-pressed.
   bool get longPressed => value.contains(MixWidgetState.longPressed);
 
@@ -69,6 +73,9 @@ class MixWidgetStateController extends ChangeNotifier {
 
   /// Sets whether the widget is in the selected state.
   set selected(bool value) => update(MixWidgetState.selected, value);
+
+  /// Sets whether the widget is in the selected state.
+  set error(bool value) => update(MixWidgetState.error, value);
 
   /// Sets whether the widget is being long-pressed.
   set longPressed(bool value) => update(MixWidgetState.longPressed, value);

--- a/packages/mix/lib/src/variants/context_variant_util/on_util.dart
+++ b/packages/mix/lib/src/variants/context_variant_util/on_util.dart
@@ -50,6 +50,7 @@ class OnContextVariantUtility {
   final selected = const OnSelectedVariant();
   final unselected = const OnNotVariant(OnSelectedVariant());
   final dragged = const OnDraggedVariant();
+  final error = const OnErrorVariant();
 
   /// Creates an [OnNotVariant] with the specified [variant].
   ///

--- a/packages/mix/lib/src/variants/widget_state_variant.dart
+++ b/packages/mix/lib/src/variants/widget_state_variant.dart
@@ -88,3 +88,8 @@ class OnSelectedVariant extends _ToggleMixStateVariant {
 class OnDraggedVariant extends _ToggleMixStateVariant {
   const OnDraggedVariant() : super(MixWidgetState.dragged);
 }
+
+/// Applies styles when the widget is error.
+class OnErrorVariant extends _ToggleMixStateVariant {
+  const OnErrorVariant() : super(MixWidgetState.error);
+}

--- a/packages/mix/test/src/widgets/widget_state/widget_state_controller_test.dart
+++ b/packages/mix/test/src/widgets/widget_state/widget_state_controller_test.dart
@@ -126,6 +126,7 @@ void main() {
       controller.dragged = true;
       controller.selected = true;
       controller.longPressed = true;
+      controller.error = true;
 
       await tester.pumpWidget(
         MaterialApp(
@@ -137,6 +138,7 @@ void main() {
             dragged: controller.dragged,
             selected: controller.selected,
             longPressed: controller.longPressed,
+            error: controller.error,
             child: Container(),
           ),
         ),
@@ -151,6 +153,7 @@ void main() {
       expect(foundModel.dragged, isTrue);
       expect(foundModel.selected, isTrue);
       expect(foundModel.longPressed, isTrue);
+      expect(foundModel.error, isTrue);
     });
 
     testWidgets('hasStateOf returns if state is set', (tester) async {
@@ -164,20 +167,23 @@ void main() {
             dragged: false,
             selected: false,
             longPressed: false,
+            error: false,
             child: Builder(
               builder: (context) {
                 expect(
-                    MixWidgetStateModel.hasStateOf(
-                      context,
-                      MixWidgetState.disabled,
-                    ),
-                    isTrue);
+                  MixWidgetStateModel.hasStateOf(
+                    context,
+                    MixWidgetState.disabled,
+                  ),
+                  isTrue,
+                );
                 expect(
-                    MixWidgetStateModel.hasStateOf(
-                      context,
-                      MixWidgetState.hovered,
-                    ),
-                    isFalse);
+                  MixWidgetStateModel.hasStateOf(
+                    context,
+                    MixWidgetState.hovered,
+                  ),
+                  isFalse,
+                );
                 return Container();
               },
             ),
@@ -195,6 +201,7 @@ void main() {
         dragged: false,
         selected: false,
         longPressed: false,
+        error: false,
         child: Container(),
       );
       final newModel = MixWidgetStateModel(
@@ -205,6 +212,7 @@ void main() {
         dragged: false,
         selected: false,
         longPressed: false,
+        error: false,
         child: Container(),
       );
 
@@ -220,6 +228,7 @@ void main() {
         dragged: false,
         selected: false,
         longPressed: false,
+        error: false,
         child: Container(),
       );
       final newModel = MixWidgetStateModel(
@@ -230,6 +239,7 @@ void main() {
         dragged: false,
         selected: false,
         longPressed: false,
+        error: false,
         child: Container(),
       );
 


### PR DESCRIPTION
### Description

- Add a new state to MixWidgetState called `error`.

### Changes

- Add the new state and update some tests

**Review Checklist**

- [x] **Testing**: Have you tested your changes, including unit tests and integration tests for affected code?
- [ ] **Breaking Changes**: Does this change introduce breaking changes affecting existing code or users?
- [ ] **Documentation Updates**: Are all relevant documentation files (e.g. README, API docs) updated to reflect the changes in this PR?
- [ ] **Website Updates**: Is the website containing the updates you make on documentation?

### Additional Information (optional)
```dart
class ExampleButton extends StatefulWidget {
  const ExampleButton({super.key});

  @override
  State<ExampleButton> createState() => _ExampleButtonState();
}

class _ExampleButtonState extends State<ExampleButton> {
  late final MixWidgetStateController controller;

  @override
  void initState() {
    super.initState();
    controller = MixWidgetStateController();
  }

  @override
  void dispose() {
    controller.dispose();
    super.dispose();
  }

  @override
  Widget build(BuildContext context) {
    return Pressable(
      onPress: () => controller.error = true,
      controller: controller,
      child: Box(
        style: Style(
          $box.chain
            ..padding.horizontal(16)
            ..padding.vertical(12)
            ..border.all(color: Colors.black)
            ..border.all(color: Colors.black)
            ..borderRadius.circular(8)
            ..color.white.shade(3)
            ..shadow.color(Colors.black)
            ..shadow.offset(2, 4),
          $on.error(
            $box.chain
              ..border.all(color: Colors.red)
              ..shadow.color(Colors.red),
            $text.style.color.red(),
          ),
          $text.style.bold(),
        ),
        child: const StyledText('Click me'),
      ),
    );
  }
}
```