### PR TITLE
WIP: Add support for onTapDown and onTapUp

### DIFF
--- a/packages/mix/lib/mix.dart
+++ b/packages/mix/lib/mix.dart
@@ -70,6 +70,7 @@ export 'src/core/spec.dart';
 export 'src/core/styled_widget.dart';
 export 'src/core/utility.dart';
 export 'src/core/variant.dart';
+export 'src/core/widget_state/press_event_mix_state.dart';
 export 'src/core/widget_state/widget_state_controller.dart';
 /// MODIFIERS
 export 'src/modifiers/align_widget_modifier.dart';

--- a/packages/mix/lib/src/core/widget_state/press_event_mix_state.dart
+++ b/packages/mix/lib/src/core/widget_state/press_event_mix_state.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/widgets.dart';
+
+enum PressEvent {
+  idle,
+  onTapUp,
+  onTapDown;
+}
+
+class PressEventMixWidgetState extends InheritedWidget {
+  const PressEventMixWidgetState(this.event, {super.key, required super.child});
+
+  static PressEventMixWidgetState? of(BuildContext context) {
+    return context.dependOnInheritedWidgetOfExactType();
+  }
+
+  final PressEvent event;
+
+  @override
+  bool updateShouldNotify(PressEventMixWidgetState oldWidget) {
+    return event != oldWidget.event;
+  }
+}

--- a/packages/mix/lib/src/variants/widget_state_variant.dart
+++ b/packages/mix/lib/src/variants/widget_state_variant.dart
@@ -2,7 +2,9 @@ import 'package:flutter/widgets.dart';
 
 import '../core/factory/style_mix.dart';
 import '../core/variant.dart';
+import '../core/widget_state/internal/gesture_mix_state.dart';
 import '../core/widget_state/internal/mouse_region_mix_state.dart';
+import '../core/widget_state/press_event_mix_state.dart';
 import '../core/widget_state/widget_state_controller.dart';
 import 'context_variant.dart';
 
@@ -60,8 +62,19 @@ class OnHoverVariant extends MixWidgetStateVariant<PointerPosition?> {
 }
 
 /// Applies styles when the widget is pressed.
-class OnPressVariant extends _ToggleMixStateVariant {
-  const OnPressVariant() : super(MixWidgetState.pressed);
+class OnPressVariant extends MixWidgetStateVariant<PressEvent> {
+  const OnPressVariant();
+
+  @override
+  PressEvent builder(BuildContext context) {
+    final event = PressEventMixWidgetState.of(context)?.event;
+
+    return event ?? PressEvent.idle;
+  }
+
+  @override
+  bool when(BuildContext context) =>
+      MixWidgetState.hasStateOf(context, MixWidgetState.pressed);
 }
 
 /// Applies styles when the widget is long pressed.

--- a/packages/mix/test/src/core/mix_state/press_states_test.dart
+++ b/packages/mix/test/src/core/mix_state/press_states_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mix/mix.dart';
+import 'package:mix/src/core/widget_state/internal/gesture_mix_state.dart';
+
+import '../../../helpers/context_finder.dart';
+import '../../../helpers/testing_utils.dart';
+
+extension _WidgetTesterX on WidgetTester {
+  PressEventMixWidgetState findPressEventWidget() {
+    return findWidgetOfType<PressEventMixWidgetState>();
+  }
+}
+
+void main() {
+  testWidgets(
+      'Pressable should transition through (onTapDown and onTapUp) states correctly',
+      (tester) async {
+    int counter = 0;
+    await tester.pumpMaterialApp(
+      PressableBox(
+        onPress: () {
+          counter++;
+        },
+        child: Text('$counter'),
+      ),
+    );
+
+    // Initial state should be idle
+    expect(tester.findPressEventWidget().event, PressEvent.idle);
+
+    // Press down on the PressableBox
+    final gesture = await tester.press(find.byType(PressableBox));
+    await tester.pumpAndSettle();
+    expect(tester.findPressEventWidget().event, PressEvent.onTapDown);
+
+    // Release the press
+    await gesture.up();
+    await tester.pumpAndSettle();
+    expect(tester.findPressEventWidget().event, PressEvent.onTapUp);
+
+    expect(counter, equals(1));
+
+    await tester.pump(const Duration(milliseconds: 300));
+    expect(tester.findPressEventWidget().event, PressEvent.idle);
+  });
+}


### PR DESCRIPTION
#### Related issue

#533

### Description

This pull request introduces support for styling widgets during the Tap Down and Tap Up events by incorporating these concepts as events in the `press` context variant. 

```dart
Style(
  $box.height(100),
  $box.width(100),
  $box.color.red(),
  $box.wrap.scale(1),
  $on.press.event(
    (e) {
      switch (e) {
        case PressEvent.onTapUp:
        case PressEvent.onTapDown:
          return Style(
            $box.color.purple(),
            $box.wrap.scale(1),
          );
        case PressEvent.idle:
          break;
      }
      return Style(
        $box.color.blue(),
      );
    },
)
```

### Changes

The main components of these changes are the `PressEvent` (`enum`) and the `PressEventMixWidgetState` (`inherited widget`). The enum value is held by `PressEventMixWidgetState` and is updated each time an onTap event occurs.

**Review Checklist**

- [ ] **Testing**: Have you tested your changes, including unit tests and integration tests for affected code?
- [ ] **Breaking Changes**: Does this change introduce breaking changes affecting existing code or users?
- [ ] **Documentation Updates**: Are all relevant documentation files (e.g. README, API docs) updated to reflect the changes in this PR?
- [ ] **Website Updates**: Is the website containing the updates you make on documentation?

### Additional Information (optional)

Is there any additional context or documentation that might be helpful for reviewers?
