### PR TITLE
feat: Utilities for text height behavior

### DIFF
--- a/packages/mix/lib/mix.dart
+++ b/packages/mix/lib/mix.dart
@@ -50,6 +50,7 @@ export 'src/attributes/shadow/shadow_util.dart';
 export 'src/attributes/spacing/edge_insets_dto.dart';
 export 'src/attributes/spacing/spacing_util.dart';
 export 'src/attributes/strut_style/strut_style_dto.dart';
+export 'src/attributes/text_height_behavior/text_height_behavior_dto.dart';
 export 'src/attributes/text_style/text_style_dto.dart';
 export 'src/attributes/text_style/text_style_util.dart';
 /// CORE

--- a/packages/mix/lib/src/attributes/enum/enum_util.dart
+++ b/packages/mix/lib/src/attributes/enum/enum_util.dart
@@ -66,6 +66,14 @@ final class TextDirectionUtility<T extends Attribute>
   const TextDirectionUtility(super.builder);
 }
 
+/// {@macro text_direction_utility}
+@MixableEnumUtility()
+final class TextLeadingDistributionUtility<T extends Attribute>
+    extends MixUtility<T, TextLeadingDistribution>
+    with _$TextLeadingDistributionUtility {
+  const TextLeadingDistributionUtility(super.builder);
+}
+
 /// {@macro tile_mode_utility}
 @MixableEnumUtility()
 final class TileModeUtility<T extends Attribute> extends MixUtility<T, TileMode>

--- a/packages/mix/lib/src/attributes/enum/enum_util.g.dart
+++ b/packages/mix/lib/src/attributes/enum/enum_util.g.dart
@@ -156,6 +156,24 @@ mixin _$TextDirectionUtility<T extends Attribute>
   T call(TextDirection value) => builder(value);
 }
 
+/// {@template text_leading_distribution_utility}
+/// A utility class for creating [Attribute] instances from [TextLeadingDistribution] values.
+///
+/// This class extends [MixUtility] and provides methods to create [Attribute] instances
+/// from predefined [TextLeadingDistribution] values.
+/// {@endtemplate}
+mixin _$TextLeadingDistributionUtility<T extends Attribute>
+    on MixUtility<T, TextLeadingDistribution> {
+  /// Creates an [Attribute] instance with [TextLeadingDistribution.proportional] value.
+  T proportional() => builder(TextLeadingDistribution.proportional);
+
+  /// Creates an [Attribute] instance with [TextLeadingDistribution.even] value.
+  T even() => builder(TextLeadingDistribution.even);
+
+  /// Creates an [Attribute] instance with the specified TextLeadingDistribution value.
+  T call(TextLeadingDistribution value) => builder(value);
+}
+
 /// {@template tile_mode_utility}
 /// A utility class for creating [Attribute] instances from [TileMode] values.
 ///

--- a/packages/mix/lib/src/attributes/scalars/scalar_util.dart
+++ b/packages/mix/lib/src/attributes/scalars/scalar_util.dart
@@ -135,12 +135,6 @@ final class ImageProviderUtility<T extends Attribute>
 }
 
 @MixableClassUtility()
-final class TextHeightBehaviorUtility<T extends Attribute>
-    extends MixUtility<T, TextHeightBehavior> with _$TextHeightBehaviorUtility {
-  const TextHeightBehaviorUtility(super.builder);
-}
-
-@MixableClassUtility()
 final class GradientTransformUtility<T extends Attribute>
     extends MixUtility<T, GradientTransform> with _$GradientTransformUtility {
   const GradientTransformUtility(super.builder);

--- a/packages/mix/lib/src/attributes/scalars/scalar_util.g.dart
+++ b/packages/mix/lib/src/attributes/scalars/scalar_util.g.dart
@@ -499,18 +499,6 @@ mixin _$ImageProviderUtility<T extends Attribute>
   T call(ImageProvider value) => builder(value);
 }
 
-/// {@template text_height_behavior_utility}
-/// A utility class for creating [Attribute] instances from [TextHeightBehavior] values.
-///
-/// This class extends [MixUtility] and provides methods to create [Attribute] instances
-/// from predefined [TextHeightBehavior] values.
-/// {@endtemplate}
-mixin _$TextHeightBehaviorUtility<T extends Attribute>
-    on MixUtility<T, TextHeightBehavior> {
-  /// Creates an [Attribute] instance with the specified TextHeightBehavior value.
-  T call(TextHeightBehavior value) => builder(value);
-}
-
 /// {@template gradient_transform_utility}
 /// A utility class for creating [Attribute] instances from [GradientTransform] values.
 ///

--- a/packages/mix/lib/src/attributes/text_height_behavior/text_height_behavior_dto.dart
+++ b/packages/mix/lib/src/attributes/text_height_behavior/text_height_behavior_dto.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:mix_annotations/mix_annotations.dart';
+
+import '../../../mix.dart';
+
+part 'text_height_behavior_dto.g.dart';
+
+@MixableDto(generateUtility: false)
+base class TextHeightBehaviorDto extends Dto<TextHeightBehavior>
+    with _$TextHeightBehaviorDto, Diagnosticable {
+  final bool? applyHeightToFirstAscent;
+  final bool? applyHeightToLastDescent;
+  final TextLeadingDistribution? leadingDistribution;
+
+  const TextHeightBehaviorDto({
+    this.applyHeightToFirstAscent,
+    this.applyHeightToLastDescent,
+    this.leadingDistribution,
+  });
+
+  @override
+  TextHeightBehavior get defaultValue => const TextHeightBehavior();
+}
+
+final class TextHeightBehaviorUtility<T extends Attribute>
+    extends DtoUtility<T, TextHeightBehaviorDto, TextHeightBehavior> {
+  late final heightToFirstAscent = BoolUtility(
+    (v) => only(applyHeightToFirstAscent: v),
+  );
+  late final heightToLastDescent = BoolUtility(
+    (v) => only(applyHeightToFirstAscent: v),
+  );
+
+  TextHeightBehaviorUtility(super.builder)
+      : super(valueToDto: (v) => v.toDto());
+
+  T leadingDistribution(TextLeadingDistribution distribution) => builder(
+        TextHeightBehaviorDto(leadingDistribution: distribution),
+      );
+
+  @override
+  T only({
+    bool? applyHeightToFirstAscent,
+    bool? applyHeightToLastDescent,
+    TextLeadingDistribution? leadingDistribution,
+  }) =>
+      builder(
+        TextHeightBehaviorDto(
+          applyHeightToFirstAscent: applyHeightToFirstAscent,
+          applyHeightToLastDescent: applyHeightToLastDescent,
+          leadingDistribution: leadingDistribution,
+        ),
+      );
+}

