### PR TITLE
fix: Add ToastLayer on RemixAPp

### DIFF
--- a/packages/remix/lib/src/components/toast/toast_layer.dart
+++ b/packages/remix/lib/src/components/toast/toast_layer.dart
@@ -107,8 +107,14 @@ class ToastLayerState extends State<ToastLayer> implements ToastActions {
   }
 }
 
-void showToast({required BuildContext context, required ToastEntry entry}) {
-  final toastState = context.findAncestorStateOfType<ToastLayerState>();
+void showToast({
+  required BuildContext context,
+  required ToastEntry entry,
+  bool useRootToastLayer = false,
+}) {
+  final toastState = useRootToastLayer
+      ? context.findRootAncestorStateOfType<ToastLayerState>()
+      : context.findAncestorStateOfType<ToastLayerState>();
 
   if (toastState == null) {
     throw FlutterError.fromParts([

--- a/packages/remix/lib/src/core/remix_app.dart
+++ b/packages/remix/lib/src/core/remix_app.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart' as m;
 import 'package:flutter/widgets.dart';
 
+import '../components/toast/toast.dart';
 import 'theme/remix_theme.dart';
 
 //ignore: avoid-unnecessary-stateful-widgets
@@ -123,13 +124,15 @@ class _RemixAppState extends State<RemixApp> {
     return RemixTheme(
       theme: widget.theme,
       darkTheme: widget.darkTheme ?? widget.theme,
-      child: widget.builder != null
-          ? Builder(
-              builder: (BuildContext context) {
-                return widget.builder!(context, child);
-              },
-            )
-          : (child ?? const SizedBox.shrink()),
+      child: ToastLayer(
+        child: widget.builder != null
+            ? Builder(
+                builder: (BuildContext context) {
+                  return widget.builder!(context, child);
+                },
+              )
+            : (child ?? const SizedBox.shrink()),
+      ),
     );
   }
 


### PR DESCRIPTION
#### Related issue

To use the `showToast` method, developers must wrap the component in a Scaffold. However, sometimes, you may need to call `showToast` using the ToastLayer of the WidgetApp, such as the material way.

### Description

Add a `ToastLayer` on Remix app
