### PR TITLE
refactor: Use WidgetState instead of MixWidgetState

### DIFF
--- a/packages/mix/example/.gitignore
+++ b/packages/mix/example/.gitignore
@@ -5,9 +5,11 @@
 *.swp
 .DS_Store
 .atom/
+.build/
 .buildlog/
 .history
 .svn/
+.swiftpm/
 migrate_working_dir/
 
 # IntelliJ related

--- a/packages/mix/lib/src/attributes/scalars/scalar_util.dart
+++ b/packages/mix/lib/src/attributes/scalars/scalar_util.dart
@@ -67,7 +67,7 @@ final class DurationUtility<T extends Attribute> extends MixUtility<T, Duration>
 }
 
 final class FontSizeUtility<T extends Attribute> extends SizingUtility<T> {
-  FontSizeUtility(super.builder);
+  const FontSizeUtility(super.builder);
 }
 
 @MixableUtility()

--- a/packages/mix/lib/src/core/element.dart
+++ b/packages/mix/lib/src/core/element.dart
@@ -45,7 +45,7 @@ mixin HasDefaultValue<Value> {
 abstract class DtoUtility<A extends Attribute, D extends Mixable<Value>, Value>
     extends MixUtility<A, D> {
   final D Function(Value) _fromValue;
-  DtoUtility(super.builder, {required D Function(Value) valueToDto})
+  const DtoUtility(super.builder, {required D Function(Value) valueToDto})
       : _fromValue = valueToDto;
 
   A only();

--- a/packages/mix/lib/src/core/utility.dart
+++ b/packages/mix/lib/src/core/utility.dart
@@ -85,5 +85,5 @@ final class BoolUtility<T extends Attribute> extends ScalarUtility<T, bool> {
 /// This class extends [DoubleUtility] and serves as a base for more specific sizing utilities.
 abstract base class SizingUtility<T extends Attribute>
     extends ScalarUtility<T, double> {
-  SizingUtility(super.builder);
+  const SizingUtility(super.builder);
 }

--- a/packages/mix/lib/src/core/widget_state/internal/gesture_mix_state.dart
+++ b/packages/mix/lib/src/core/widget_state/internal/gesture_mix_state.dart
@@ -87,11 +87,18 @@ class _GestureMixStateWidgetState extends State<GestureMixStateWidget> {
   int _pressCount = 0;
   Timer? _timer;
   late final MixWidgetStateController _controller;
+  bool _longPressed = false;
 
   @override
   void initState() {
     super.initState();
     _controller = widget.controller ?? MixWidgetStateController();
+  }
+
+  void _setLongPressed(bool value) {
+    setState(() {
+      _longPressed = value;
+    });
   }
 
   void _onPanUpdate(DragUpdateDetails event) {
@@ -117,27 +124,27 @@ class _GestureMixStateWidgetState extends State<GestureMixStateWidget> {
   }
 
   void _onTapUp(TapUpDetails details) {
-    _controller.longPressed = false;
+    _setLongPressed(false);
     widget.onTapUp?.call(details);
   }
 
   void _onTapCancel() {
-    _controller.longPressed = false;
+    _setLongPressed(false);
     widget.onTapCancel?.call();
   }
 
   void _onLongPressStart(LongPressStartDetails details) {
-    _controller.longPressed = true;
+    _setLongPressed(true);
     widget.onLongPressStart?.call(details);
   }
 
   void _onLongPressEnd(LongPressEndDetails details) {
-    _controller.longPressed = false;
+    _setLongPressed(false);
     widget.onLongPressEnd?.call(details);
   }
 
   void _onLongPressCancel() {
-    _controller.longPressed = false;
+    _setLongPressed(false);
     widget.onLongPressCancel?.call();
   }
 
@@ -188,22 +195,52 @@ class _GestureMixStateWidgetState extends State<GestureMixStateWidget> {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTapUp: widget.onTap != null ? _onTapUp : null,
-      onTap: widget.onTap != null ? _onTap : null,
-      onTapCancel: widget.onTap != null ? _onTapCancel : null,
-      onLongPressCancel: widget.onLongPress != null ? _onLongPressCancel : null,
-      onLongPress: widget.onLongPress != null ? _onLongPress : null,
-      onLongPressStart: widget.onLongPress != null ? _onLongPressStart : null,
-      onLongPressEnd: widget.onLongPress != null ? _onLongPressEnd : null,
-      onPanDown: widget.onPanDown != null ? _onPanDown : null,
-      onPanStart: widget.onPanStart != null ? _onPanStart : null,
-      onPanUpdate: widget.onPanUpdate != null ? _onPanUpdate : null,
-      onPanEnd: widget.onPanEnd != null ? _onPanEnd : null,
-      onPanCancel: widget.onPanCancel != null ? _onPanCancel : null,
-      behavior: widget.hitTestBehavior,
-      excludeFromSemantics: widget.excludeFromSemantics,
-      child: widget.child,
+    return LongPressInheritedState(
+      longPressed: _longPressed,
+      child: GestureDetector(
+        onTapUp: widget.onTap != null ? _onTapUp : null,
+        onTap: widget.onTap != null ? _onTap : null,
+        onTapCancel: widget.onTap != null ? _onTapCancel : null,
+        onLongPressCancel:
+            widget.onLongPress != null ? _onLongPressCancel : null,
+        onLongPress: widget.onLongPress != null ? _onLongPress : null,
+        onLongPressStart: widget.onLongPress != null ? _onLongPressStart : null,
+        onLongPressEnd: widget.onLongPress != null ? _onLongPressEnd : null,
+        onPanDown: widget.onPanDown != null ? _onPanDown : null,
+        onPanStart: widget.onPanStart != null ? _onPanStart : null,
+        onPanUpdate: widget.onPanUpdate != null ? _onPanUpdate : null,
+        onPanEnd: widget.onPanEnd != null ? _onPanEnd : null,
+        onPanCancel: widget.onPanCancel != null ? _onPanCancel : null,
+        behavior: widget.hitTestBehavior,
+        excludeFromSemantics: widget.excludeFromSemantics,
+        child: widget.child,
+      ),
     );
+  }
+}
+
+class LongPressInheritedState extends InheritedWidget {
+  const LongPressInheritedState({
+    super.key,
+    required super.child,
+    required this.longPressed,
+  });
+
+  static LongPressInheritedState? maybeOf(BuildContext context) {
+    return context.dependOnInheritedWidgetOfExactType();
+  }
+
+  static LongPressInheritedState of(BuildContext context) {
+    final LongPressInheritedState? result = maybeOf(context);
+    assert(result != null, 'No LongPressVariantController found in context');
+
+    return result!;
+  }
+
+  final bool longPressed;
+
+  @override
+  bool updateShouldNotify(LongPressInheritedState oldWidget) {
+    return oldWidget.longPressed != longPressed;
   }
 }

--- a/packages/mix/lib/src/core/widget_state/internal/mix_widget_state_builder.dart
+++ b/packages/mix/lib/src/core/widget_state/internal/mix_widget_state_builder.dart
@@ -26,7 +26,6 @@ class MixWidgetStateBuilder extends StatelessWidget {
           dragged: controller.dragged,
           selected: controller.selected,
           error: controller.error,
-          longPressed: controller.longPressed,
           child: Builder(builder: builder),
         );
       },
@@ -44,7 +43,6 @@ class MixWidgetStateModel extends InheritedModel<MixWidgetState> {
     required this.dragged,
     required this.selected,
     required this.error,
-    required this.longPressed,
     required super.child,
   });
 
@@ -71,7 +69,6 @@ class MixWidgetStateModel extends InheritedModel<MixWidgetState> {
       MixWidgetState.pressed => model.pressed,
       MixWidgetState.dragged => model.dragged,
       MixWidgetState.selected => model.selected,
-      MixWidgetState.longPressed => model.longPressed,
       MixWidgetState.error => model.error,
     };
   }
@@ -80,7 +77,6 @@ class MixWidgetStateModel extends InheritedModel<MixWidgetState> {
   final bool hovered;
   final bool focused;
   final bool pressed;
-  final bool longPressed;
   final bool dragged;
   final bool selected;
   final bool error;
@@ -93,7 +89,6 @@ class MixWidgetStateModel extends InheritedModel<MixWidgetState> {
         oldWidget.pressed != pressed ||
         oldWidget.dragged != dragged ||
         oldWidget.selected != selected ||
-        oldWidget.longPressed != longPressed ||
         oldWidget.error != error;
   }
 
@@ -114,8 +109,6 @@ class MixWidgetStateModel extends InheritedModel<MixWidgetState> {
             dependencies.contains(MixWidgetState.dragged) ||
         oldWidget.selected != selected &&
             dependencies.contains(MixWidgetState.selected) ||
-        oldWidget.longPressed != longPressed &&
-            dependencies.contains(MixWidgetState.longPressed) ||
         oldWidget.error != error && dependencies.contains(MixWidgetState.error);
   }
 }

--- a/packages/mix/lib/src/core/widget_state/internal/mix_widget_state_builder.dart
+++ b/packages/mix/lib/src/core/widget_state/internal/mix_widget_state_builder.dart
@@ -67,7 +67,7 @@ class MixWidgetStateModel extends InheritedModel<WidgetState> {
       WidgetState.dragged => model.dragged,
       WidgetState.selected => model.selected,
       WidgetState.error => model.error,
-      _ => false,
+      WidgetState.scrolledUnder => false,
     };
   }
 

