### PR TITLE
fix: `canRequestFocus` property on `InteractiveMixStateWidget`

### DIFF
--- a/packages/mix/lib/src/core/widget_state/internal/interactive_mix_state.dart
+++ b/packages/mix/lib/src/core/widget_state/internal/interactive_mix_state.dart
@@ -88,18 +88,21 @@ class _InteractiveStateBuilderState extends State<InteractiveMixStateWidget> {
 
   @override
   Widget build(BuildContext context) {
-    return FocusableActionDetector(
-      enabled: widget.enabled,
-      focusNode: widget.focusNode,
-      autofocus: widget.autofocus,
-      shortcuts: widget.shortcuts,
-      actions: widget.actions,
-      onShowFocusHighlight: _onShowFocusHighlight,
-      onShowHoverHighlight: _onShowHoverHighlight,
-      onFocusChange: widget.onFocusChange,
-      mouseCursor: widget.mouseCursor,
-      includeFocusSemantics: false,
-      child: widget.child,
+    return ExcludeFocus(
+      excluding: !widget.canRequestFocus,
+      child: FocusableActionDetector(
+        enabled: widget.enabled,
+        focusNode: widget.focusNode,
+        autofocus: widget.autofocus,
+        shortcuts: widget.shortcuts,
+        actions: widget.actions,
+        onShowFocusHighlight: _onShowFocusHighlight,
+        onShowHoverHighlight: _onShowHoverHighlight,
+        onFocusChange: widget.onFocusChange,
+        mouseCursor: widget.mouseCursor,
+        includeFocusSemantics: false,
+        child: widget.child,
+      ),
     );
   }
 }


### PR DESCRIPTION
### Description

Fix the implementation of the functionality `canRequestFocus` on `InteractiveMixStateWidget`

### Changes

- Add a ExcludeFocus on `InteractiveMixStateWidget`

**Review Checklist**

- [ ] **Testing**: Have you tested your changes, including unit tests and integration tests for affected code?
- [ ] **Breaking Changes**: Does this change introduce breaking changes affecting existing code or users?
- [ ] **Documentation Updates**: Are all relevant documentation files (e.g. README, API docs) updated to reflect the changes in this PR?
- [ ] **Website Updates**: Is the website containing the updates you make on documentation?
