### PR TITLE
refactor(remix): improve widgetbook navigation

### DIFF
--- a/packages/remix/demo/build.yaml
+++ b/packages/remix/demo/build.yaml
@@ -1,0 +1,6 @@
+targets:
+  $default:
+    builders:
+      widgetbook_generator:use_case_builder:
+        options:
+          nav_path_mode: use-case

--- a/packages/remix/demo/lib/main.directories.g.dart
+++ b/packages/remix/demo/lib/main.directories.g.dart
@@ -36,257 +36,152 @@ final directories = <_i1.WidgetbookNode>[
   _i1.WidgetbookFolder(
     name: 'components',
     children: [
-      _i1.WidgetbookFolder(
-        name: 'accordion',
-        children: [
-          _i1.WidgetbookLeafComponent(
-            name: 'Accordion',
-            useCase: _i1.WidgetbookUseCase(
-              name: 'Accordion Component',
-              builder: _i2.buildAccordionUseCase,
-            ),
-          )
-        ],
+      _i1.WidgetbookLeafComponent(
+        name: 'Accordion',
+        useCase: _i1.WidgetbookUseCase(
+          name: 'Accordion Component',
+          builder: _i2.buildAccordionUseCase,
+        ),
       ),
-      _i1.WidgetbookFolder(
-        name: 'avatar',
-        children: [
-          _i1.WidgetbookLeafComponent(
-            name: 'Avatar',
-            useCase: _i1.WidgetbookUseCase(
-              name: 'Avatar Component',
-              builder: _i3.buildAvatarUseCase,
-            ),
-          )
-        ],
+      _i1.WidgetbookLeafComponent(
+        name: 'Avatar',
+        useCase: _i1.WidgetbookUseCase(
+          name: 'Avatar Component',
+          builder: _i3.buildAvatarUseCase,
+        ),
       ),
-      _i1.WidgetbookFolder(
-        name: 'badge',
-        children: [
-          _i1.WidgetbookLeafComponent(
-            name: 'Badge',
-            useCase: _i1.WidgetbookUseCase(
-              name: 'Badge Component',
-              builder: _i4.buildAvatarUseCase,
-            ),
-          )
-        ],
+      _i1.WidgetbookLeafComponent(
+        name: 'Badge',
+        useCase: _i1.WidgetbookUseCase(
+          name: 'Badge Component',
+          builder: _i4.buildAvatarUseCase,
+        ),
       ),
-      _i1.WidgetbookFolder(
-        name: 'button',
-        children: [
-          _i1.WidgetbookLeafComponent(
-            name: 'Button',
-            useCase: _i1.WidgetbookUseCase(
-              name: 'Button Component',
-              builder: _i5.buildButtonUseCase,
-            ),
-          )
-        ],
+      _i1.WidgetbookLeafComponent(
+        name: 'Button',
+        useCase: _i1.WidgetbookUseCase(
+          name: 'Button Component',
+          builder: _i5.buildButtonUseCase,
+        ),
       ),
-      _i1.WidgetbookFolder(
-        name: 'callout',
-        children: [
-          _i1.WidgetbookLeafComponent(
-            name: 'Callout',
-            useCase: _i1.WidgetbookUseCase(
-              name: 'Callout Component',
-              builder: _i6.buildCalloutUseCase,
-            ),
-          )
-        ],
+      _i1.WidgetbookLeafComponent(
+        name: 'Callout',
+        useCase: _i1.WidgetbookUseCase(
+          name: 'Callout Component',
+          builder: _i6.buildCalloutUseCase,
+        ),
       ),
-      _i1.WidgetbookFolder(
-        name: 'card',
-        children: [
-          _i1.WidgetbookLeafComponent(
-            name: 'Card',
-            useCase: _i1.WidgetbookUseCase(
-              name: 'Card Component',
-              builder: _i7.buildCard,
-            ),
-          )
-        ],
+      _i1.WidgetbookLeafComponent(
+        name: 'Card',
+        useCase: _i1.WidgetbookUseCase(
+          name: 'Card Component',
+          builder: _i7.buildCard,
+        ),
       ),
-      _i1.WidgetbookFolder(
-        name: 'checkbox',
-        children: [
-          _i1.WidgetbookLeafComponent(
-            name: 'Checkbox',
-            useCase: _i1.WidgetbookUseCase(
-              name: 'Checkbox Component',
-              builder: _i8.buildCheckboxUseCase,
-            ),
-          )
-        ],
+      _i1.WidgetbookLeafComponent(
+        name: 'Checkbox',
+        useCase: _i1.WidgetbookUseCase(
+          name: 'Checkbox Component',
+          builder: _i8.buildCheckboxUseCase,
+        ),
       ),
-      _i1.WidgetbookFolder(
-        name: 'chip',
-        children: [
-          _i1.WidgetbookLeafComponent(
-            name: 'Chip',
-            useCase: _i1.WidgetbookUseCase(
-              name: 'Chip Component',
-              builder: _i9.buildChipUseCase,
-            ),
-          )
-        ],
+      _i1.WidgetbookLeafComponent(
+        name: 'Chip',
+        useCase: _i1.WidgetbookUseCase(
+          name: 'Chip Component',
+          builder: _i9.buildChipUseCase,
+        ),
       ),
-      _i1.WidgetbookFolder(
-        name: 'dialog',
-        children: [
-          _i1.WidgetbookLeafComponent(
-            name: 'Dialog',
-            useCase: _i1.WidgetbookUseCase(
-              name: 'Dialog Component',
-              builder: _i10.buildButtonUseCase,
-            ),
-          )
-        ],
+      _i1.WidgetbookLeafComponent(
+        name: 'Dialog',
+        useCase: _i1.WidgetbookUseCase(
+          name: 'Dialog Component',
+          builder: _i10.buildButtonUseCase,
+        ),
       ),
-      _i1.WidgetbookFolder(
-        name: 'divider',
-        children: [
-          _i1.WidgetbookLeafComponent(
-            name: 'Divider',
-            useCase: _i1.WidgetbookUseCase(
-              name: 'Divider Component',
-              builder: _i11.buildDivider,
-            ),
-          )
-        ],
+      _i1.WidgetbookLeafComponent(
+        name: 'Divider',
+        useCase: _i1.WidgetbookUseCase(
+          name: 'Divider Component',
+          builder: _i11.buildDivider,
+        ),
       ),
-      _i1.WidgetbookFolder(
-        name: 'icon_button',
-        children: [
-          _i1.WidgetbookLeafComponent(
-            name: 'IconButton',
-            useCase: _i1.WidgetbookUseCase(
-              name: 'Button Component',
-              builder: _i12.buildButtonUseCase,
-            ),
-          )
-        ],
+      _i1.WidgetbookLeafComponent(
+        name: 'IconButton',
+        useCase: _i1.WidgetbookUseCase(
+          name: 'Button Component',
+          builder: _i12.buildButtonUseCase,
+        ),
       ),
-      _i1.WidgetbookFolder(
-        name: 'menu_item',
-        children: [
-          _i1.WidgetbookLeafComponent(
-            name: 'MenuItem',
-            useCase: _i1.WidgetbookUseCase(
-              name: 'Menu Item Component',
-              builder: _i13.buildButtonUseCase,
-            ),
-          )
-        ],
+      _i1.WidgetbookLeafComponent(
+        name: 'MenuItem',
+        useCase: _i1.WidgetbookUseCase(
+          name: 'Menu Item Component',
+          builder: _i13.buildButtonUseCase,
+        ),
       ),
-      _i1.WidgetbookFolder(
-        name: 'progress',
-        children: [
-          _i1.WidgetbookLeafComponent(
-            name: 'Progress',
-            useCase: _i1.WidgetbookUseCase(
-              name: 'Progress Component',
-              builder: _i14.buildProgressUseCase,
-            ),
-          )
-        ],
+      _i1.WidgetbookLeafComponent(
+        name: 'Progress',
+        useCase: _i1.WidgetbookUseCase(
+          name: 'Progress Component',
+          builder: _i14.buildProgressUseCase,
+        ),
       ),
-      _i1.WidgetbookFolder(
-        name: 'radio',
-        children: [
-          _i1.WidgetbookLeafComponent(
-            name: 'Radio',
-            useCase: _i1.WidgetbookUseCase(
-              name: 'Radio Component',
-              builder: _i15.buildRadioUseCase,
-            ),
-          )
-        ],
+      _i1.WidgetbookLeafComponent(
+        name: 'Radio',
+        useCase: _i1.WidgetbookUseCase(
+          name: 'Radio Component',
+          builder: _i15.buildRadioUseCase,
+        ),
       ),
-      _i1.WidgetbookFolder(
-        name: 'segmented_control',
-        children: [
-          _i1.WidgetbookLeafComponent(
-            name: 'SegmentedControl',
-            useCase: _i1.WidgetbookUseCase(
-              name: 'SegmentedControl Component',
-              builder: _i16.buildAccordionUseCase,
-            ),
-          )
-        ],
+      _i1.WidgetbookLeafComponent(
+        name: 'SegmentedControl',
+        useCase: _i1.WidgetbookUseCase(
+          name: 'SegmentedControl Component',
+          builder: _i16.buildAccordionUseCase,
+        ),
       ),
-      _i1.WidgetbookFolder(
-        name: 'select',
-        children: [
-          _i1.WidgetbookLeafComponent(
-            name: 'Select',
-            useCase: _i1.WidgetbookUseCase(
-              name: 'Select Component',
-              builder: _i17.buildSelect,
-            ),
-          )
-        ],
+      _i1.WidgetbookLeafComponent(
+        name: 'Select',
+        useCase: _i1.WidgetbookUseCase(
+          name: 'Select Component',
+          builder: _i17.buildSelect,
+        ),
       ),
-      _i1.WidgetbookFolder(
-        name: 'slider',
-        children: [
-          _i1.WidgetbookLeafComponent(
-            name: 'Slider',
-            useCase: _i1.WidgetbookUseCase(
-              name: 'Slider Component',
-              builder: _i18.buildButtonUseCase,
-            ),
-          )
-        ],
+      _i1.WidgetbookLeafComponent(
+        name: 'Slider',
+        useCase: _i1.WidgetbookUseCase(
+          name: 'Slider Component',
+          builder: _i18.buildButtonUseCase,
+        ),
       ),
-      _i1.WidgetbookFolder(
-        name: 'spinner',
-        children: [
-          _i1.WidgetbookLeafComponent(
-            name: 'Spinner',
-            useCase: _i1.WidgetbookUseCase(
-              name: 'Spinner Component',
-              builder: _i19.buildSpinnerUseCase,
-            ),
-          )
-        ],
+      _i1.WidgetbookLeafComponent(
+        name: 'Spinner',
+        useCase: _i1.WidgetbookUseCase(
+          name: 'Spinner Component',
+          builder: _i19.buildSpinnerUseCase,
+        ),
       ),
-      _i1.WidgetbookFolder(
-        name: 'switch',
-        children: [
-          _i1.WidgetbookLeafComponent(
-            name: 'Switch',
-            useCase: _i1.WidgetbookUseCase(
-              name: 'Switch Component',
-              builder: _i20.buildSwitchUseCase,
-            ),
-          )
-        ],
+      _i1.WidgetbookLeafComponent(
+        name: 'Switch',
+        useCase: _i1.WidgetbookUseCase(
+          name: 'Switch Component',
+          builder: _i20.buildSwitchUseCase,
+        ),
       ),
-      _i1.WidgetbookFolder(
-        name: 'textfield',
-        children: [
-          _i1.WidgetbookLeafComponent(
-            name: 'TextField',
-            useCase: _i1.WidgetbookUseCase(
-              name: 'TextField Component',
-              builder: _i21.buildButtonUseCase,
-            ),
-          )
-        ],
+      _i1.WidgetbookLeafComponent(
+        name: 'TextField',
+        useCase: _i1.WidgetbookUseCase(
+          name: 'TextField Component',
+          builder: _i21.buildButtonUseCase,
+        ),
       ),
-      _i1.WidgetbookFolder(
-        name: 'toast',
-        children: [
-          _i1.WidgetbookLeafComponent(
-            name: 'Toast',
-            useCase: _i1.WidgetbookUseCase(
-              name: 'Toast Component',
-              builder: _i22.buildButtonUseCase,
-            ),
-          )
-        ],
+      _i1.WidgetbookLeafComponent(
+        name: 'Toast',
+        useCase: _i1.WidgetbookUseCase(
+          name: 'Toast Component',
+          builder: _i22.buildButtonUseCase,
+        ),
       ),
     ],
   )


### PR DESCRIPTION
Saw that the new Remix package is using Widgetbook.
A small improvement to the navigation, to make it less tedious to jump between use-cases.

### Before

<img width="1920" alt="before" src="https://github.com/user-attachments/assets/12e70e1d-0a9d-4ed9-8464-b001e161d014">

### After

<img width="1920" alt="after" src="https://github.com/user-attachments/assets/c5aa3270-d1da-42ed-9ab5-575c9f294ef0">