--- a/packages/mix/lib/src/core/widget_state/internal/mix_widget_state_builder.dart
+++ b/packages/mix/lib/src/core/widget_state/internal/mix_widget_state_builder.dart
@@ -33,7 +33,7 @@ class MixWidgetStateBuilder extends StatelessWidget {
   }
 }
 
-class MixWidgetStateModel extends InheritedModel<MixWidgetState> {
+class MixWidgetStateModel extends InheritedModel<WidgetState> {
   const MixWidgetStateModel({
     super.key,
     required this.disabled,
@@ -46,30 +46,28 @@ class MixWidgetStateModel extends InheritedModel<MixWidgetState> {
     required super.child,
   });
 
-  static MixWidgetStateModel? of(
-    BuildContext context, [
-    MixWidgetState? state,
-  ]) {
+  static MixWidgetStateModel? of(BuildContext context, [WidgetState? state]) {
     return InheritedModel.inheritFrom<MixWidgetStateModel>(
       context,
       aspect: state,
     );
   }
 
-  static bool hasStateOf(BuildContext context, MixWidgetState state) {
+  static bool hasStateOf(BuildContext context, WidgetState state) {
     final model = of(context, state);
     if (model == null) {
       return false;
     }
 
     return switch (state) {
-      MixWidgetState.disabled => model.disabled,
-      MixWidgetState.hovered => model.hovered,
-      MixWidgetState.focused => model.focused,
-      MixWidgetState.pressed => model.pressed,
-      MixWidgetState.dragged => model.dragged,
-      MixWidgetState.selected => model.selected,
-      MixWidgetState.error => model.error,
+      WidgetState.disabled => model.disabled,
+      WidgetState.hovered => model.hovered,
+      WidgetState.focused => model.focused,
+      WidgetState.pressed => model.pressed,
+      WidgetState.dragged => model.dragged,
+      WidgetState.selected => model.selected,
+      WidgetState.error => model.error,
+      _ => false,
     };
   }
 
@@ -95,20 +93,20 @@ class MixWidgetStateModel extends InheritedModel<MixWidgetState> {
   @override
   bool updateShouldNotifyDependent(
     MixWidgetStateModel oldWidget,
-    Set<MixWidgetState> dependencies,
+    Set<WidgetState> dependencies,
   ) {
     return oldWidget.disabled != disabled &&
-            dependencies.contains(MixWidgetState.disabled) ||
+            dependencies.contains(WidgetState.disabled) ||
         oldWidget.hovered != hovered &&
-            dependencies.contains(MixWidgetState.hovered) ||
+            dependencies.contains(WidgetState.hovered) ||
         oldWidget.focused != focused &&
-            dependencies.contains(MixWidgetState.focused) ||
+            dependencies.contains(WidgetState.focused) ||
         oldWidget.pressed != pressed &&
-            dependencies.contains(MixWidgetState.pressed) ||
+            dependencies.contains(WidgetState.pressed) ||
         oldWidget.dragged != dragged &&
-            dependencies.contains(MixWidgetState.dragged) ||
+            dependencies.contains(WidgetState.dragged) ||
         oldWidget.selected != selected &&
-            dependencies.contains(MixWidgetState.selected) ||
-        oldWidget.error != error && dependencies.contains(MixWidgetState.error);
+            dependencies.contains(WidgetState.selected) ||
+        oldWidget.error != error && dependencies.contains(WidgetState.error);
   }
 }

--- a/packages/mix/lib/src/core/widget_state/widget_state_controller.dart
+++ b/packages/mix/lib/src/core/widget_state/widget_state_controller.dart
@@ -2,15 +2,7 @@ import "package:flutter/material.dart";
 
 import "internal/mix_widget_state_builder.dart";
 
-enum MixWidgetState {
-  hovered,
-  focused,
-  pressed,
-  dragged,
-  selected,
-  disabled,
-  error;
-
+extension MixWidgetState on WidgetState {
   static const of = MixWidgetStateModel.of;
   static const hasStateOf = MixWidgetStateModel.hasStateOf;
 }
@@ -29,56 +21,56 @@ class MixWidgetStateController extends ChangeNotifier {
   /// This is annotated with `@visibleForTesting` to indicate that it is
   /// accessible for testing purposes.
   @visibleForTesting
-  Set<MixWidgetState> value = {};
+  Set<WidgetState> value = {};
 
   /// Whether the widget is currently in the disabled state.
-  bool get disabled => value.contains(MixWidgetState.disabled);
+  bool get disabled => value.contains(WidgetState.disabled);
 
   /// Whether the widget is currently being hovered over.
-  bool get hovered => value.contains(MixWidgetState.hovered);
+  bool get hovered => value.contains(WidgetState.hovered);
 
   /// Whether the widget currently has focus.
-  bool get focused => value.contains(MixWidgetState.focused);
+  bool get focused => value.contains(WidgetState.focused);
 
   /// Whether the widget is currently being pressed.
-  bool get pressed => value.contains(MixWidgetState.pressed);
+  bool get pressed => value.contains(WidgetState.pressed);
 
   /// Whether the widget is currently being dragged.
-  bool get dragged => value.contains(MixWidgetState.dragged);
+  bool get dragged => value.contains(WidgetState.dragged);
 
   /// Whether the widget is currently in the selected state.
-  bool get selected => value.contains(MixWidgetState.selected);
+  bool get selected => value.contains(WidgetState.selected);
 
   /// Whether the widget is currently in the error state.
-  bool get error => value.contains(MixWidgetState.error);
+  bool get error => value.contains(WidgetState.error);
 
   /// Sets whether the widget is in the disabled state.
-  set disabled(bool value) => update(MixWidgetState.disabled, value);
+  set disabled(bool value) => update(WidgetState.disabled, value);
 
   /// Sets whether the widget is being hovered over.
-  set hovered(bool value) => update(MixWidgetState.hovered, value);
+  set hovered(bool value) => update(WidgetState.hovered, value);
 
   /// Sets whether the widget has focus.
-  set focused(bool value) => update(MixWidgetState.focused, value);
+  set focused(bool value) => update(WidgetState.focused, value);
 
   /// Sets whether the widget is being pressed.
-  set pressed(bool value) => update(MixWidgetState.pressed, value);
+  set pressed(bool value) => update(WidgetState.pressed, value);
 
   /// Sets whether the widget is being dragged.
-  set dragged(bool value) => update(MixWidgetState.dragged, value);
+  set dragged(bool value) => update(WidgetState.dragged, value);
 
   /// Sets whether the widget is in the selected state.
-  set selected(bool value) => update(MixWidgetState.selected, value);
+  set selected(bool value) => update(WidgetState.selected, value);
 
   /// Sets whether the widget is in the selected state.
-  set error(bool value) => update(MixWidgetState.error, value);
+  set error(bool value) => update(WidgetState.error, value);
 
   /// Updates the state of the widget for a given [key].
   ///
   /// If [add] is true, the [key] state is added to [value]. If false, it is
   /// removed. Listeners are notified if the state has changed.
   // ignore: prefer-named-boolean-parameters
-  void update(MixWidgetState key, bool add) {
+  void update(WidgetState key, bool add) {
     final valueHasChanged = add ? value.add(key) : value.remove(key);
 
     if (valueHasChanged) {
@@ -91,7 +83,7 @@ class MixWidgetStateController extends ChangeNotifier {
   /// [updates] is a list of tuples, where each tuple contains a state [key]
   /// and a boolean [add] indicating whether to add or remove the state.
   /// Listeners are notified if any state has changed.
-  void batch(List<(MixWidgetState, bool)> updates) {
+  void batch(List<(WidgetState, bool)> updates) {
     var valueHasChanged = false;
     for (final update in updates) {
       final key = update.$1;
@@ -109,5 +101,5 @@ class MixWidgetStateController extends ChangeNotifier {
   }
 
   /// Checks if the widget is currently in the given state [key].
-  bool has(MixWidgetState key) => value.contains(key);
+  bool has(WidgetState key) => value.contains(key);
 }

--- a/packages/mix/lib/src/core/widget_state/widget_state_controller.dart
+++ b/packages/mix/lib/src/core/widget_state/widget_state_controller.dart
@@ -10,8 +10,8 @@ extension MixWidgetState on WidgetState {
 /// A controller that manages the state of a widget.
 ///
 /// [MixWidgetStateController] tracks various states of a widget, such as
-/// [disabled], [hovered], [focused], [pressed], [dragged], [selected], and
-/// [longPressed]. These states are stored in a [Set] called [value].
+/// [disabled], [hovered], [focused], [pressed], [dragged], [selected].
+/// These states are stored in a [Set] called [value].
 ///
 /// The controller extends [ChangeNotifier], allowing listeners to be notified
 /// when the state of the widget changes.

--- a/packages/mix/lib/src/core/widget_state/widget_state_controller.dart
+++ b/packages/mix/lib/src/core/widget_state/widget_state_controller.dart
@@ -9,8 +9,7 @@ enum MixWidgetState {
   dragged,
   selected,
   disabled,
-  error,
-  longPressed;
+  error;
 
   static const of = MixWidgetStateModel.of;
   static const hasStateOf = MixWidgetStateModel.hasStateOf;
@@ -53,9 +52,6 @@ class MixWidgetStateController extends ChangeNotifier {
   /// Whether the widget is currently in the error state.
   bool get error => value.contains(MixWidgetState.error);
 
-  /// Whether the widget is currently being long-pressed.
-  bool get longPressed => value.contains(MixWidgetState.longPressed);
-
   /// Sets whether the widget is in the disabled state.
   set disabled(bool value) => update(MixWidgetState.disabled, value);
 
@@ -76,9 +72,6 @@ class MixWidgetStateController extends ChangeNotifier {
 
   /// Sets whether the widget is in the selected state.
   set error(bool value) => update(MixWidgetState.error, value);
-
-  /// Sets whether the widget is being long-pressed.
-  set longPressed(bool value) => update(MixWidgetState.longPressed, value);
 
   /// Updates the state of the widget for a given [key].
   ///

--- a/packages/mix/lib/src/variants/context_variant_util/on_util.dart
+++ b/packages/mix/lib/src/variants/context_variant_util/on_util.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
-import 'on_platform_util.dart';
 
 import '../../theme/tokens/breakpoints_token.dart';
 import '../widget_state_variant.dart';
@@ -9,6 +8,7 @@ import 'on_brightness_util.dart';
 import 'on_directionality_util.dart';
 import 'on_not_util.dart';
 import 'on_orientation_util.dart';
+import 'on_platform_util.dart';
 
 class OnContextVariantUtility {
   // Platform variants
@@ -46,6 +46,9 @@ class OnContextVariantUtility {
   final focus = const OnFocusedVariant();
   final enabled = const OnNotVariant(OnDisabledVariant());
   final disabled = const OnDisabledVariant();
+  @Deprecated(
+    'The longPress variant has been removed. Please implement your own context variant for it',
+  )
   final longPress = const OnLongPressVariant();
   final selected = const OnSelectedVariant();
   final unselected = const OnNotVariant(OnSelectedVariant());

--- a/packages/mix/lib/src/variants/widget_state_variant.dart
+++ b/packages/mix/lib/src/variants/widget_state_variant.dart
@@ -2,6 +2,7 @@ import 'package:flutter/widgets.dart';
 
 import '../core/factory/style_mix.dart';
 import '../core/variant.dart';
+import '../core/widget_state/internal/gesture_mix_state.dart';
 import '../core/widget_state/internal/mouse_region_mix_state.dart';
 import '../core/widget_state/widget_state_controller.dart';
 import 'context_variant.dart';
@@ -65,8 +66,16 @@ class OnPressVariant extends _ToggleMixStateVariant {
 }
 
 /// Applies styles when the widget is long pressed.
-class OnLongPressVariant extends _ToggleMixStateVariant {
-  const OnLongPressVariant() : super(MixWidgetState.longPressed);
+class OnLongPressVariant extends ContextVariant {
+  @override
+  final priority = VariantPriority.highest;
+
+  const OnLongPressVariant();
+
+  @override
+  bool when(BuildContext context) {
+    return LongPressInheritedState.of(context).longPressed;
+  }
 }
 
 /// Applies styles when the widget is disabled.

--- a/packages/mix/lib/src/variants/widget_state_variant.dart
+++ b/packages/mix/lib/src/variants/widget_state_variant.dart
@@ -70,6 +70,9 @@ class OnLongPressVariant extends ContextVariant {
   @override
   final priority = VariantPriority.highest;
 
+  @Deprecated(
+    'The longPress variant has been removed. Please implement your own context variant for it',
+  )
   const OnLongPressVariant();
 
   @override

--- a/packages/mix/lib/src/variants/widget_state_variant.dart
+++ b/packages/mix/lib/src/variants/widget_state_variant.dart
@@ -26,7 +26,7 @@ abstract class MixWidgetStateVariant<Value> extends ContextVariant {
 }
 
 abstract class _ToggleMixStateVariant extends MixWidgetStateVariant<bool> {
-  final MixWidgetState _state;
+  final WidgetState _state;
   const _ToggleMixStateVariant(this._state);
 
   @override
@@ -56,13 +56,13 @@ class OnHoverVariant extends MixWidgetStateVariant<PointerPosition?> {
   @override
   bool when(BuildContext context) => MixWidgetState.hasStateOf(
         context,
-        MixWidgetState.hovered,
+        WidgetState.hovered,
       );
 }
 
 /// Applies styles when the widget is pressed.
 class OnPressVariant extends _ToggleMixStateVariant {
-  const OnPressVariant() : super(MixWidgetState.pressed);
+  const OnPressVariant() : super(WidgetState.pressed);
 }
 
 /// Applies styles when the widget is long pressed.
@@ -80,25 +80,25 @@ class OnLongPressVariant extends ContextVariant {
 
 /// Applies styles when the widget is disabled.
 class OnDisabledVariant extends _ToggleMixStateVariant {
-  const OnDisabledVariant() : super(MixWidgetState.disabled);
+  const OnDisabledVariant() : super(WidgetState.disabled);
 }
 
 /// Applies styles when the widget has focus.
 class OnFocusedVariant extends _ToggleMixStateVariant {
-  const OnFocusedVariant() : super(MixWidgetState.focused);
+  const OnFocusedVariant() : super(WidgetState.focused);
 }
 
 /// Applies styles when the widget is selected
 class OnSelectedVariant extends _ToggleMixStateVariant {
-  const OnSelectedVariant() : super(MixWidgetState.selected);
+  const OnSelectedVariant() : super(WidgetState.selected);
 }
 
 /// Applies styles when the widget is dragged.
 class OnDraggedVariant extends _ToggleMixStateVariant {
-  const OnDraggedVariant() : super(MixWidgetState.dragged);
+  const OnDraggedVariant() : super(WidgetState.dragged);
 }
 
 /// Applies styles when the widget is error.
 class OnErrorVariant extends _ToggleMixStateVariant {
-  const OnErrorVariant() : super(MixWidgetState.error);
+  const OnErrorVariant() : super(WidgetState.error);
 }

--- a/packages/mix/test/helpers/testing_utils.dart
+++ b/packages/mix/test/helpers/testing_utils.dart
@@ -121,7 +121,6 @@ extension WidgetTesterExt on WidgetTester {
     bool focused = false,
     bool pressed = false,
     bool hovered = false,
-    bool longPressed = false,
   }) async {
     final controller = MixWidgetStateController();
 
@@ -129,7 +128,6 @@ extension WidgetTesterExt on WidgetTester {
     controller.focused = focused;
     controller.hovered = hovered;
     controller.pressed = pressed;
-    controller.longPressed = longPressed;
 
     await pumpWidget(
       MaterialApp(

--- a/packages/mix/test/src/core/mix_state/internal/gesture_mix_state_test.dart
+++ b/packages/mix/test/src/core/mix_state/internal/gesture_mix_state_test.dart
@@ -78,8 +78,10 @@ void main() {
       final context = tester.element(find.byKey(key));
 
       expect(onLongPressCalled, isTrue);
-      expect(MixWidgetState.hasStateOf(context, MixWidgetState.longPressed),
-          isTrue);
+      expect(
+        LongPressInheritedState.of(context).longPressed,
+        isTrue,
+      );
     });
 
     testWidgets('should update press state after delay when tapped',

--- a/packages/mix/test/src/core/mix_state/internal/gesture_mix_state_test.dart
+++ b/packages/mix/test/src/core/mix_state/internal/gesture_mix_state_test.dart
@@ -56,7 +56,7 @@ void main() {
       final context = tester.element(find.byKey(key));
 
       expect(
-        MixWidgetState.hasStateOf(context, MixWidgetState.pressed),
+        MixWidgetState.hasStateOf(context, WidgetState.pressed),
         isTrue,
         reason: 'GesturableState should be pressed immediately after tap',
       );
@@ -97,7 +97,7 @@ void main() {
       await tester.pump();
       final context = tester.element(find.byKey(key));
       expect(
-        MixWidgetState.hasStateOf(context, MixWidgetState.pressed),
+        MixWidgetState.hasStateOf(context, WidgetState.pressed),
         isTrue,
         reason: 'GesturableState should be pressed immediately after tap',
       );
@@ -106,7 +106,7 @@ void main() {
         const Duration(milliseconds: 50),
       );
       expect(
-        MixWidgetState.hasStateOf(context, MixWidgetState.pressed),
+        MixWidgetState.hasStateOf(context, WidgetState.pressed),
         isTrue,
         reason: 'GesturableState should still be pressed 50ms after tap',
       );
@@ -115,7 +115,7 @@ void main() {
         const Duration(milliseconds: 100),
       );
       expect(
-        MixWidgetState.hasStateOf(context, MixWidgetState.pressed),
+        MixWidgetState.hasStateOf(context, WidgetState.pressed),
         isFalse,
         reason:
             'GesturableState should be unpressed after unpressDelay has passed',
@@ -133,7 +133,7 @@ void main() {
       await tester.tap(find.byType(GestureMixStateWidget));
       final context = tester.element(find.byKey(key));
       expect(
-          MixWidgetState.hasStateOf(context, MixWidgetState.pressed), isFalse);
+          MixWidgetState.hasStateOf(context, WidgetState.pressed), isFalse);
     });
 
     testWidgets('GesturableWidget pan functions test', (

--- a/packages/mix/test/src/core/mix_state/internal/interactive_mix_state_test.dart
+++ b/packages/mix/test/src/core/mix_state/internal/interactive_mix_state_test.dart
@@ -17,7 +17,7 @@ void main() {
       var context = tester.element(find.byType(Container));
 
       expect(
-        MixWidgetState.hasStateOf(context, MixWidgetState.disabled),
+        MixWidgetState.hasStateOf(context, WidgetState.disabled),
         isTrue,
       );
 
@@ -27,8 +27,7 @@ void main() {
 
       context = tester.element(find.byType(Container));
 
-      expect(
-          MixWidgetState.hasStateOf(context, MixWidgetState.disabled), isFalse);
+      expect(MixWidgetState.hasStateOf(context, WidgetState.disabled), isFalse);
     });
 
     testWidgets('should update focused state', (WidgetTester tester) async {
@@ -41,7 +40,7 @@ void main() {
 
       var context = tester.element(find.byType(Container));
       expect(
-        MixWidgetState.hasStateOf(context, MixWidgetState.focused),
+        MixWidgetState.hasStateOf(context, WidgetState.focused),
         isTrue,
       );
 
@@ -51,8 +50,7 @@ void main() {
 
       context = tester.element(find.byType(Container));
 
-      expect(
-          MixWidgetState.hasStateOf(context, MixWidgetState.focused), isFalse);
+      expect(MixWidgetState.hasStateOf(context, WidgetState.focused), isFalse);
     });
 
     testWidgets('should update hovered state', (WidgetTester tester) async {
@@ -66,8 +64,7 @@ void main() {
       );
 
       var context = tester.element(find.byType(Container));
-      expect(
-          MixWidgetState.hasStateOf(context, MixWidgetState.hovered), isTrue);
+      expect(MixWidgetState.hasStateOf(context, WidgetState.hovered), isTrue);
 
       controller.hovered = false;
 
@@ -75,8 +72,7 @@ void main() {
 
       context = tester.element(find.byType(Container));
 
-      expect(
-          MixWidgetState.hasStateOf(context, MixWidgetState.hovered), isFalse);
+      expect(MixWidgetState.hasStateOf(context, WidgetState.hovered), isFalse);
     });
   });
 }

--- a/packages/mix/test/src/variants/widget_state_variant_test.dart
+++ b/packages/mix/test/src/variants/widget_state_variant_test.dart
@@ -2,6 +2,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mix/mix.dart';
+import 'package:mix/src/core/widget_state/internal/gesture_mix_state.dart';
 
 import '../../helpers/testing_utils.dart';
 
@@ -33,11 +34,12 @@ void main() {
       expect(onPressAttr.variant.when(context), true);
     });
 
-    testWidgets('long press state', (tester) async {
-      await tester.pumpWithPressable(
-        Container(),
-        longPressed: true,
-        focused: true,
+    testWidgets('long press state when long pressed', (tester) async {
+      await tester.pumpWidget(
+        LongPressInheritedState(
+          longPressed: true,
+          child: Container(),
+        ),
       );
 
       final context = tester.element(find.byType(Container));
@@ -49,8 +51,6 @@ void main() {
         onLongPressAttr.value,
         Style(attribute1, attribute2, attribute3),
       );
-
-      expect(onLongPressAttr.variant.when(context), true);
     });
 
     testWidgets('hover state', (tester) async {

--- a/packages/mix/test/src/widgets/widget_state/widget_state_controller_test.dart
+++ b/packages/mix/test/src/widgets/widget_state/widget_state_controller_test.dart
@@ -49,7 +49,6 @@ void main() {
       expect(controller.pressed, isFalse);
       expect(controller.dragged, isFalse);
       expect(controller.selected, isFalse);
-      expect(controller.longPressed, isFalse);
     });
 
     test('update individual state', () {
@@ -72,9 +71,6 @@ void main() {
 
       controller.selected = true;
       expect(controller.selected, isTrue);
-
-      controller.longPressed = true;
-      expect(controller.longPressed, isTrue);
     });
 
     test('batch update states', () {
@@ -92,7 +88,6 @@ void main() {
       expect(controller.pressed, isFalse);
       expect(controller.dragged, isFalse);
       expect(controller.selected, isFalse);
-      expect(controller.longPressed, isFalse);
     });
 
     test('notifyListeners called on state change', () {
@@ -125,7 +120,6 @@ void main() {
       controller.pressed = true;
       controller.dragged = true;
       controller.selected = true;
-      controller.longPressed = true;
       controller.error = true;
 
       await tester.pumpWidget(
@@ -137,7 +131,6 @@ void main() {
             pressed: controller.pressed,
             dragged: controller.dragged,
             selected: controller.selected,
-            longPressed: controller.longPressed,
             error: controller.error,
             child: Container(),
           ),
@@ -152,7 +145,6 @@ void main() {
       expect(foundModel.pressed, isTrue);
       expect(foundModel.dragged, isTrue);
       expect(foundModel.selected, isTrue);
-      expect(foundModel.longPressed, isTrue);
       expect(foundModel.error, isTrue);
     });
 
@@ -166,7 +158,6 @@ void main() {
             pressed: false,
             dragged: false,
             selected: false,
-            longPressed: false,
             error: false,
             child: Builder(
               builder: (context) {
@@ -200,7 +191,6 @@ void main() {
         pressed: false,
         dragged: false,
         selected: false,
-        longPressed: false,
         error: false,
         child: Container(),
       );
@@ -211,7 +201,6 @@ void main() {
         pressed: false,
         dragged: false,
         selected: false,
-        longPressed: false,
         error: false,
         child: Container(),
       );
@@ -227,7 +216,6 @@ void main() {
         pressed: false,
         dragged: false,
         selected: false,
-        longPressed: false,
         error: false,
         child: Container(),
       );
@@ -238,7 +226,6 @@ void main() {
         pressed: false,
         dragged: false,
         selected: false,
-        longPressed: false,
         error: false,
         child: Container(),
       );
@@ -259,7 +246,7 @@ void main() {
   ) async {
     bool hovered = false;
     bool pressed = false;
-    bool longPressed = false;
+
     bool focused = false;
 
     await tester.pumpWidget(
@@ -271,7 +258,6 @@ void main() {
             controller.disabled = false;
             controller.hovered = hovered;
             controller.pressed = pressed;
-            controller.longPressed = longPressed;
             controller.focused = focused;
 
             return Column(
@@ -283,7 +269,6 @@ void main() {
                       children: [
                         Text('Disabled: ${controller.disabled}'),
                         Text('Hovered: ${controller.hovered}'),
-                        Text('LongPressed: ${controller.longPressed}'),
                         Text('Pressed: ${controller.pressed}'),
                       ],
                     );
@@ -294,7 +279,6 @@ void main() {
                     setState(() {
                       hovered = !hovered;
                       pressed = !pressed;
-                      longPressed = !longPressed;
                       focused = !focused;
                     });
                   },
@@ -310,7 +294,6 @@ void main() {
     expect(find.text('Disabled: false'), findsOneWidget);
     expect(find.text('Hovered: false'), findsOneWidget);
     expect(find.text('Pressed: false'), findsOneWidget);
-    expect(find.text('LongPressed: false'), findsOneWidget);
     expect(find.text('Focused: false'), findsNothing);
 
     await tester.tap(find.text('Update State'));
@@ -319,7 +302,6 @@ void main() {
     expect(find.text('Disabled: false'), findsOneWidget);
     expect(find.text('Hovered: true'), findsOneWidget);
     expect(find.text('Pressed: true'), findsOneWidget);
-    expect(find.text('LongPressed: true'), findsOneWidget);
     expect(find.text('Focused: true'), findsNothing);
   });
 
@@ -351,14 +333,9 @@ void main() {
       return TrackRebuildWidget.findState(tester, 'pressed');
     }
 
-    TrackRebuildWidgetState getLongPressed() {
-      return TrackRebuildWidget.findState(tester, 'longPressed');
-    }
-
     var disabled = getDisabled();
     var hovered = getHovered();
     var pressed = getPressed();
-    var longPressed = getLongPressed();
 
     expect(disabled.buildCount, 1,
         reason: 'Disabled state should not have rebuilt');
@@ -372,10 +349,6 @@ void main() {
         reason: 'Pressed state should not have rebuilt');
     expect(pressed.state, false,
         reason: 'Pressed state should initially be false');
-    expect(longPressed.buildCount, 1,
-        reason: 'Long pressed state should not have rebuilt');
-    expect(longPressed.state, false,
-        reason: 'Long pressed state should initially be false');
 
     controller.hovered = true;
     await tester.pump();
@@ -383,7 +356,6 @@ void main() {
     disabled = getDisabled();
     hovered = getHovered();
     pressed = getPressed();
-    longPressed = getLongPressed();
 
     expect(disabled.buildCount, 1,
         reason: 'Disabled state should not rebuild when hovered changes');
@@ -397,10 +369,6 @@ void main() {
         reason: 'Pressed state should not rebuild when hovered changes');
     expect(pressed.state, false,
         reason: 'Pressed state should remain false when hovered changes');
-    expect(longPressed.buildCount, 1,
-        reason: 'Long pressed state should not rebuild when hovered changes');
-    expect(longPressed.state, false,
-        reason: 'Long pressed state should remain false when hovered changes');
 
     controller.pressed = true;
     await tester.pump();
@@ -408,7 +376,6 @@ void main() {
     disabled = getDisabled();
     hovered = getHovered();
     pressed = getPressed();
-    longPressed = getLongPressed();
 
     expect(disabled.buildCount, 1,
         reason: 'Disabled state should not rebuild when pressed changes');
@@ -422,18 +389,12 @@ void main() {
         reason: 'Pressed state should rebuild when set to true');
     expect(pressed.state, true,
         reason: 'Pressed state should be true after being set');
-    expect(longPressed.buildCount, 1,
-        reason: 'Long pressed state should not rebuild when pressed changes');
-    expect(longPressed.state, false,
-        reason: 'Long pressed state should remain false when pressed changes');
 
-    controller.longPressed = true;
     await tester.pump();
 
     disabled = getDisabled();
     hovered = getHovered();
     pressed = getPressed();
-    longPressed = getLongPressed();
 
     expect(disabled.buildCount, 1,
         reason: 'Disabled state should not rebuild when long pressed changes');
@@ -447,10 +408,6 @@ void main() {
         reason: 'Pressed state should not rebuild when long pressed changes');
     expect(pressed.state, true,
         reason: 'Pressed state should remain true when long pressed changes');
-    expect(longPressed.buildCount, 2,
-        reason: 'Long pressed state should rebuild when set to true');
-    expect(longPressed.state, true,
-        reason: 'Long pressed state should be true after being set');
 
     controller.disabled = true;
 
@@ -459,7 +416,6 @@ void main() {
     disabled = getDisabled();
     hovered = getHovered();
     pressed = getPressed();
-    longPressed = getLongPressed();
 
     expect(disabled.buildCount, 2,
         reason: 'Disabled state should rebuild when set to true');
@@ -473,10 +429,6 @@ void main() {
         reason: 'Pressed state should not rebuild when disabled changes');
     expect(pressed.state, true,
         reason: 'Pressed state should remain true when disabled changes');
-    expect(longPressed.buildCount, 2,
-        reason: 'Long pressed state should not rebuild when disabled changes');
-    expect(longPressed.state, true,
-        reason: 'Long pressed state should remain true when disabled changes');
   });
 }
 
@@ -514,10 +466,6 @@ class _PressableStateTestWidgetState extends State<PressableStateTestWidget> {
           TrackRebuildWidget(
             text: 'pressed',
             stateBuilder: _widgetStateOf(MixWidgetState.pressed),
-          ),
-          TrackRebuildWidget(
-            text: 'longPressed',
-            stateBuilder: _widgetStateOf(MixWidgetState.longPressed),
           ),
         ],
       ),

--- a/packages/mix/test/src/widgets/widget_state/widget_state_controller_test.dart
+++ b/packages/mix/test/src/widgets/widget_state/widget_state_controller_test.dart
@@ -77,9 +77,9 @@ void main() {
       final controller = MixWidgetStateController();
 
       controller.batch([
-        (MixWidgetState.disabled, true),
-        (MixWidgetState.hovered, true),
-        (MixWidgetState.focused, true),
+        (WidgetState.disabled, true),
+        (WidgetState.hovered, true),
+        (WidgetState.focused, true),
       ]);
 
       expect(controller.disabled, isTrue);
@@ -100,8 +100,8 @@ void main() {
       expect(notifyListenersCallCount, 1);
 
       controller.batch([
-        (MixWidgetState.hovered, true),
-        (MixWidgetState.focused, true),
+        (WidgetState.hovered, true),
+        (WidgetState.focused, true),
       ]);
       expect(notifyListenersCallCount, 2);
 
@@ -164,14 +164,14 @@ void main() {
                 expect(
                   MixWidgetStateModel.hasStateOf(
                     context,
-                    MixWidgetState.disabled,
+                    WidgetState.disabled,
                   ),
                   isTrue,
                 );
                 expect(
                   MixWidgetStateModel.hasStateOf(
                     context,
-                    MixWidgetState.hovered,
+                    WidgetState.hovered,
                   ),
                   isFalse,
                 );
@@ -232,11 +232,10 @@ void main() {
 
       expect(
           newModel
-              .updateShouldNotifyDependent(oldModel, {MixWidgetState.disabled}),
+              .updateShouldNotifyDependent(oldModel, {WidgetState.disabled}),
           isTrue);
       expect(
-          newModel
-              .updateShouldNotifyDependent(oldModel, {MixWidgetState.hovered}),
+          newModel.updateShouldNotifyDependent(oldModel, {WidgetState.hovered}),
           isFalse);
     });
   });
@@ -442,7 +441,7 @@ class PressableStateTestWidget extends StatefulWidget {
 }
 
 class _PressableStateTestWidgetState extends State<PressableStateTestWidget> {
-  bool Function(BuildContext) _widgetStateOf(MixWidgetState state) {
+  bool Function(BuildContext) _widgetStateOf(WidgetState state) {
     return (BuildContext context) {
       return MixWidgetState.hasStateOf(context, state);
     };
@@ -457,15 +456,15 @@ class _PressableStateTestWidgetState extends State<PressableStateTestWidget> {
         children: [
           TrackRebuildWidget(
             text: 'disabled',
-            stateBuilder: _widgetStateOf(MixWidgetState.disabled),
+            stateBuilder: _widgetStateOf(WidgetState.disabled),
           ),
           TrackRebuildWidget(
             text: 'hovered',
-            stateBuilder: _widgetStateOf(MixWidgetState.hovered),
+            stateBuilder: _widgetStateOf(WidgetState.hovered),
           ),
           TrackRebuildWidget(
             text: 'pressed',
-            stateBuilder: _widgetStateOf(MixWidgetState.pressed),
+            stateBuilder: _widgetStateOf(WidgetState.pressed),
           ),
         ],
       ),

--- a/packages/mix_generator/lib/src/core/metadata/base_metadata.dart
+++ b/packages/mix_generator/lib/src/core/metadata/base_metadata.dart
@@ -28,7 +28,7 @@ abstract class BaseMetadata {
   /// Whether the class is abstract
   final bool isAbstract;
 
-  BaseMetadata({
+  const BaseMetadata({
     required this.element,
     required this.name,
     required this.parameters,

--- a/packages/mix_generator/lib/src/core/metadata/property_metadata.dart
+++ b/packages/mix_generator/lib/src/core/metadata/property_metadata.dart
@@ -26,7 +26,7 @@ class MixableTypeMetadata extends BaseMetadata {
   /// Whether this type implements HasDefaultValue mixin
   final bool hasDefaultValue;
 
-  MixableTypeMetadata({
+  const MixableTypeMetadata({
     required super.element,
     required super.name,
     required super.parameters,

--- a/packages/mix_generator/lib/src/core/metadata/spec_metadata.dart
+++ b/packages/mix_generator/lib/src/core/metadata/spec_metadata.dart
@@ -14,7 +14,7 @@ class SpecMetadata extends BaseMetadata {
   /// Whether this is a widget modifier spec
   final bool isWidgetModifier;
 
-  SpecMetadata({
+  const SpecMetadata({
     required super.element,
     required super.name,
     required super.parameters,

--- a/packages/mix_generator/lib/src/core/metadata/tokens_metadata.dart
+++ b/packages/mix_generator/lib/src/core/metadata/tokens_metadata.dart
@@ -45,7 +45,7 @@ class TokensMetadata extends BaseMetadata {
     ),
   };
 
-  TokensMetadata({
+  const TokensMetadata({
     required super.element,
     required super.name,
     required super.parameters,

--- a/packages/mix_generator/lib/src/core/metadata/utility_metadata.dart
+++ b/packages/mix_generator/lib/src/core/metadata/utility_metadata.dart
@@ -25,7 +25,7 @@ class UtilityMetadata extends BaseMetadata {
 
   static final _logger = Logger('UtilityMetadata');
 
-  UtilityMetadata({
+  const UtilityMetadata({
     required super.element,
     required super.name,
     required super.parameters,


### PR DESCRIPTION
### Description

- Remove `MixWidgetState` and use `MixWidgetState` instead

### Changes

- Create `LongPressInheritedState` that expose the longPress state instead of depend on `MixWidgetState`;
- Replace`MixWidgetState` for `WidgetState`

**Review Checklist**

- [x] **Testing**: Have you tested your changes, including unit tests and integration tests for affected code?
- [ ] **Breaking Changes**: Does this change introduce breaking changes affecting existing code or users?
- [ ] **Documentation Updates**: Are all relevant documentation files (e.g. README, API docs) updated to reflect the changes in this PR?
- [ ] **Website Updates**: Is the website containing the updates you make on documentation?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new inherited widget to provide long-press state to widget descendants.

- **Refactor**
  - Unified widget state handling by replacing a custom enum with a standard widget state type.
  - Removed the long-press state from the general widget state model and controller, now handled via the new inherited widget.
  - Made constructors of core utility and metadata classes constant to support compile-time instantiation.
  - Deprecated built-in long-press variants and advised custom implementation for long press handling.

- **Bug Fixes**
  - Adjusted state variant logic and tests to accurately reflect long-press and other widget states.

- **Tests**
  - Updated and simplified tests to align with the new state management approach and improved long-press detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->