### PR TITLE
add positioned

### DIFF
--- a/packages/mix/lib/src/modifiers/internal/render_widget_modifier.dart
+++ b/packages/mix/lib/src/modifiers/internal/render_widget_modifier.dart
@@ -15,6 +15,7 @@ import '../fractionally_sized_box_widget_modifier.dart';
 import '../intrinsic_widget_modifier.dart';
 import '../opacity_widget_modifier.dart';
 import '../padding_widget_modifier.dart';
+import '../positioned_widget_modifier.dart';
 import '../rotated_box_widget_modifier.dart';
 import '../sized_box_widget_modifier.dart';
 import '../transform_widget_modifier.dart';
@@ -25,6 +26,10 @@ const _defaultOrder = [
   // automatically adjust its size to fill the available space. This modifier is applied first to
   // ensure that the widget is not affected by any other modifiers.
   FlexibleModifierSpec,
+
+  // 2. PositionedModifierSpec: Positions the widget within a Stack widget. This modifier must be
+  // applied before any other transformations to ensure that the widget is positioned correctly within the stack.
+  PositionedModifierSpec,
 
   // 2. VisibilityModifier: Controls overall visibility. If the widget is set to be invisible,
   // none of the subsequent decorations are processed, providing an early exit and optimizing performance.

--- a/packages/mix/lib/src/modifiers/positioned_widget_modifier.dart
+++ b/packages/mix/lib/src/modifiers/positioned_widget_modifier.dart
@@ -1,0 +1,104 @@
+// ignore_for_file: prefer-named-boolean-parameters
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:mix_annotations/mix_annotations.dart';
+
+import '../core/attribute.dart';
+import '../core/factory/mix_data.dart';
+import '../core/modifier.dart';
+import '../core/utility.dart';
+
+part 'positioned_widget_modifier.g.dart';
+
+@MixableSpec(skipUtility: true)
+final class PositionedModifierSpec
+    extends WidgetModifierSpec<PositionedModifierSpec>
+    with _$PositionedModifierSpec, Diagnosticable {
+  final num? right;
+  final num? left;
+  final num? top;
+  final num? bottom;
+  final num? width;
+  final num? height;
+  final bool fill;
+
+  const PositionedModifierSpec({
+    this.right,
+    this.left,
+    this.top,
+    this.bottom,
+    this.width,
+    this.height,
+    bool? fill,
+  }) : fill = fill ?? false;
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    _debugFillProperties(properties);
+  }
+
+  @override
+  Widget build(Widget child) {
+    if (fill == true) {
+      return Positioned.fill(
+        bottom: bottom?.toDouble(),
+        top: top?.toDouble(),
+        right: right?.toDouble(),
+        left: left?.toDouble(),
+        child: child,
+      );
+    } else {
+      return Positioned(
+        right: right?.toDouble(),
+        left: left?.toDouble(),
+        top: top?.toDouble(),
+        bottom: bottom?.toDouble(),
+        width: width?.toDouble(),
+        height: height?.toDouble(),
+        child: child,
+      );
+    }
+  }
+}
+
+final class PositionedModifierSpecUtility<T extends Attribute>
+    extends MixUtility<T, PositionedModifierSpecAttribute> {
+  PositionedModifierSpecUtility(super.builder);
+
+  T call({
+    double? right,
+    double? left,
+    double? top,
+    double? bottom,
+    double? width,
+    double? height,
+  }) =>
+      builder(
+        PositionedModifierSpecAttribute(
+          right: right,
+          left: left,
+          top: top,
+          bottom: bottom,
+          width: width,
+          height: height,
+        ),
+      );
+
+  T fill({
+    double? right,
+    double? left,
+    double? top,
+    double? bottom,
+  }) =>
+      builder(
+        PositionedModifierSpecAttribute(
+          right: right,
+          left: left,
+          top: top,
+          bottom: bottom,
+          fill: true,
+        ),
+      );
+}