--- a/packages/mix/lib/src/attributes/text_height_behavior/text_height_behavior_dto.dart
+++ b/packages/mix/lib/src/attributes/text_height_behavior/text_height_behavior_dto.dart
@@ -1,8 +1,9 @@
+// ignore_for_file: prefer_relative_imports,avoid-importing-entrypoint-exports
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
+import 'package:mix/mix.dart';
 import 'package:mix_annotations/mix_annotations.dart';
-
-import '../../../mix.dart';
 
 part 'text_height_behavior_dto.g.dart';
 

--- a/packages/mix/lib/src/attributes/text_height_behavior/text_height_behavior_dto.dart
+++ b/packages/mix/lib/src/attributes/text_height_behavior/text_height_behavior_dto.dart
@@ -32,12 +32,12 @@ final class TextHeightBehaviorUtility<T extends Attribute>
     (v) => only(applyHeightToLastDescent: v),
   );
 
+  late final leadingDistribution = TextLeadingDistributionUtility(
+    (v) => only(leadingDistribution: v),
+  );
+
   TextHeightBehaviorUtility(super.builder)
       : super(valueToDto: (v) => v.toDto());
-
-  T leadingDistribution(TextLeadingDistribution distribution) => builder(
-        TextHeightBehaviorDto(leadingDistribution: distribution),
-      );
 
   @Deprecated("Use the utilities instead")
   T call(TextHeightBehavior value) => builder(value.toDto());

--- a/packages/mix/lib/src/attributes/text_height_behavior/text_height_behavior_dto.dart
+++ b/packages/mix/lib/src/attributes/text_height_behavior/text_height_behavior_dto.dart
@@ -39,6 +39,9 @@ final class TextHeightBehaviorUtility<T extends Attribute>
         TextHeightBehaviorDto(leadingDistribution: distribution),
       );
 
