### PR TITLE
fix: Order of modifiers implementation on Box, Image and Text

### DIFF
--- a/packages/mix/lib/src/specs/box/box_widget.dart
+++ b/packages/mix/lib/src/specs/box/box_widget.dart
@@ -133,6 +133,10 @@ class _AnimatedBoxSpecWidgetState
   Widget build(BuildContext context) {
     final spec = _boxSpec?.evaluate(animation);
 
-    return BoxSpecWidget(spec: spec, child: widget.child);
+    return BoxSpecWidget(
+      spec: spec,
+      orderOfModifiers: widget.orderOfModifiers,
+      child: widget.child,
+    );
   }
 }

--- a/packages/mix/lib/src/specs/image/image_widget.dart
+++ b/packages/mix/lib/src/specs/image/image_widget.dart
@@ -53,11 +53,12 @@ class StyledImage extends StyledWidget {
               gaplessPlayback: gaplessPlayback,
               isAntiAlias: isAntiAlias,
               matchTextDirection: matchTextDirection,
-              opacity: opacity,
               orderOfModifiers: orderOfModifiers,
+              opacity: opacity,
             )
           : ImageSpecWidget(
               spec: spec,
+              orderOfModifiers: orderOfModifiers,
               image: image,
               frameBuilder: frameBuilder,
               loadingBuilder: loadingBuilder,
@@ -68,7 +69,6 @@ class StyledImage extends StyledWidget {
               isAntiAlias: isAntiAlias,
               opacity: opacity,
               matchTextDirection: matchTextDirection,
-              orderOfModifiers: orderOfModifiers,
             );
     });
   }

--- a/packages/mix/lib/src/specs/image/image_widget.dart
+++ b/packages/mix/lib/src/specs/image/image_widget.dart
@@ -54,6 +54,7 @@ class StyledImage extends StyledWidget {
               isAntiAlias: isAntiAlias,
               matchTextDirection: matchTextDirection,
               opacity: opacity,
+              orderOfModifiers: orderOfModifiers,
             )
           : ImageSpecWidget(
               spec: spec,
@@ -67,6 +68,7 @@ class StyledImage extends StyledWidget {
               isAntiAlias: isAntiAlias,
               opacity: opacity,
               matchTextDirection: matchTextDirection,
+              orderOfModifiers: orderOfModifiers,
             );
     });
   }
@@ -148,6 +150,7 @@ class AnimatedImageSpecWidget extends ImplicitlyAnimatedWidget {
     this.gaplessPlayback = false,
     this.isAntiAlias = false,
     this.matchTextDirection = false,
+    this.orderOfModifiers = const [],
     this.opacity,
   });
 
@@ -162,6 +165,7 @@ class AnimatedImageSpecWidget extends ImplicitlyAnimatedWidget {
   final bool isAntiAlias;
   final bool matchTextDirection;
   final Animation<double>? opacity;
+  final List<Type> orderOfModifiers;
 
   @override
   AnimatedWidgetBaseState<AnimatedImageSpecWidget> createState() =>
@@ -190,6 +194,7 @@ class _AnimateImageSpecState
 
     return ImageSpecWidget(
       spec: spec,
+      orderOfModifiers: widget.orderOfModifiers,
       image: widget.image,
       frameBuilder: widget.frameBuilder,
       loadingBuilder: widget.loadingBuilder,

--- a/packages/mix/lib/src/specs/text/text_spec.dart
+++ b/packages/mix/lib/src/specs/text/text_spec.dart
@@ -109,20 +109,28 @@ final class TextSpec extends Spec<TextSpec> with _$TextSpec, Diagnosticable {
     super.modifiers,
   });
 
-  Widget call(String text, {String? semanticLabel, Locale? locale}) {
+  Widget call(
+    String text, {
+    @Deprecated('Use semanticsLabel instead') String? semanticLabel,
+    String? semanticsLabel,
+    Locale? locale,
+    List<Type> orderOfModifiers = const [],
+  }) {
     return isAnimated
         ? AnimatedTextSpecWidget(
             text,
             spec: this,
-            semanticsLabel: semanticLabel,
+            semanticsLabel: semanticsLabel ?? semanticLabel,
             locale: locale,
             duration: animated!.duration,
             curve: animated!.curve,
+            orderOfModifiers: orderOfModifiers,
           )
         : TextSpecWidget(
             text,
             spec: this,
-            semanticsLabel: semanticLabel,
+            semanticsLabel: semanticsLabel ?? semanticLabel,
+            orderOfModifiers: orderOfModifiers,
             locale: locale,
           );
   }

--- a/packages/mix/lib/src/specs/text/text_spec.dart
+++ b/packages/mix/lib/src/specs/text/text_spec.dart
@@ -122,16 +122,16 @@ final class TextSpec extends Spec<TextSpec> with _$TextSpec, Diagnosticable {
             spec: this,
             semanticsLabel: semanticsLabel ?? semanticLabel,
             locale: locale,
+            orderOfModifiers: orderOfModifiers,
             duration: animated!.duration,
             curve: animated!.curve,
-            orderOfModifiers: orderOfModifiers,
           )
         : TextSpecWidget(
             text,
             spec: this,
             semanticsLabel: semanticsLabel ?? semanticLabel,
-            orderOfModifiers: orderOfModifiers,
             locale: locale,
+            orderOfModifiers: orderOfModifiers,
           );
   }
 

--- a/packages/mix/lib/src/specs/text/text_widget.dart
+++ b/packages/mix/lib/src/specs/text/text_widget.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 
 import '../../core/styled_widget.dart';
 import '../../modifiers/internal/render_widget_modifier.dart';
-import '../../theme/mix/mix_theme.dart';
 import 'text_spec.dart';
 
 /// [StyledText] - A styled widget for displaying text with a mix of styles.
@@ -53,11 +52,8 @@ class StyledText extends StyledWidget {
   Widget build(BuildContext context) {
     return withMix(context, (contextNew) {
       final spec = TextSpec.of(contextNew);
-      return spec(
-        text,
-        semanticsLabel: semanticsLabel,
-        locale: locale,
-      );
+
+      return spec(text, semanticsLabel: semanticsLabel, locale: locale);
     });
   }
 }
@@ -151,8 +147,8 @@ class _AnimatedTextSpecWidgetState
       widget.text,
       spec: spec,
       semanticsLabel: widget.semanticsLabel,
-      orderOfModifiers: widget.orderOfModifiers,
       locale: widget.locale,
+      orderOfModifiers: widget.orderOfModifiers,
     );
   }
 }