--- a/packages/mix/lib/src/modifiers/positioned_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/positioned_widget_modifier.g.dart
@@ -1,0 +1,211 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'positioned_widget_modifier.dart';
+
+// **************************************************************************
+// MixableSpecGenerator
+// **************************************************************************
+
+mixin _$PositionedModifierSpec on WidgetModifierSpec<PositionedModifierSpec> {
+  /// Creates a copy of this [PositionedModifierSpec] but with the given fields
+  /// replaced with the new values.
+  @override
+  PositionedModifierSpec copyWith({
+    num? right,
+    num? left,
+    num? top,
+    num? bottom,
+    num? width,
+    num? height,
+  }) {
+    return PositionedModifierSpec(
+      right: right ?? _$this.right,
+      left: left ?? _$this.left,
+      top: top ?? _$this.top,
+      bottom: bottom ?? _$this.bottom,
+      width: width ?? _$this.width,
+      height: height ?? _$this.height,
+    );
+  }
+
+  /// Linearly interpolates between this [PositionedModifierSpec] and another [PositionedModifierSpec] based on the given parameter [t].
+  ///
+  /// The parameter [t] represents the interpolation factor, typically ranging from 0.0 to 1.0.
+  /// When [t] is 0.0, the current [PositionedModifierSpec] is returned. When [t] is 1.0, the [other] [PositionedModifierSpec] is returned.
+  /// For values of [t] between 0.0 and 1.0, an interpolated [PositionedModifierSpec] is returned.
+  ///
+  /// If [other] is null, this method returns the current [PositionedModifierSpec] instance.
+  ///
+  /// The interpolation is performed on each property of the [PositionedModifierSpec] using the appropriate
+  /// interpolation method:
+  ///
+
+  /// For [right] and [left] and [top] and [bottom] and [width] and [height], the interpolation is performed using a step function.
+  /// If [t] is less than 0.5, the value from the current [PositionedModifierSpec] is used. Otherwise, the value
+  /// from the [other] [PositionedModifierSpec] is used.
+  ///
+  /// This method is typically used in animations to smoothly transition between
+  /// different [PositionedModifierSpec] configurations.
+  @override
+  PositionedModifierSpec lerp(PositionedModifierSpec? other, double t) {
+    if (other == null) return _$this;
+
+    return PositionedModifierSpec(
+      right: t < 0.5 ? _$this.right : other.right,
+      left: t < 0.5 ? _$this.left : other.left,
+      top: t < 0.5 ? _$this.top : other.top,
+      bottom: t < 0.5 ? _$this.bottom : other.bottom,
+      width: t < 0.5 ? _$this.width : other.width,
+      height: t < 0.5 ? _$this.height : other.height,
+    );
+  }
+
+  /// The list of properties that constitute the state of this [PositionedModifierSpec].
+  ///
+  /// This property is used by the [==] operator and the [hashCode] getter to
+  /// compare two [PositionedModifierSpec] instances for equality.
+  @override
+  List<Object?> get props => [
+        _$this.right,
+        _$this.left,
+        _$this.top,
+        _$this.bottom,
+        _$this.width,
+        _$this.height,
+      ];
+
+  PositionedModifierSpec get _$this => this as PositionedModifierSpec;
+
+  void _debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    properties
+        .add(DiagnosticsProperty('right', _$this.right, defaultValue: null));
+    properties
+        .add(DiagnosticsProperty('left', _$this.left, defaultValue: null));
+    properties.add(DiagnosticsProperty('top', _$this.top, defaultValue: null));
+    properties
+        .add(DiagnosticsProperty('bottom', _$this.bottom, defaultValue: null));
+    properties
+        .add(DiagnosticsProperty('width', _$this.width, defaultValue: null));
+    properties
+        .add(DiagnosticsProperty('height', _$this.height, defaultValue: null));
+  }
+}
+
+/// Represents the attributes of a [PositionedModifierSpec].
+///
+/// This class encapsulates properties defining the layout and
+/// appearance of a [PositionedModifierSpec].
+///
+/// Use this class to configure the attributes of a [PositionedModifierSpec] and pass it to
+/// the [PositionedModifierSpec] constructor.
+final class PositionedModifierSpecAttribute
+    extends WidgetModifierSpecAttribute<PositionedModifierSpec>
+    with Diagnosticable {
+  final num? right;
+  final num? left;
+  final num? top;
+  final num? bottom;
+  final num? width;
+  final num? height;
+
+  const PositionedModifierSpecAttribute({
+    this.right,
+    this.left,
+    this.top,
+    this.bottom,
+    this.width,
+    this.height,
+  });
+
+  /// Resolves to [PositionedModifierSpec] using the provided [MixData].
+  ///
+  /// If a property is null in the [MixData], it falls back to the
+  /// default value defined in the `defaultValue` for that property.
+  ///
+  /// ```dart
+  /// final positionedModifierSpec = PositionedModifierSpecAttribute(...).resolve(mix);
+  /// ```
+  @override
+  PositionedModifierSpec resolve(MixData mix) {
+    return PositionedModifierSpec(
+      right: right,
+      left: left,
+      top: top,
+      bottom: bottom,
+      width: width,
+      height: height,
+    );
+  }
+
+  /// Merges the properties of this [PositionedModifierSpecAttribute] with the properties of [other].
+  ///
+  /// If [other] is null, returns this instance unchanged. Otherwise, returns a new
+  /// [PositionedModifierSpecAttribute] with the properties of [other] taking precedence over
+  /// the corresponding properties of this instance.
+  ///
+  /// Properties from [other] that are null will fall back
+  /// to the values from this instance.
+  @override
+  PositionedModifierSpecAttribute merge(
+      PositionedModifierSpecAttribute? other) {
+    if (other == null) return this;
+
+    return PositionedModifierSpecAttribute(
+      right: other.right ?? right,
+      left: other.left ?? left,
+      top: other.top ?? top,
+      bottom: other.bottom ?? bottom,
+      width: other.width ?? width,
+      height: other.height ?? height,
+    );
+  }
+
+  /// The list of properties that constitute the state of this [PositionedModifierSpecAttribute].
+  ///
+  /// This property is used by the [==] operator and the [hashCode] getter to
+  /// compare two [PositionedModifierSpecAttribute] instances for equality.
+  @override
+  List<Object?> get props => [
+        right,
+        left,
+        top,
+        bottom,
+        width,
+        height,
+      ];
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty('right', right, defaultValue: null));
+    properties.add(DiagnosticsProperty('left', left, defaultValue: null));
+    properties.add(DiagnosticsProperty('top', top, defaultValue: null));
+    properties.add(DiagnosticsProperty('bottom', bottom, defaultValue: null));
+    properties.add(DiagnosticsProperty('width', width, defaultValue: null));
+    properties.add(DiagnosticsProperty('height', height, defaultValue: null));
+  }
+}
+
+/// A tween that interpolates between two [PositionedModifierSpec] instances.
+///
+/// This class can be used in animations to smoothly transition between
+/// different [PositionedModifierSpec] specifications.
+class PositionedModifierSpecTween extends Tween<PositionedModifierSpec?> {
+  PositionedModifierSpecTween({
+    super.begin,
+    super.end,
+  });
+
+  @override
+  PositionedModifierSpec lerp(double t) {
+    if (begin == null && end == null) {
+      return const PositionedModifierSpec();
+    }
+
+    if (begin == null) {
+      return end!;
+    }
+
+    return begin!.lerp(end!, t);
+  }
+}