+  @Deprecated("Use the utilities instead")
+  T call(TextHeightBehavior value) => builder(value.toDto());
+
   @override
   T only({
     bool? applyHeightToFirstAscent,

--- a/packages/mix/lib/src/attributes/text_height_behavior/text_height_behavior_dto.dart
+++ b/packages/mix/lib/src/attributes/text_height_behavior/text_height_behavior_dto.dart
@@ -29,7 +29,7 @@ final class TextHeightBehaviorUtility<T extends Attribute>
     (v) => only(applyHeightToFirstAscent: v),
   );
   late final heightToLastDescent = BoolUtility(
-    (v) => only(applyHeightToFirstAscent: v),
+    (v) => only(applyHeightToLastDescent: v),
   );
 
   TextHeightBehaviorUtility(super.builder)

--- a/packages/mix/lib/src/attributes/text_height_behavior/text_height_behavior_dto.g.dart
+++ b/packages/mix/lib/src/attributes/text_height_behavior/text_height_behavior_dto.g.dart
@@ -1,0 +1,80 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'text_height_behavior_dto.dart';
+
+// **************************************************************************
+// MixableDtoGenerator
+// **************************************************************************
+
+mixin _$TextHeightBehaviorDto on Dto<TextHeightBehavior> {
+  /// Resolves to [TextHeightBehavior] using the provided [MixData].
+  ///
+  /// If a property is null in the [MixData], it falls back to the
+  /// default value defined in the `defaultValue` for that property.
+  ///
+  /// ```dart
+  /// final textHeightBehavior = TextHeightBehaviorDto(...).resolve(mix);
+  /// ```
+  @override
+  TextHeightBehavior resolve(MixData mix) {
+    return TextHeightBehavior(
+      applyHeightToFirstAscent: _$this.applyHeightToFirstAscent ??
+          defaultValue.applyHeightToFirstAscent,
+      applyHeightToLastDescent: _$this.applyHeightToLastDescent ??
+          defaultValue.applyHeightToLastDescent,
+      leadingDistribution:
+          _$this.leadingDistribution ?? defaultValue.leadingDistribution,
+    );
+  }
+
+  /// Merges the properties of this [TextHeightBehaviorDto] with the properties of [other].
+  ///
+  /// If [other] is null, returns this instance unchanged. Otherwise, returns a new
+  /// [TextHeightBehaviorDto] with the properties of [other] taking precedence over
+  /// the corresponding properties of this instance.
+  ///
+  /// Properties from [other] that are null will fall back
+  /// to the values from this instance.
+  @override
+  TextHeightBehaviorDto merge(covariant TextHeightBehaviorDto? other) {
+    if (other == null) return _$this;
+
+    return TextHeightBehaviorDto(
+      applyHeightToFirstAscent:
+          other.applyHeightToFirstAscent ?? _$this.applyHeightToFirstAscent,
+      applyHeightToLastDescent:
+          other.applyHeightToLastDescent ?? _$this.applyHeightToLastDescent,
+      leadingDistribution:
+          other.leadingDistribution ?? _$this.leadingDistribution,
+    );
+  }
+
+  /// The list of properties that constitute the state of this [TextHeightBehaviorDto].
+  ///
+  /// This property is used by the [==] operator and the [hashCode] getter to
+  /// compare two [TextHeightBehaviorDto] instances for equality.
+  @override
+  List<Object?> get props => [
+        _$this.applyHeightToFirstAscent,
+        _$this.applyHeightToLastDescent,
+        _$this.leadingDistribution,
+      ];
+
+  TextHeightBehaviorDto get _$this => this as TextHeightBehaviorDto;
+}
+
+extension TextHeightBehaviorMixExt on TextHeightBehavior {
+  TextHeightBehaviorDto toDto() {
+    return TextHeightBehaviorDto(
+      applyHeightToFirstAscent: applyHeightToFirstAscent,
+      applyHeightToLastDescent: applyHeightToLastDescent,
+      leadingDistribution: leadingDistribution,
+    );
+  }
+}
+
+extension ListTextHeightBehaviorMixExt on List<TextHeightBehavior> {
+  List<TextHeightBehaviorDto> toDto() {
+    return map((e) => e.toDto()).toList();
+  }
+}

--- a/packages/mix/lib/src/specs/text/text_spec.dart
+++ b/packages/mix/lib/src/specs/text/text_spec.dart
@@ -11,6 +11,7 @@ import '../../attributes/modifiers/widget_modifiers_data_dto.dart';
 import '../../attributes/modifiers/widget_modifiers_util.dart';
 import '../../attributes/scalars/scalar_util.dart';
 import '../../attributes/strut_style/strut_style_dto.dart';
+import '../../attributes/text_height_behavior/text_height_behavior_dto.dart';
 import '../../attributes/text_style/text_style_dto.dart';
 import '../../attributes/text_style/text_style_util.dart';
 import '../../core/attribute.dart';
@@ -32,7 +33,6 @@ final class TextSpec extends Spec<TextSpec> with _$TextSpec, Diagnosticable {
   final TextAlign? textAlign;
   final int? maxLines;
   final TextWidthBasis? textWidthBasis;
-  final TextHeightBehavior? textHeightBehavior;
   final TextScaler? textScaler;
   final TextStyle? style;
   final TextDirection? textDirection;
@@ -40,6 +40,9 @@ final class TextSpec extends Spec<TextSpec> with _$TextSpec, Diagnosticable {
 
   @Deprecated('Use textScaler instead')
   final double? textScaleFactor;
+
+  @MixableProperty(dto: MixableFieldDto(type: TextHeightBehaviorDto))
+  final TextHeightBehavior? textHeightBehavior;
 
   @MixableProperty(
     utilities: [

--- a/packages/mix/lib/src/specs/text/text_spec.g.dart
+++ b/packages/mix/lib/src/specs/text/text_spec.g.dart
@@ -189,7 +189,7 @@ final class TextSpecAttribute extends SpecAttribute<TextSpec>
   final int? maxLines;
   final TextStyleDto? style;
   final TextWidthBasis? textWidthBasis;
-  final TextHeightBehavior? textHeightBehavior;
+  final TextHeightBehaviorDto? textHeightBehavior;
   final TextDirection? textDirection;
   final bool? softWrap;
   final TextDirectiveDto? directive;
@@ -230,7 +230,7 @@ final class TextSpecAttribute extends SpecAttribute<TextSpec>
       maxLines: maxLines,
       style: style?.resolve(mix),
       textWidthBasis: textWidthBasis,
-      textHeightBehavior: textHeightBehavior,
+      textHeightBehavior: textHeightBehavior?.resolve(mix),
       textDirection: textDirection,
       softWrap: softWrap,
       directive: directive?.resolve(mix),
@@ -260,7 +260,8 @@ final class TextSpecAttribute extends SpecAttribute<TextSpec>
       maxLines: other.maxLines ?? maxLines,
       style: style?.merge(other.style) ?? other.style,
       textWidthBasis: other.textWidthBasis ?? textWidthBasis,
-      textHeightBehavior: other.textHeightBehavior ?? textHeightBehavior,
+      textHeightBehavior: textHeightBehavior?.merge(other.textHeightBehavior) ??
+          other.textHeightBehavior,
       textDirection: other.textDirection ?? textDirection,
       softWrap: other.softWrap ?? softWrap,
       directive: directive?.merge(other.directive) ?? other.directive,
@@ -410,7 +411,7 @@ class TextSpecUtility<T extends Attribute>
     int? maxLines,
     TextStyleDto? style,
     TextWidthBasis? textWidthBasis,
-    TextHeightBehavior? textHeightBehavior,
+    TextHeightBehaviorDto? textHeightBehavior,
     TextDirection? textDirection,
     bool? softWrap,
     TextDirectiveDto? directive,

--- a/packages/mix/test/src/attributes/scalars/scalar_util_test.dart
+++ b/packages/mix/test/src/attributes/scalars/scalar_util_test.dart
@@ -589,396 +589,377 @@ void main() {
     });
   });
 
-  group('TextHeightBehaviorUtility Tests', () {
-    const utility = TextHeightBehaviorUtility(UtilityTestAttribute.new);
+  group('TextScalerUtility Tests', () {
+    const utility = TextScalerUtility(UtilityTestAttribute.new);
 
     test('call() returns correct instance', () {
-      final textHeightBehavior = utility(
-        const TextHeightBehavior(
-          applyHeightToFirstAscent: true,
-          applyHeightToLastDescent: false,
-        ),
+      final textScaler = utility(
+        const TextScaler.linear(2),
       );
 
-      expect(textHeightBehavior.value, isA<TextHeightBehavior>());
-      expect(textHeightBehavior.value.applyHeightToFirstAscent, isTrue);
-      expect(textHeightBehavior.value.applyHeightToLastDescent, isFalse);
+      final linearTextScaler = utility.linear(3);
+
+      final noScalingTextScaler = utility.noScaling();
+
+      expect(textScaler.value, isA<TextScaler>());
+      expect(textScaler.value, const TextScaler.linear(2));
+      expect(linearTextScaler.value, const TextScaler.linear(3));
+      expect(noScalingTextScaler.value, TextScaler.noScaling);
     });
-    group('TextScalerUtility Tests', () {
-      const utility = TextScalerUtility(UtilityTestAttribute.new);
-
-      test('call() returns correct instance', () {
-        final textScaler = utility(
-          const TextScaler.linear(2),
-        );
-
-        final linearTextScaler = utility.linear(3);
-
-        final noScalingTextScaler = utility.noScaling();
-
-        expect(textScaler.value, isA<TextScaler>());
-        expect(textScaler.value, const TextScaler.linear(2));
-        expect(linearTextScaler.value, const TextScaler.linear(3));
-        expect(noScalingTextScaler.value, TextScaler.noScaling);
-      });
-    });
-    group('DurationUtility Tests', () {
-      const utility = DurationUtility(UtilityTestAttribute.new);
-      test('microseconds() returns correct instance', () {
-        final duration = utility.microseconds(500);
-        expect(duration.value, isA<Duration>());
-        expect(duration.value.inMicroseconds, 500);
-      });
-
-      test('milliseconds() returns correct instance', () {
-        final duration = utility.milliseconds(1500);
-        expect(duration.value, isA<Duration>());
-        expect(duration.value.inMilliseconds, 1500);
-      });
-
-      test('seconds() returns correct instance', () {
-        final duration = utility.seconds(30);
-        expect(duration.value, isA<Duration>());
-        expect(duration.value.inSeconds, 30);
-      });
-
-      test('minutes() returns correct instance', () {
-        final duration = utility.minutes(2);
-        expect(duration.value, isA<Duration>());
-        expect(duration.value.inMinutes, 2);
-      });
-
-      test('zero() returns correct instance', () {
-        final duration = utility.zero();
-        expect(duration.value, isA<Duration>());
-        expect(duration.value.inMicroseconds, 0);
-      });
-
-      test('call() returns correct instance', () {
-        final duration = utility(const Duration(seconds: 5));
-        expect(duration.value, isA<Duration>());
-        expect(duration.value.inSeconds, 5);
-      });
-    });
-    group('FontFeatureUtility Tests', () {
-      const utility = FontFeatureUtility(UtilityTestAttribute.new);
-
-      test('call() returns correct instance', () {
-        final fontFeature = utility(
-          const FontFeature('liga', 1),
-        );
-
-        expect(fontFeature.value, isA<FontFeature>());
-        expect(fontFeature.value.feature, 'liga');
-        expect(fontFeature.value.value, 1);
-      });
-
-      test('enable() returns correct instance', () {
-        final fontFeature = utility.enable('liga');
-
-        expect(fontFeature.value, isA<FontFeature>());
-        expect(fontFeature.value.feature, 'liga');
-        expect(fontFeature.value.value, 1);
-      });
-
-      test('disable() returns correct instance', () {
-        final fontFeature = utility.disable('liga');
-
-        expect(fontFeature.value, isA<FontFeature>());
-        expect(fontFeature.value.feature, 'liga');
-        expect(fontFeature.value.value, 0);
-      });
-
-      test('alternative() returns correct instance', () {
-        final fontFeature = utility.alternative(2);
-
-        expect(fontFeature.value, isA<FontFeature>());
-        expect(fontFeature.value, const FontFeature.alternative(2));
-      });
-
-      test('randomize() returns correct instance', () {
-        final fontFeature = utility.randomize();
-
-        expect(fontFeature.value, isA<FontFeature>());
-        expect(fontFeature.value, const FontFeature.randomize());
-      });
-
-      test('swash() returns correct instance', () {
-        final fontFeature = utility.swash();
-
-        expect(fontFeature.value, isA<FontFeature>());
-        expect(fontFeature.value, const FontFeature.swash());
-      });
-
-      test('alternativeFractions() returns correct instance', () {
-        final fontFeature = utility.alternativeFractions();
-
-        expect(fontFeature.value, isA<FontFeature>());
-        expect(fontFeature.value, const FontFeature.alternativeFractions());
-      });
-
-      test('contextualAlternates() returns correct instance', () {
-        final fontFeature = utility.contextualAlternates();
-
-        expect(fontFeature.value, isA<FontFeature>());
-        expect(fontFeature.value, const FontFeature.contextualAlternates());
-      });
-
-      test('caseSensitiveForms() returns correct instance', () {
-        final fontFeature = utility.caseSensitiveForms();
-
-        expect(fontFeature.value, isA<FontFeature>());
-        expect(fontFeature.value, const FontFeature.caseSensitiveForms());
-      });
-
-      test('characterVariant() returns correct instance', () {
-        final fontFeature = utility.characterVariant(5);
-
-        expect(fontFeature.value, isA<FontFeature>());
-        expect(fontFeature.value, FontFeature.characterVariant(5));
-      });
-
-      test('historicalForms() returns correct instance', () {
-        final fontFeature = utility.historicalForms();
-
-        expect(fontFeature.value, isA<FontFeature>());
-        expect(fontFeature.value, const FontFeature.historicalForms());
-      });
-
-      test('historicalLigatures() returns correct instance', () {
-        final fontFeature = utility.historicalLigatures();
-
-        expect(fontFeature.value, isA<FontFeature>());
-        expect(fontFeature.value, const FontFeature.historicalLigatures());
-      });
-
-      test('liningFigures() returns correct instance', () {
-        final fontFeature = utility.liningFigures();
-
-        expect(fontFeature.value, isA<FontFeature>());
-        expect(fontFeature.value, const FontFeature.liningFigures());
-      });
-
-      test('localeAware() returns correct instance', () {
-        final fontFeature = utility.localeAware();
-        final fontFeatureEnabled = utility.localeAware(enable: true);
-        final fontFeatureDisabled = utility.localeAware(enable: false);
-
-        expect(fontFeature.value, isA<FontFeature>());
-        expect(fontFeature.value, const FontFeature.localeAware());
-        expect(fontFeatureEnabled.value,
-            const FontFeature.localeAware(enable: true));
-        expect(fontFeatureDisabled.value,
-            const FontFeature.localeAware(enable: false));
-      });
-
-      test('notationalForms() returns correct instance', () {
-        final fontFeature = utility.notationalForms(2);
-
-        expect(fontFeature.value, isA<FontFeature>());
-        expect(fontFeature.value, const FontFeature.notationalForms(2));
-      });
-
-      test('numerators() returns correct instance', () {
-        final fontFeature = utility.numerators();
-
-        expect(fontFeature.value, isA<FontFeature>());
-        expect(fontFeature.value, const FontFeature.numerators());
-      });
-
-      test('ordinalForms() returns correct instance', () {
-        final fontFeature = utility.ordinalForms();
-
-        expect(fontFeature.value, isA<FontFeature>());
-        expect(fontFeature.value, const FontFeature.ordinalForms());
-      });
-
-      test('proportionalFigures() returns correct instance', () {
-        final fontFeature = utility.proportionalFigures();
-
-        expect(fontFeature.value, isA<FontFeature>());
-        expect(fontFeature.value, const FontFeature.proportionalFigures());
-      });
-
-      test('stylisticAlternates() returns correct instance', () {
-        final fontFeature = utility.stylisticAlternates();
-
-        expect(fontFeature.value, isA<FontFeature>());
-        expect(fontFeature.value, const FontFeature.stylisticAlternates());
-      });
-
-      test('scientificInferiors() returns correct instance', () {
-        final fontFeature = utility.scientificInferiors();
-
-        expect(fontFeature.value, isA<FontFeature>());
-        expect(fontFeature.value, const FontFeature.scientificInferiors());
-      });
-
-      test('stylisticSet() returns correct instance', () {
-        final fontFeature = utility.stylisticSet(2);
-
-        expect(fontFeature.value, isA<FontFeature>());
-        expect(fontFeature.value, FontFeature.stylisticSet(2));
-      });
-
-      test('subscripts() returns correct instance', () {
-        final fontFeature = utility.subscripts();
-
-        expect(fontFeature.value, isA<FontFeature>());
-        expect(fontFeature.value, const FontFeature.subscripts());
-      });
-
-      test('superscripts() returns correct instance', () {
-        final fontFeature = utility.superscripts();
-
-        expect(fontFeature.value, isA<FontFeature>());
-        expect(fontFeature.value, const FontFeature.superscripts());
-      });
-
-      test('tabularFigures() returns correct instance', () {
-        final fontFeature = utility.tabularFigures();
-
-        expect(fontFeature.value, isA<FontFeature>());
-        expect(fontFeature.value, const FontFeature.tabularFigures());
-      });
+  });
+  group('DurationUtility Tests', () {
+    const utility = DurationUtility(UtilityTestAttribute.new);
+    test('microseconds() returns correct instance', () {
+      final duration = utility.microseconds(500);
+      expect(duration.value, isA<Duration>());
+      expect(duration.value.inMicroseconds, 500);
     });
 
-    group('AlignmentDirectionalUtility Tests', () {
-      const utility = AlignmentDirectionalUtility(UtilityTestAttribute.new);
-
-      test('only() returns correct instance with y and start values', () {
-        final alignmentDirectional = utility.only(y: 5, start: 10);
-
-        expect(alignmentDirectional.value, isA<AlignmentDirectional>());
-        expect(alignmentDirectional.value,
-            equals(const AlignmentDirectional(10, 5)));
-      });
-
-      test('only() returns correct instance with only y value', () {
-        final alignmentDirectional = utility.only(y: 5);
-
-        expect(alignmentDirectional.value, isA<AlignmentDirectional>());
-        expect(alignmentDirectional.value,
-            equals(const AlignmentDirectional(0, 5)));
-      });
-
-      test('only() returns correct instance with only start value', () {
-        final alignmentDirectional = utility.only(start: 10);
-
-        expect(alignmentDirectional.value, isA<AlignmentDirectional>());
-        expect(alignmentDirectional.value,
-            equals(const AlignmentDirectional(10, 0)));
-      });
-
-      test('only() returns correct instance with no values', () {
-        final alignmentDirectional = utility.only(y: -1, start: -1);
-
-        expect(alignmentDirectional.value, isA<AlignmentDirectional>());
-        expect(
-            alignmentDirectional.value, equals(AlignmentDirectional.topStart));
-      });
-
-      test('topStart() returns correct instance', () {
-        final alignmentDirectional = utility.topStart();
-
-        expect(alignmentDirectional.value, isA<AlignmentDirectional>());
-        expect(
-            alignmentDirectional.value, equals(AlignmentDirectional.topStart));
-      });
-
-      test('topCenter() returns correct instance', () {
-        final alignmentDirectional = utility.topCenter();
-
-        expect(alignmentDirectional.value, isA<AlignmentDirectional>());
-        expect(
-            alignmentDirectional.value, equals(AlignmentDirectional.topCenter));
-      });
-
-      test('topEnd() returns correct instance', () {
-        final alignmentDirectional = utility.topEnd();
-
-        expect(alignmentDirectional.value, isA<AlignmentDirectional>());
-        expect(alignmentDirectional.value, equals(AlignmentDirectional.topEnd));
-      });
-
-      test('centerStart() returns correct instance', () {
-        final alignmentDirectional = utility.centerStart();
-
-        expect(alignmentDirectional.value, isA<AlignmentDirectional>());
-        expect(alignmentDirectional.value,
-            equals(AlignmentDirectional.centerStart));
-      });
-
-      test('center() returns correct instance', () {
-        final alignmentDirectional = utility.center();
-
-        expect(alignmentDirectional.value, isA<AlignmentDirectional>());
-        expect(alignmentDirectional.value, equals(AlignmentDirectional.center));
-      });
-
-      test('centerEnd() returns correct instance', () {
-        final alignmentDirectional = utility.centerEnd();
-
-        expect(alignmentDirectional.value, isA<AlignmentDirectional>());
-        expect(
-            alignmentDirectional.value, equals(AlignmentDirectional.centerEnd));
-      });
-
-      test('bottomStart() returns correct instance', () {
-        final alignmentDirectional = utility.bottomStart();
-
-        expect(alignmentDirectional.value, isA<AlignmentDirectional>());
-        expect(alignmentDirectional.value,
-            equals(AlignmentDirectional.bottomStart));
-      });
-
-      test('bottomCenter() returns correct instance', () {
-        final alignmentDirectional = utility.bottomCenter();
-
-        expect(alignmentDirectional.value, isA<AlignmentDirectional>());
-        expect(alignmentDirectional.value,
-            equals(AlignmentDirectional.bottomCenter));
-      });
-
-      test('bottomEnd() returns correct instance', () {
-        final alignmentDirectional = utility.bottomEnd();
-
-        expect(alignmentDirectional.value, isA<AlignmentDirectional>());
-        expect(
-            alignmentDirectional.value, equals(AlignmentDirectional.bottomEnd));
-      });
-
-      test('call() returns correct instance', () {
-        final alignmentDirectional = utility(AlignmentDirectional.topStart);
-
-        expect(alignmentDirectional.value, isA<AlignmentDirectional>());
-        expect(
-            alignmentDirectional.value, equals(AlignmentDirectional.topStart));
-      });
-    });
-    group('PaintUtility Tests', () {
-      const utility = PaintUtility(UtilityTestAttribute.new);
-      test('PaintUtility returns correct instance', () {
-        final paint = utility(Paint());
-        expect(paint.value, isA<Paint>());
-      });
+    test('milliseconds() returns correct instance', () {
+      final duration = utility.milliseconds(1500);
+      expect(duration.value, isA<Duration>());
+      expect(duration.value.inMilliseconds, 1500);
     });
 
-    group('LocaleUtility Tests', () {
-      const utility = LocaleUtility(UtilityTestAttribute.new);
-      test('LocaleUtility returns correct instance', () {
-        final locale = utility(const Locale('en', 'US'));
-        expect(locale.value, isA<Locale>());
-        expect(locale.value.languageCode, 'en');
-        expect(locale.value.countryCode, 'US');
-      });
+    test('seconds() returns correct instance', () {
+      final duration = utility.seconds(30);
+      expect(duration.value, isA<Duration>());
+      expect(duration.value.inSeconds, 30);
+    });
 
-      test('LocaleUtility handles locale without country code', () {
-        final locale = utility(const Locale('fr'));
-        expect(locale.value, isA<Locale>());
-        expect(locale.value.languageCode, 'fr');
-        expect(locale.value.countryCode, null);
-      });
+    test('minutes() returns correct instance', () {
+      final duration = utility.minutes(2);
+      expect(duration.value, isA<Duration>());
+      expect(duration.value.inMinutes, 2);
+    });
+
+    test('zero() returns correct instance', () {
+      final duration = utility.zero();
+      expect(duration.value, isA<Duration>());
+      expect(duration.value.inMicroseconds, 0);
+    });
+
+    test('call() returns correct instance', () {
+      final duration = utility(const Duration(seconds: 5));
+      expect(duration.value, isA<Duration>());
+      expect(duration.value.inSeconds, 5);
+    });
+  });
+  group('FontFeatureUtility Tests', () {
+    const utility = FontFeatureUtility(UtilityTestAttribute.new);
+
+    test('call() returns correct instance', () {
+      final fontFeature = utility(
+        const FontFeature('liga', 1),
+      );
+
+      expect(fontFeature.value, isA<FontFeature>());
+      expect(fontFeature.value.feature, 'liga');
+      expect(fontFeature.value.value, 1);
+    });
+
+    test('enable() returns correct instance', () {
+      final fontFeature = utility.enable('liga');
+
+      expect(fontFeature.value, isA<FontFeature>());
+      expect(fontFeature.value.feature, 'liga');
+      expect(fontFeature.value.value, 1);
+    });
+
+    test('disable() returns correct instance', () {
+      final fontFeature = utility.disable('liga');
+
+      expect(fontFeature.value, isA<FontFeature>());
+      expect(fontFeature.value.feature, 'liga');
+      expect(fontFeature.value.value, 0);
+    });
+
+    test('alternative() returns correct instance', () {
+      final fontFeature = utility.alternative(2);
+
+      expect(fontFeature.value, isA<FontFeature>());
+      expect(fontFeature.value, const FontFeature.alternative(2));
+    });
+
+    test('randomize() returns correct instance', () {
+      final fontFeature = utility.randomize();
+
+      expect(fontFeature.value, isA<FontFeature>());
+      expect(fontFeature.value, const FontFeature.randomize());
+    });
+
+    test('swash() returns correct instance', () {
+      final fontFeature = utility.swash();
+
+      expect(fontFeature.value, isA<FontFeature>());
+      expect(fontFeature.value, const FontFeature.swash());
+    });
+
+    test('alternativeFractions() returns correct instance', () {
+      final fontFeature = utility.alternativeFractions();
+
+      expect(fontFeature.value, isA<FontFeature>());
+      expect(fontFeature.value, const FontFeature.alternativeFractions());
+    });
+
+    test('contextualAlternates() returns correct instance', () {
+      final fontFeature = utility.contextualAlternates();
+
+      expect(fontFeature.value, isA<FontFeature>());
+      expect(fontFeature.value, const FontFeature.contextualAlternates());
+    });
+
+    test('caseSensitiveForms() returns correct instance', () {
+      final fontFeature = utility.caseSensitiveForms();
+
+      expect(fontFeature.value, isA<FontFeature>());
+      expect(fontFeature.value, const FontFeature.caseSensitiveForms());
+    });
+
+    test('characterVariant() returns correct instance', () {
+      final fontFeature = utility.characterVariant(5);
+
+      expect(fontFeature.value, isA<FontFeature>());
+      expect(fontFeature.value, FontFeature.characterVariant(5));
+    });
+
+    test('historicalForms() returns correct instance', () {
+      final fontFeature = utility.historicalForms();
+
+      expect(fontFeature.value, isA<FontFeature>());
+      expect(fontFeature.value, const FontFeature.historicalForms());
+    });
+
+    test('historicalLigatures() returns correct instance', () {
+      final fontFeature = utility.historicalLigatures();
+
+      expect(fontFeature.value, isA<FontFeature>());
+      expect(fontFeature.value, const FontFeature.historicalLigatures());
+    });
+
+    test('liningFigures() returns correct instance', () {
+      final fontFeature = utility.liningFigures();
+
+      expect(fontFeature.value, isA<FontFeature>());
+      expect(fontFeature.value, const FontFeature.liningFigures());
+    });
+
+    test('localeAware() returns correct instance', () {
+      final fontFeature = utility.localeAware();
+      final fontFeatureEnabled = utility.localeAware(enable: true);
+      final fontFeatureDisabled = utility.localeAware(enable: false);
+
+      expect(fontFeature.value, isA<FontFeature>());
+      expect(fontFeature.value, const FontFeature.localeAware());
+      expect(fontFeatureEnabled.value,
+          const FontFeature.localeAware(enable: true));
+      expect(fontFeatureDisabled.value,
+          const FontFeature.localeAware(enable: false));
+    });
+
+    test('notationalForms() returns correct instance', () {
+      final fontFeature = utility.notationalForms(2);
+
+      expect(fontFeature.value, isA<FontFeature>());
+      expect(fontFeature.value, const FontFeature.notationalForms(2));
+    });
+
+    test('numerators() returns correct instance', () {
+      final fontFeature = utility.numerators();
+
+      expect(fontFeature.value, isA<FontFeature>());
+      expect(fontFeature.value, const FontFeature.numerators());
+    });
+
+    test('ordinalForms() returns correct instance', () {
+      final fontFeature = utility.ordinalForms();
+
+      expect(fontFeature.value, isA<FontFeature>());
+      expect(fontFeature.value, const FontFeature.ordinalForms());
+    });
+
+    test('proportionalFigures() returns correct instance', () {
+      final fontFeature = utility.proportionalFigures();
+
+      expect(fontFeature.value, isA<FontFeature>());
+      expect(fontFeature.value, const FontFeature.proportionalFigures());
+    });
+
+    test('stylisticAlternates() returns correct instance', () {
+      final fontFeature = utility.stylisticAlternates();
+
+      expect(fontFeature.value, isA<FontFeature>());
+      expect(fontFeature.value, const FontFeature.stylisticAlternates());
+    });
+
+    test('scientificInferiors() returns correct instance', () {
+      final fontFeature = utility.scientificInferiors();
+
+      expect(fontFeature.value, isA<FontFeature>());
+      expect(fontFeature.value, const FontFeature.scientificInferiors());
+    });
+
+    test('stylisticSet() returns correct instance', () {
+      final fontFeature = utility.stylisticSet(2);
+
+      expect(fontFeature.value, isA<FontFeature>());
+      expect(fontFeature.value, FontFeature.stylisticSet(2));
+    });
+
+    test('subscripts() returns correct instance', () {
+      final fontFeature = utility.subscripts();
+
+      expect(fontFeature.value, isA<FontFeature>());
+      expect(fontFeature.value, const FontFeature.subscripts());
+    });
+
+    test('superscripts() returns correct instance', () {
+      final fontFeature = utility.superscripts();
+
+      expect(fontFeature.value, isA<FontFeature>());
+      expect(fontFeature.value, const FontFeature.superscripts());
+    });
+
+    test('tabularFigures() returns correct instance', () {
+      final fontFeature = utility.tabularFigures();
+
+      expect(fontFeature.value, isA<FontFeature>());
+      expect(fontFeature.value, const FontFeature.tabularFigures());
+    });
+  });
+
+  group('AlignmentDirectionalUtility Tests', () {
+    const utility = AlignmentDirectionalUtility(UtilityTestAttribute.new);
+
+    test('only() returns correct instance with y and start values', () {
+      final alignmentDirectional = utility.only(y: 5, start: 10);
+
+      expect(alignmentDirectional.value, isA<AlignmentDirectional>());
+      expect(alignmentDirectional.value,
+          equals(const AlignmentDirectional(10, 5)));
+    });
+
+    test('only() returns correct instance with only y value', () {
+      final alignmentDirectional = utility.only(y: 5);
+
+      expect(alignmentDirectional.value, isA<AlignmentDirectional>());
+      expect(
+          alignmentDirectional.value, equals(const AlignmentDirectional(0, 5)));
+    });
+
+    test('only() returns correct instance with only start value', () {
+      final alignmentDirectional = utility.only(start: 10);
+
+      expect(alignmentDirectional.value, isA<AlignmentDirectional>());
+      expect(alignmentDirectional.value,
+          equals(const AlignmentDirectional(10, 0)));
+    });
+
+    test('only() returns correct instance with no values', () {
+      final alignmentDirectional = utility.only(y: -1, start: -1);
+
+      expect(alignmentDirectional.value, isA<AlignmentDirectional>());
+      expect(alignmentDirectional.value, equals(AlignmentDirectional.topStart));
+    });
+
+    test('topStart() returns correct instance', () {
+      final alignmentDirectional = utility.topStart();
+
+      expect(alignmentDirectional.value, isA<AlignmentDirectional>());
+      expect(alignmentDirectional.value, equals(AlignmentDirectional.topStart));
+    });
+
+    test('topCenter() returns correct instance', () {
+      final alignmentDirectional = utility.topCenter();
+
+      expect(alignmentDirectional.value, isA<AlignmentDirectional>());
+      expect(
+          alignmentDirectional.value, equals(AlignmentDirectional.topCenter));
+    });
+
+    test('topEnd() returns correct instance', () {
+      final alignmentDirectional = utility.topEnd();
+
+      expect(alignmentDirectional.value, isA<AlignmentDirectional>());
+      expect(alignmentDirectional.value, equals(AlignmentDirectional.topEnd));
+    });
+
+    test('centerStart() returns correct instance', () {
+      final alignmentDirectional = utility.centerStart();
+
+      expect(alignmentDirectional.value, isA<AlignmentDirectional>());
+      expect(
+          alignmentDirectional.value, equals(AlignmentDirectional.centerStart));
+    });
+
+    test('center() returns correct instance', () {
+      final alignmentDirectional = utility.center();
+
+      expect(alignmentDirectional.value, isA<AlignmentDirectional>());
+      expect(alignmentDirectional.value, equals(AlignmentDirectional.center));
+    });
+
+    test('centerEnd() returns correct instance', () {
+      final alignmentDirectional = utility.centerEnd();
+
+      expect(alignmentDirectional.value, isA<AlignmentDirectional>());
+      expect(
+          alignmentDirectional.value, equals(AlignmentDirectional.centerEnd));
+    });
+
+    test('bottomStart() returns correct instance', () {
+      final alignmentDirectional = utility.bottomStart();
+
+      expect(alignmentDirectional.value, isA<AlignmentDirectional>());
+      expect(
+          alignmentDirectional.value, equals(AlignmentDirectional.bottomStart));
+    });
+
+    test('bottomCenter() returns correct instance', () {
+      final alignmentDirectional = utility.bottomCenter();
+
+      expect(alignmentDirectional.value, isA<AlignmentDirectional>());
+      expect(alignmentDirectional.value,
+          equals(AlignmentDirectional.bottomCenter));
+    });
+
+    test('bottomEnd() returns correct instance', () {
+      final alignmentDirectional = utility.bottomEnd();
+
+      expect(alignmentDirectional.value, isA<AlignmentDirectional>());
+      expect(
+          alignmentDirectional.value, equals(AlignmentDirectional.bottomEnd));
+    });
+
+    test('call() returns correct instance', () {
+      final alignmentDirectional = utility(AlignmentDirectional.topStart);
+
+      expect(alignmentDirectional.value, isA<AlignmentDirectional>());
+      expect(alignmentDirectional.value, equals(AlignmentDirectional.topStart));
+    });
+  });
+  group('PaintUtility Tests', () {
+    const utility = PaintUtility(UtilityTestAttribute.new);
+    test('PaintUtility returns correct instance', () {
+      final paint = utility(Paint());
+      expect(paint.value, isA<Paint>());
+    });
+  });
+
+  group('LocaleUtility Tests', () {
+    const utility = LocaleUtility(UtilityTestAttribute.new);
+    test('LocaleUtility returns correct instance', () {
+      final locale = utility(const Locale('en', 'US'));
+      expect(locale.value, isA<Locale>());
+      expect(locale.value.languageCode, 'en');
+      expect(locale.value.countryCode, 'US');
+    });
+
+    test('LocaleUtility handles locale without country code', () {
+      final locale = utility(const Locale('fr'));
+      expect(locale.value, isA<Locale>());
+      expect(locale.value.languageCode, 'fr');
+      expect(locale.value.countryCode, null);
     });
   });
 

--- a/packages/mix/test/src/attributes/text_height_behavior/text_height_behavior_dto_test.dart
+++ b/packages/mix/test/src/attributes/text_height_behavior/text_height_behavior_dto_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mix/src/attributes/text_height_behavior/text_height_behavior_dto.dart';
+
+import '../../../helpers/testing_utils.dart';
+
+void main() {
+  group('TextHeightBehaviorDto', () {
+    test('creates with default values', () {
+      const dto = TextHeightBehaviorDto();
+      expect(dto.applyHeightToFirstAscent, isNull);
+      expect(dto.applyHeightToLastDescent, isNull);
+      expect(dto.leadingDistribution, isNull);
+    });
+
+    test('creates with custom values', () {
+      const dto = TextHeightBehaviorDto(
+        applyHeightToFirstAscent: true,
+        applyHeightToLastDescent: false,
+        leadingDistribution: TextLeadingDistribution.even,
+      );
+      expect(dto.applyHeightToFirstAscent, isTrue);
+      expect(dto.applyHeightToLastDescent, isFalse);
+      expect(dto.leadingDistribution, TextLeadingDistribution.even);
+    });
+  });
+
+  group('TextHeightBehaviorUtility', () {
+    late TextHeightBehaviorUtility utility;
+
+    setUp(() {
+      utility = TextHeightBehaviorUtility(UtilityTestAttribute.new);
+    });
+
+    test('heightToFirstAscent sets applyHeightToFirstAscent', () {
+      final result = utility.heightToFirstAscent(true)
+          as UtilityTestAttribute<TextHeightBehaviorDto>;
+      expect(result.value.applyHeightToFirstAscent, isTrue);
+      expect(result.value.applyHeightToLastDescent, isNull);
+      expect(result.value.leadingDistribution, isNull);
+    });
+
+    test('heightToLastDescent sets applyHeightToLastDescent', () {
+      final result = utility.heightToLastDescent(false)
+          as UtilityTestAttribute<TextHeightBehaviorDto>;
+      expect(result.value.applyHeightToFirstAscent, isNull);
+      expect(result.value.applyHeightToLastDescent, isFalse);
+      expect(result.value.leadingDistribution, isNull);
+    });
+
+    test('leadingDistribution sets leadingDistribution', () {
+      final result =
+          utility.leadingDistribution(TextLeadingDistribution.proportional)
+              as UtilityTestAttribute<TextHeightBehaviorDto>;
+      expect(result.value.applyHeightToFirstAscent, isNull);
+      expect(result.value.applyHeightToLastDescent, isNull);
+      expect(result.value.leadingDistribution,
+          TextLeadingDistribution.proportional);
+    });
+
+    test('only sets multiple properties', () {
+      final result = utility.only(
+        applyHeightToFirstAscent: true,
+        applyHeightToLastDescent: false,
+        leadingDistribution: TextLeadingDistribution.even,
+      ) as UtilityTestAttribute<TextHeightBehaviorDto>;
+      expect(result.value.applyHeightToFirstAscent, isTrue);
+      expect(result.value.applyHeightToLastDescent, isFalse);
+      expect(result.value.leadingDistribution, TextLeadingDistribution.even);
+    });
+  });
+}

--- a/packages/mix/test/src/deprecated/text_attribute_test.dart
+++ b/packages/mix/test/src/deprecated/text_attribute_test.dart
@@ -23,7 +23,7 @@ void main() {
         fontFamily: 'Roboto',
       ),
       textWidthBasis: TextWidthBasis.longestLine,
-      textHeightBehavior: const TextHeightBehavior(
+      textHeightBehavior: const TextHeightBehaviorDto(
         applyHeightToFirstAscent: true,
         applyHeightToLastDescent: true,
       ),
@@ -40,7 +40,8 @@ void main() {
       expect(textSpecAttribute.maxLines, 2);
       expect(textSpecAttribute.style, isA<TextStyleDto>());
       expect(textSpecAttribute.textWidthBasis, TextWidthBasis.longestLine);
-      expect(textSpecAttribute.textHeightBehavior, isA<TextHeightBehavior>());
+      expect(
+          textSpecAttribute.textHeightBehavior, isA<TextHeightBehaviorDto>());
       expect(textSpecAttribute.textDirection, TextDirection.rtl);
       expect(textSpecAttribute.softWrap, true);
     });
@@ -63,7 +64,7 @@ void main() {
           fontFamily: 'Helvetica',
         ),
         textWidthBasis: TextWidthBasis.longestLine,
-        textHeightBehavior: const TextHeightBehavior(
+        textHeightBehavior: const TextHeightBehaviorDto(
           applyHeightToFirstAscent: false,
           applyHeightToLastDescent: false,
         ),

--- a/packages/mix/test/src/deprecated/text_spec_test.dart
+++ b/packages/mix/test/src/deprecated/text_spec_test.dart
@@ -19,7 +19,7 @@ void main() {
             maxLines: 2,
             style: TextStyleDto(color: const ColorDto(Colors.red)),
             textWidthBasis: TextWidthBasis.longestLine,
-            textHeightBehavior: const TextHeightBehavior(
+            textHeightBehavior: const TextHeightBehaviorDto(
               applyHeightToFirstAscent: true,
               applyHeightToLastDescent: true,
             ),
@@ -195,7 +195,7 @@ void main() {
             maxLines: 2,
             style: TextStyleDto(color: const ColorDto(Colors.red)),
             textWidthBasis: TextWidthBasis.longestLine,
-            textHeightBehavior: const TextHeightBehavior(
+            textHeightBehavior: const TextHeightBehaviorDto(
               applyHeightToFirstAscent: true,
               applyHeightToLastDescent: true,
             ),

--- a/packages/mix/test/src/specs/text/text_attribute_test.dart
+++ b/packages/mix/test/src/specs/text/text_attribute_test.dart
@@ -22,7 +22,7 @@ void main() {
         fontFamily: 'Roboto',
       ),
       textWidthBasis: TextWidthBasis.longestLine,
-      textHeightBehavior: const TextHeightBehavior(
+      textHeightBehavior: const TextHeightBehaviorDto(
         applyHeightToFirstAscent: true,
         applyHeightToLastDescent: true,
       ),
@@ -39,7 +39,8 @@ void main() {
       expect(textSpecAttribute.maxLines, 2);
       expect(textSpecAttribute.style, isA<TextStyleDto>());
       expect(textSpecAttribute.textWidthBasis, TextWidthBasis.longestLine);
-      expect(textSpecAttribute.textHeightBehavior, isA<TextHeightBehavior>());
+      expect(
+          textSpecAttribute.textHeightBehavior, isA<TextHeightBehaviorDto>());
       expect(textSpecAttribute.textDirection, TextDirection.rtl);
       expect(textSpecAttribute.softWrap, true);
     });
@@ -62,7 +63,7 @@ void main() {
           fontFamily: 'Helvetica',
         ),
         textWidthBasis: TextWidthBasis.longestLine,
-        textHeightBehavior: const TextHeightBehavior(
+        textHeightBehavior: const TextHeightBehaviorDto(
           applyHeightToFirstAscent: false,
           applyHeightToLastDescent: false,
         ),

--- a/packages/mix/test/src/specs/text/text_spec_test.dart
+++ b/packages/mix/test/src/specs/text/text_spec_test.dart
@@ -18,7 +18,7 @@ void main() {
             maxLines: 2,
             style: TextStyleDto(color: const ColorDto(Colors.red)),
             textWidthBasis: TextWidthBasis.longestLine,
-            textHeightBehavior: const TextHeightBehavior(
+            textHeightBehavior: const TextHeightBehaviorDto(
               applyHeightToFirstAscent: true,
               applyHeightToLastDescent: true,
             ),
@@ -194,7 +194,7 @@ void main() {
             maxLines: 2,
             style: TextStyleDto(color: const ColorDto(Colors.red)),
             textWidthBasis: TextWidthBasis.longestLine,
-            textHeightBehavior: const TextHeightBehavior(
+            textHeightBehavior: const TextHeightBehaviorDto(
               applyHeightToFirstAscent: true,
               applyHeightToLastDescent: true,
             ),


### PR DESCRIPTION
### Description

before
```dart
$text.textHeightBehavior(
   const TextHeightBehavior(
      applyHeightToFirstAscent: false,
      applyHeightToLastDescent: false,
    ),
)
```
now
```dart
$text.chain
    ..textHeightBehavior.heightToFirstAscent(false),
    ..textHeightBehavior.heightToLastDescent(false),
)
```

### Changes

- Create a utility for this TextHeightBehavior and TextLeadingDistribution 
- Reorganize `scalar_util_test.dart` file

**Review Checklist**

- [x] **Testing**: Have you tested your changes, including unit tests and integration tests for affected code?
- [ ] **Breaking Changes**: Does this change introduce breaking changes affecting existing code or users?
- [ ] **Documentation Updates**: Are all relevant documentation files (e.g. README, API docs) updated to reflect the changes in this PR?
- [ ] **Website Updates**: Is the website containing the updates you make on documentation?