--- a/packages/mix/lib/src/specs/text/text_widget.dart
+++ b/packages/mix/lib/src/specs/text/text_widget.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../core/styled_widget.dart';
 import '../../modifiers/internal/render_widget_modifier.dart';
+import '../../theme/mix/mix_theme.dart';
 import 'text_spec.dart';
 
 /// [StyledText] - A styled widget for displaying text with a mix of styles.
@@ -50,24 +51,13 @@ class StyledText extends StyledWidget {
 
   @override
   Widget build(BuildContext context) {
-    return withMix(context, (context) {
-      final spec = TextSpec.of(context);
-
-      return spec.isAnimated
-          ? AnimatedTextSpecWidget(
-              text,
-              spec: spec,
-              semanticsLabel: semanticsLabel,
-              locale: locale,
-              duration: spec.animated!.duration,
-              curve: spec.animated!.curve,
-            )
-          : TextSpecWidget(
-              text,
-              spec: spec,
-              semanticsLabel: semanticsLabel,
-              locale: locale,
-            );
+    return withMix(context, (contextNew) {
+      final spec = TextSpec.of(contextNew);
+      return spec(
+        text,
+        semanticsLabel: semanticsLabel,
+        locale: locale,
+      );
     });
   }
 }
@@ -93,7 +83,7 @@ class TextSpecWidget extends StatelessWidget {
     // The Text widget is used here, applying the resolved styles and properties from TextSpec.
     return RenderSpecModifiers(
       spec: spec ?? const TextSpec(),
-      orderOfModifiers: const [],
+      orderOfModifiers: orderOfModifiers,
       child: Text(
         spec?.directive?.apply(text) ?? text,
         style: spec?.style,
@@ -121,6 +111,7 @@ class AnimatedTextSpecWidget extends ImplicitlyAnimatedWidget {
     this.spec,
     this.semanticsLabel,
     this.locale,
+    this.orderOfModifiers = const [],
     super.key,
     required super.duration,
     super.curve = Curves.linear,
@@ -131,7 +122,7 @@ class AnimatedTextSpecWidget extends ImplicitlyAnimatedWidget {
   final String? semanticsLabel;
   final Locale? locale;
   final TextSpec? spec;
-
+  final List<Type> orderOfModifiers;
   @override
   AnimatedWidgetBaseState<AnimatedTextSpecWidget> createState() =>
       _AnimatedTextSpecWidgetState();
@@ -160,6 +151,7 @@ class _AnimatedTextSpecWidgetState
       widget.text,
       spec: spec,
       semanticsLabel: widget.semanticsLabel,
+      orderOfModifiers: widget.orderOfModifiers,
       locale: widget.locale,
     );
   }


### PR DESCRIPTION
### Description

- The API related to order of modifiers was not implemented correctly on Box and Image

### Changes

- Add parameter order of modifiers
- Fix places where it was not implemented correctly

**Review Checklist**

- [ ] **Testing**: Have you tested your changes, including unit tests and integration tests for affected code?
- [ ] **Breaking Changes**: Does this change introduce breaking changes affecting existing code or users?
- [ ] **Documentation Updates**: Are all relevant documentation files (e.g. README, API docs) updated to reflect the changes in this PR?
- [ ] **Website Updates**: Is the website containing the updates you make on documentation?