--- a/packages/mix/lib/src/modifiers/positioned_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/positioned_widget_modifier.g.dart
@@ -17,6 +17,7 @@ mixin _$PositionedModifierSpec on WidgetModifierSpec<PositionedModifierSpec> {
     num? bottom,
     num? width,
     num? height,
+    bool? fill,
   }) {
     return PositionedModifierSpec(
       right: right ?? _$this.right,
@@ -25,6 +26,7 @@ mixin _$PositionedModifierSpec on WidgetModifierSpec<PositionedModifierSpec> {
       bottom: bottom ?? _$this.bottom,
       width: width ?? _$this.width,
       height: height ?? _$this.height,
+      fill: fill ?? _$this.fill,
     );
   }
 
@@ -40,7 +42,7 @@ mixin _$PositionedModifierSpec on WidgetModifierSpec<PositionedModifierSpec> {
   /// interpolation method:
   ///
 
-  /// For [right] and [left] and [top] and [bottom] and [width] and [height], the interpolation is performed using a step function.
+  /// For [right] and [left] and [top] and [bottom] and [width] and [height] and [fill], the interpolation is performed using a step function.
   /// If [t] is less than 0.5, the value from the current [PositionedModifierSpec] is used. Otherwise, the value
   /// from the [other] [PositionedModifierSpec] is used.
   ///
@@ -57,6 +59,7 @@ mixin _$PositionedModifierSpec on WidgetModifierSpec<PositionedModifierSpec> {
       bottom: t < 0.5 ? _$this.bottom : other.bottom,
       width: t < 0.5 ? _$this.width : other.width,
       height: t < 0.5 ? _$this.height : other.height,
+      fill: t < 0.5 ? _$this.fill : other.fill,
     );
   }
 
@@ -72,6 +75,7 @@ mixin _$PositionedModifierSpec on WidgetModifierSpec<PositionedModifierSpec> {
         _$this.bottom,
         _$this.width,
         _$this.height,
+        _$this.fill,
       ];
 
   PositionedModifierSpec get _$this => this as PositionedModifierSpec;
@@ -88,6 +92,8 @@ mixin _$PositionedModifierSpec on WidgetModifierSpec<PositionedModifierSpec> {
         .add(DiagnosticsProperty('width', _$this.width, defaultValue: null));
     properties
         .add(DiagnosticsProperty('height', _$this.height, defaultValue: null));
+    properties
+        .add(DiagnosticsProperty('fill', _$this.fill, defaultValue: null));
   }
 }
 
@@ -107,6 +113,7 @@ final class PositionedModifierSpecAttribute
   final num? bottom;
   final num? width;
   final num? height;
+  final bool? fill;
 
   const PositionedModifierSpecAttribute({
     this.right,
@@ -115,6 +122,7 @@ final class PositionedModifierSpecAttribute
     this.bottom,
     this.width,
     this.height,
+    this.fill,
   });
 
   /// Resolves to [PositionedModifierSpec] using the provided [MixData].
@@ -134,6 +142,7 @@ final class PositionedModifierSpecAttribute
       bottom: bottom,
       width: width,
       height: height,
+      fill: fill,
     );
   }
 
@@ -157,6 +166,7 @@ final class PositionedModifierSpecAttribute
       bottom: other.bottom ?? bottom,
       width: other.width ?? width,
       height: other.height ?? height,
+      fill: other.fill ?? fill,
     );
   }
 
@@ -172,6 +182,7 @@ final class PositionedModifierSpecAttribute
         bottom,
         width,
         height,
+        fill,
       ];
 
   @override
@@ -183,6 +194,7 @@ final class PositionedModifierSpecAttribute
     properties.add(DiagnosticsProperty('bottom', bottom, defaultValue: null));
     properties.add(DiagnosticsProperty('width', width, defaultValue: null));
     properties.add(DiagnosticsProperty('height', height, defaultValue: null));
+    properties.add(DiagnosticsProperty('fill', fill, defaultValue: null));
   }
 }
 

--- a/packages/mix/lib/src/modifiers/widget_modifiers_util.dart
+++ b/packages/mix/lib/src/modifiers/widget_modifiers_util.dart
@@ -10,6 +10,7 @@ import 'intrinsic_widget_modifier.dart';
 import 'mouse_cursor_modifier.dart';
 import 'opacity_widget_modifier.dart';
 import 'padding_widget_modifier.dart';
+import 'positioned_widget_modifier.dart';
 import 'rotated_box_widget_modifier.dart';
 import 'scroll_view_widget_modifier.dart';
 import 'sized_box_widget_modifier.dart';
@@ -42,6 +43,7 @@ abstract class ModifierUtility<T extends Attribute, Value>
   late final sizedBox = SizedBoxModifierSpecUtility(only);
   late final cursor = MouseCursorModifierSpecUtility(only);
   late final padding = PaddingModifierSpecUtility(only).padding;
+  late final positioned = PositionedModifierSpecUtility(only);
 
   /// This modifier wraps the widget with a [SingleChildScrollView].
   late final scrollView = ScrollViewModifierSpecUtility(only);

--- a/packages/mix/test/src/modifiers/positioned_widget_modifier_test.dart
+++ b/packages/mix/test/src/modifiers/positioned_widget_modifier_test.dart
@@ -1,0 +1,160 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mix/src/modifiers/positioned_widget_modifier.dart';
+
+import '../../helpers/testing_utils.dart';
+
+void main() {
+  group('PositionedModifierSpec', () {
+    test('Constructor assigns values correctly', () {
+      const bottom = 0;
+      const top = 1.0;
+      const left = 2;
+      const right = 3;
+      const width = 4;
+      const height = 5;
+      const modifier = PositionedModifierSpec(
+        bottom: bottom,
+        top: top,
+        left: left,
+        right: right,
+        width: width,
+        height: height,
+      );
+      expect(modifier.bottom, bottom);
+      expect(modifier.top, top);
+      expect(modifier.left, left);
+      expect(modifier.right, right);
+      expect(modifier.width, width);
+      expect(modifier.height, height);
+    });
+
+    test('Lerp method interpolates correctly', () {
+      const start = PositionedModifierSpec(
+        bottom: 0,
+        top: 1.0,
+        left: 2,
+        right: 3,
+        width: 4,
+        height: 5,
+      );
+
+      const end = PositionedModifierSpec(
+        bottom: 6,
+        top: 7.0,
+        left: 8,
+        right: 9,
+        width: 10,
+        height: 11,
+      );
+      final result = start.lerp(end, 0.5);
+      expect(result.bottom, 3);
+      expect(result.top, 4.0);
+      expect(result.left, 5);
+      expect(result.right, 6);
+      expect(result.width, 7);
+      expect(result.height, 8);
+    });
+
+    test('Equality and hashcode test', () {
+      const modifier1 = PositionedModifierSpec(
+        bottom: 0,
+        top: 1.0,
+        left: 2,
+        right: 3,
+        width: 4,
+        height: 5,
+      );
+      const modifier2 = PositionedModifierSpec(
+        bottom: 0,
+        top: 1.0,
+        left: 2,
+        right: 3,
+        width: 4,
+        height: 5,
+      );
+      const modifier3 = PositionedModifierSpec(
+        bottom: null,
+        top: null,
+        left: null,
+        right: null,
+        width: null,
+        height: null,
+      );
+
+      expect(modifier1, modifier2);
+      expect(modifier1.hashCode, modifier2.hashCode);
+      expect(modifier1 == modifier3, false);
+      expect(modifier1.hashCode == modifier3.hashCode, false);
+    });
+
+    testWidgets(
+      'Build method creates Flexible widget with correct flex and fit',
+      (WidgetTester tester) async {
+        const bottom = 0;
+        const top = 1.0;
+        const left = 2;
+        const right = 3;
+        const width = 4;
+        const height = 5;
+        const modifier = PositionedModifierSpec(
+          bottom: bottom,
+          top: top,
+          left: left,
+          right: right,
+          width: width,
+          height: height,
+        );
+
+        await tester.pumpMaterialApp(
+          Row(children: [modifier.build(Container())]),
+        );
+
+        final Positioned flexibleWidget =
+            tester.widget(find.byType(Positioned));
+
+        expect(find.byType(Positioned), findsOneWidget);
+        expect(flexibleWidget.bottom, bottom.toDouble());
+        expect(flexibleWidget.top, top.toDouble());
+        expect(flexibleWidget.left, left.toDouble());
+        expect(flexibleWidget.right, right.toDouble());
+        expect(flexibleWidget.width, width.toDouble());
+        expect(flexibleWidget.height, height.toDouble());
+      },
+    );
+  });
+
+  group('PositionedModifierSpecAttribute', () {
+    test('merge', () {
+      const modifier = PositionedModifierSpecAttribute(
+          right: 1, top: 2, width: 3, height: 4);
+      const other = PositionedModifierSpecAttribute(
+          right: 1, top: 2, width: 3, height: 4);
+      final result = modifier.merge(other);
+      expect(result, modifier);
+    });
+
+    test('resolve', () {
+      const modifier = PositionedModifierSpecAttribute();
+      final result = modifier.resolve(EmptyMixData);
+      expect(result, isA<PositionedModifierSpec>());
+    });
+
+    // equality
+    test('equality', () {
+      const modifier = PositionedModifierSpecAttribute(
+          right: 1, top: 2, width: 3, height: 4);
+      const other = PositionedModifierSpecAttribute(
+          right: 1, top: 2, width: 3, height: 4);
+      expect(modifier, other);
+    });
+
+    test('inequality', () {
+      const modifier = PositionedModifierSpecAttribute(
+          right: 1, top: 2, width: 3, height: 4);
+      const other = PositionedModifierSpecAttribute(
+          right: 1, top: 2, width: 3, height: 5);
+      expect(modifier, isNot(other));
+    });
+  });
+}

--- a/packages/mix/test/src/modifiers/positioned_widget_modifier_test.dart
+++ b/packages/mix/test/src/modifiers/positioned_widget_modifier_test.dart
@@ -89,7 +89,7 @@ void main() {
     });
 
     testWidgets(
-      'Build method creates Flexible widget with correct flex and fit',
+      'Build method creates Positioned widget with correct positioning properties',
       (WidgetTester tester) async {
         const bottom = 0;
         const top = 1.0;

--- a/packages/mix/test/src/modifiers/widget_modifiers_util_test.dart
+++ b/packages/mix/test/src/modifiers/widget_modifiers_util_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mix/mix.dart';
 import 'package:mix/src/modifiers/internal/render_widget_modifier.dart';
+import 'package:mix/src/modifiers/positioned_widget_modifier.dart';
 
 import '../../empty_widget.dart';
 import '../../helpers/testing_utils.dart';
@@ -23,6 +24,7 @@ void main() {
     const clipTriangle =
         ClipTriangleModifierSpecUtility(UtilityTestAttribute.new);
     final sizedBox = SizedBoxModifierSpecUtility(UtilityTestAttribute.new);
+    final positioned = PositionedModifierSpecUtility(UtilityTestAttribute.new);
     const fractionallySizedBox =
         FractionallySizedBoxModifierSpecUtility(UtilityTestAttribute.new);
     const intrinsicHeight =
@@ -168,6 +170,29 @@ void main() {
 
       expect(widget.width, 100);
       expect(widget.height, 100);
+    });
+
+    test('positioned creates PositionedModifier correctly', () {
+      final positionedModifier = positioned(width: 50, height: 60, top: 50);
+
+      final widget = positionedModifier.value
+          .resolve(EmptyMixData)
+          .build(const Empty()) as Positioned;
+
+      expect(widget.width, 50);
+      expect(widget.height, 60);
+      expect(widget.top, 50);
+    });
+    test('positioned.fill creates PositionedModifier correctly', () {
+      final positionedModifier = positioned.fill(top: 50);
+
+      final widget = positionedModifier.value
+          .resolve(EmptyMixData)
+          .build(const Empty()) as Positioned;
+
+      expect(widget.top, 50);
+      expect(widget.height, null);
+      expect(widget.width, null);
     });
 
     test(
@@ -410,6 +435,39 @@ void main() {
         );
 
         _expectOneWidgetOfType<SizedBox>();
+      },
+    );
+    testWidgets(
+      'Applying a positioned must add a Positioned widget in the widget tree',
+      (tester) async {
+        await tester.pumpWidget(Directionality(
+          textDirection: TextDirection.ltr,
+          child: Stack(
+            children: [
+              _TestableRenderModifier(
+                Style(
+                  $with.positioned(),
+                ),
+              ),
+            ],
+          ),
+        ));
+
+        _expectOneWidgetOfType<Positioned>();
+
+        await tester.pumpWidget(Directionality(
+          textDirection: TextDirection.ltr,
+          child: Stack(
+            children: [
+              _TestableRenderModifier(
+                Style(
+                  $with.positioned.fill(),
+                ),
+              ),
+            ],
+          ),
+        ));
+        _expectOneWidgetOfType<Positioned>();
       },
     );
   });


### PR DESCRIPTION
#### Related issue

No

### Description

Create a modifier for wrapping a widget in a Positioned so that it can be used to position a widget in a stack

### Changes

- Create `PositionedModifierSpec`
- Add to top of modifier order (`_defaultOrder`)
- Create tests
- Add to the `ModifierUtility`

**Review Checklist**

- [x] **Testing**: Have you tested your changes, including unit tests and integration tests for affected code?
- [ ] **Breaking Changes**: Does this change introduce breaking changes affecting existing code or users?
- [ ] **Documentation Updates**: Are all relevant documentation files (e.g. README, API docs) updated to reflect the changes in this PR?
- [ ] **Website Updates**: Is the website containing the updates you make on documentation?

### Additional Information (optional)

Is there any additional context or documentation that might be helpful for reviewers?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a flexible widget positioning modifier that offers precise control over placement and sizing, including an option to expand fully.
  - Enhanced the modifier utility to integrate positioning features for improved layout management.

- **Tests**
  - Added comprehensive tests to validate the new positioning functionality, ensuring smooth transitions and correct behavior during widget rendering.
  - Implemented tests for the `PositionedModifierSpecUtility` to verify correct widget creation and integration within the widget tree.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->