### PR TITLE
refactor(mix): simplify deferred merge and stabilize variant ordering

### DIFF
--- a/packages/mix/lib/src/core/spec_utility.dart
+++ b/packages/mix/lib/src/core/spec_utility.dart
@@ -44,6 +44,14 @@ abstract class StyleAttributeBuilder<S extends Spec<S>> extends Style<S>
   List<VariantStyle<S>>? get $variants => style.$variants;
 
   @override
+  bool get hasBasePayload => style.hasBasePayload;
+
+  @override
+  Style<S> copyWithVariants(List<VariantStyle<S>>? variants) {
+    return style.copyWithVariants(variants);
+  }
+
+  @override
   List<Object?> get props => [style];
 }
 
@@ -82,6 +90,14 @@ abstract class StyleMutableBuilder<S extends Spec<S>> extends Style<S>
   /// Mutable variants from internal attribute
   @override
   List<VariantStyle<S>>? get $variants => value.$variants;
+
+  @override
+  bool get hasBasePayload => value.hasBasePayload;
+
+  @override
+  Style<S> copyWithVariants(List<VariantStyle<S>>? variants) {
+    return value.copyWithVariants(variants);
+  }
 
   @override
   List<Object?> get props => [mutable];

--- a/packages/mix/lib/src/core/style.dart
+++ b/packages/mix/lib/src/core/style.dart
@@ -11,6 +11,8 @@ import 'spec.dart';
 import 'style_spec.dart';
 import 'widget_modifier.dart';
 
+export '../variants/variant.dart' show ContextVariantBuilder;
+
 /// Marker interface for style-related elements.
 @internal
 sealed class StyleElement {
@@ -22,6 +24,12 @@ sealed class StyleElement {
 /// Provides variant support, modifiers, and animation configuration for styled elements.
 abstract class Style<S extends Spec<S>> extends Mix<StyleSpec<S>>
     implements StyleElement {
+  static int _activeVariantResolutionDepth = 0;
+
+  @internal
+  static bool get isResolvingActiveVariants =>
+      _activeVariantResolutionDepth > 0;
+
   final List<VariantStyle<S>>? $variants;
 
   final WidgetModifierConfig? $modifier;
@@ -84,74 +92,84 @@ abstract class Style<S extends Spec<S>> extends Mix<StyleSpec<S>>
     BuildContext context, {
     required Set<NamedVariant> namedVariants,
   }) {
-    // Filter variants that should be active in this context
-    final activeVariants = ($variants ?? [])
-        .where(
-          (variantAttr) => switch (variantAttr.variant) {
-            (ContextVariant variant) => variant.when(context),
-            (NamedVariant variant) => namedVariants.contains(variant),
-            (ContextVariantBuilder _) => true,
-          },
-        )
-        .toList();
+    _activeVariantResolutionDepth++;
+    try {
+      // Filter variants that should be active in this context.
+      final activeVariants = ($variants ?? [])
+          .where(
+            (variantAttr) => switch (variantAttr.variant) {
+              (ContextVariant variant) => variant.when(context),
+              (NamedVariant variant) => namedVariants.contains(variant),
+              (ContextVariantBuilder _) => true,
+            },
+          )
+          .toList();
 
-    // Sort by priority: WidgetStateVariant gets applied last (highest priority)
-    activeVariants.sort(
-      (a, b) => Comparable.compare(
-        a.variant is WidgetStateVariant ? 1 : 0,
-        b.variant is WidgetStateVariant ? 1 : 0,
-      ),
-    );
+      // Preserve insertion order while still applying WidgetStateVariant last.
+      final prioritizedVariants = <VariantStyle<S>>[];
+      final widgetStateVariants = <VariantStyle<S>>[];
+      for (final variantAttr in activeVariants) {
+        if (variantAttr.variant is WidgetStateVariant) {
+          widgetStateVariants.add(variantAttr);
+        } else {
+          prioritizedVariants.add(variantAttr);
+        }
+      }
+      prioritizedVariants.addAll(widgetStateVariants);
 
-    // Extract the style from each active variant
-    final stylesToMerge = <(Style<S>, bool)>[]; // (style, isFromStyleVariation)
+      // Extract the style from each active variant
+      final stylesToMerge =
+          <(Style<S>, bool)>[]; // (style, isFromStyleVariation)
 
-    for (final variantAttr in activeVariants) {
-      final result = switch (variantAttr.variant) {
-        ContextVariantBuilder variant => (
-          variant.build(context) as Style<S>,
-          false,
-        ),
-        (ContextVariant() || NamedVariant()) => () {
-          // Check if the value is a StyleVariation
-          // ignore: avoid-unrelated-type-assertions
-          if (variantAttr.value is StyleVariation<S>) {
-            // ignore: avoid-unrelated-type-casts
-            final styleVariation = variantAttr.value as StyleVariation<S>;
-            // Only apply if this variant is active
-            if (namedVariants.contains(styleVariation.variantType)) {
-              return (
-                styleVariation.styleBuilder(this, namedVariants, context),
-                true,
-              );
+      for (final variantAttr in prioritizedVariants) {
+        final result = switch (variantAttr.variant) {
+          ContextVariantBuilder variant => (
+            variant.build(context) as Style<S>,
+            false,
+          ),
+          (ContextVariant() || NamedVariant()) => () {
+            // Check if the value is a StyleVariation
+            // ignore: avoid-unrelated-type-assertions
+            if (variantAttr.value is StyleVariation<S>) {
+              // ignore: avoid-unrelated-type-casts
+              final styleVariation = variantAttr.value as StyleVariation<S>;
+              // Only apply if this variant is active
+              if (namedVariants.contains(styleVariation.variantType)) {
+                return (
+                  styleVariation.styleBuilder(this, namedVariants, context),
+                  true,
+                );
+              }
             }
-          }
 
-          return (variantAttr.value, false);
-        }(),
-      };
-      stylesToMerge.add(result);
+            return (variantAttr.value, false);
+          }(),
+        };
+        stylesToMerge.add(result);
+      }
+
+      // Start with current style as base
+      Style<S> mergedStyle = this;
+
+      // Merge each variant style, recursively resolving nested variants
+      for (final (variantStyle, isFromStyleVariation) in stylesToMerge) {
+        final fullyResolvedStyle = isFromStyleVariation
+            // For StyleVariation results, we don't recursively resolve variants
+            // since StyleVariation.styleBuilder should handle its own variant logic
+            // and return a final style. This prevents infinite recursion.
+            ? variantStyle
+            // For regular variants, recursively resolve any nested variants
+            : variantStyle.mergeActiveVariants(
+                context,
+                namedVariants: namedVariants,
+              );
+        mergedStyle = mergedStyle.merge(fullyResolvedStyle);
+      }
+
+      return mergedStyle;
+    } finally {
+      _activeVariantResolutionDepth--;
     }
-
-    // Start with current style as base
-    Style<S> mergedStyle = this;
-
-    // Merge each variant style, recursively resolving nested variants
-    for (final (variantStyle, isFromStyleVariation) in stylesToMerge) {
-      final fullyResolvedStyle = isFromStyleVariation
-          // For StyleVariation results, we don't recursively resolve variants
-          // since StyleVariation.styleBuilder should handle its own variant logic
-          // and return a final style. This prevents infinite recursion.
-          ? variantStyle
-          // For regular variants, recursively resolve any nested variants
-          : variantStyle.mergeActiveVariants(
-              context,
-              namedVariants: namedVariants,
-            );
-      mergedStyle = mergedStyle.merge(fullyResolvedStyle);
-    }
-
-    return mergedStyle;
   }
 
   /// Resolves this attribute to its concrete value using the provided [BuildContext].

--- a/packages/mix/lib/src/core/style.dart
+++ b/packages/mix/lib/src/core/style.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import '../animation/animation_config.dart';
+import 'helpers.dart';
 import '../modifiers/widget_modifier_config.dart';
 import '../variants/variant.dart';
 import 'internal/compare_mixin.dart';
@@ -25,6 +26,7 @@ sealed class StyleElement {
 abstract class Style<S extends Spec<S>> extends Mix<StyleSpec<S>>
     implements StyleElement {
   static int _activeVariantMergeDepth = 0;
+  static final _visitedStyles = <int>{};
 
   @internal
   static bool get isResolvingActiveVariants => _activeVariantMergeDepth > 0;
@@ -50,6 +52,38 @@ abstract class Style<S extends Spec<S>> extends Mix<StyleSpec<S>>
   }) : $modifier = modifier,
        $animation = animation,
        $variants = variants;
+
+  @internal
+  bool get hasBasePayload;
+
+  /// Copies current style payload while replacing only variants.
+  @internal
+  Style<S> copyWithVariants(List<VariantStyle<S>>? variants);
+
+  @internal
+  Style<S>? deferMerge(covariant Style<S>? other) {
+    if (other == null) return null;
+    if (isResolvingActiveVariants) return null;
+
+    final hasBuilders =
+        $variants?.any((v) => v.variant is ContextVariantBuilder) ?? false;
+    if (!hasBuilders) return null;
+
+    List<VariantStyle<S>>? deferredVariants;
+    if (other.hasBasePayload) {
+      final payload = other.copyWithVariants(null);
+      deferredVariants = [
+        VariantStyle<S>(DeferredVariant<S>(payload), payload),
+      ];
+    }
+
+    return copyWithVariants(
+      MixOps.mergeVariants(
+        [...?$variants, ...?deferredVariants],
+        other.$variants,
+      ),
+    );
+  }
 
   /// Gets the closest [Style] from the widget tree.
   ///
@@ -100,80 +134,90 @@ abstract class Style<S extends Spec<S>> extends Mix<StyleSpec<S>>
     BuildContext context, {
     required Set<NamedVariant> namedVariants,
   }) {
-    // Filter variants that should be active in this context.
-    final activeVariants = ($variants ?? [])
-        .where(
-          (variantAttr) => switch (variantAttr.variant) {
-            (ContextVariant variant) => variant.when(context),
-            (NamedVariant variant) => namedVariants.contains(variant),
-            (ContextVariantBuilder _) => true,
-          },
-        )
-        .toList();
+    final styleId = identityHashCode(this);
+    if (!_visitedStyles.add(styleId)) return this;
 
-    // Preserve insertion order while still applying WidgetStateVariant last.
-    final prioritizedVariants = <VariantStyle<S>>[];
-    final widgetStateVariants = <VariantStyle<S>>[];
-    for (final variantAttr in activeVariants) {
-      if (variantAttr.variant is WidgetStateVariant) {
-        widgetStateVariants.add(variantAttr);
-      } else {
-        prioritizedVariants.add(variantAttr);
+    try {
+      // Filter variants that should be active in this context.
+      final activeVariants = ($variants ?? [])
+          .where(
+            (variantAttr) => switch (variantAttr.variant) {
+              (ContextVariant variant) => variant.when(context),
+              (NamedVariant variant) => namedVariants.contains(variant),
+              (ContextVariantBuilder _) => true,
+              (DeferredVariant _) => true,
+            },
+          )
+          .toList();
+
+      // Preserve insertion order while still applying WidgetStateVariant last.
+      final prioritizedVariants = <VariantStyle<S>>[];
+      final widgetStateVariants = <VariantStyle<S>>[];
+      for (final variantAttr in activeVariants) {
+        if (variantAttr.variant is WidgetStateVariant) {
+          widgetStateVariants.add(variantAttr);
+        } else {
+          prioritizedVariants.add(variantAttr);
+        }
       }
-    }
-    prioritizedVariants.addAll(widgetStateVariants);
+      prioritizedVariants.addAll(widgetStateVariants);
 
-    // Extract the style from each active variant
-    final stylesToMerge = <(Style<S>, bool)>[]; // (style, isFromStyleVariation)
+      // Extract the style from each active variant
+      final stylesToMerge =
+          <(Style<S>, bool)>[]; // (style, isFromStyleVariation)
 
-    for (final variantAttr in prioritizedVariants) {
-      final result = switch (variantAttr.variant) {
-        ContextVariantBuilder variant => (
-          variant.build(context) as Style<S>,
-          false,
-        ),
-        (ContextVariant() || NamedVariant()) => () {
-          // Check if the value is a StyleVariation
-          // ignore: avoid-unrelated-type-assertions
-          if (variantAttr.value is StyleVariation<S>) {
-            // ignore: avoid-unrelated-type-casts
-            final styleVariation = variantAttr.value as StyleVariation<S>;
-            // Only apply if this variant is active
-            if (namedVariants.contains(styleVariation.variantType)) {
-              return (
-                styleVariation.styleBuilder(this, namedVariants, context),
-                true,
-              );
+      for (final variantAttr in prioritizedVariants) {
+        final result = switch (variantAttr.variant) {
+          ContextVariantBuilder variant => (
+            variant.build(context) as Style<S>,
+            false,
+          ),
+          DeferredVariant variant => (variant.payload as Style<S>, false),
+          (ContextVariant() || NamedVariant()) => () {
+            // Check if the value is a StyleVariation
+            // ignore: avoid-unrelated-type-assertions
+            if (variantAttr.value is StyleVariation<S>) {
+              // ignore: avoid-unrelated-type-casts
+              final styleVariation = variantAttr.value as StyleVariation<S>;
+              // Only apply if this variant is active
+              if (namedVariants.contains(styleVariation.variantType)) {
+                return (
+                  styleVariation.styleBuilder(this, namedVariants, context),
+                  true,
+                );
+              }
             }
-          }
 
-          return (variantAttr.value, false);
-        }(),
-      };
-      stylesToMerge.add(result);
+            return (variantAttr.value, false);
+          }(),
+        };
+        stylesToMerge.add(result);
+      }
+
+      // Start with current style as base
+      Style<S> mergedStyle = this;
+
+      // Merge each variant style, recursively resolving nested variants
+      for (final (variantStyle, isFromStyleVariation) in stylesToMerge) {
+        final fullyResolvedStyle = isFromStyleVariation
+            // For StyleVariation results, we don't recursively resolve variants
+            // since StyleVariation.styleBuilder should handle its own variant logic
+            // and return a final style. This prevents infinite recursion.
+            ? variantStyle
+            // For regular variants, recursively resolve any nested variants
+            : variantStyle.mergeActiveVariants(
+                context,
+                namedVariants: namedVariants,
+              );
+        mergedStyle = _withActiveVariantMergeGuard(
+          () => mergedStyle.merge(fullyResolvedStyle),
+        );
+      }
+
+      return mergedStyle;
+    } finally {
+      _visitedStyles.remove(styleId);
     }
-
-    // Start with current style as base
-    Style<S> mergedStyle = this;
-
-    // Merge each variant style, recursively resolving nested variants
-    for (final (variantStyle, isFromStyleVariation) in stylesToMerge) {
-      final fullyResolvedStyle = isFromStyleVariation
-          // For StyleVariation results, we don't recursively resolve variants
-          // since StyleVariation.styleBuilder should handle its own variant logic
-          // and return a final style. This prevents infinite recursion.
-          ? variantStyle
-          // For regular variants, recursively resolve any nested variants
-          : variantStyle.mergeActiveVariants(
-              context,
-              namedVariants: namedVariants,
-            );
-      mergedStyle = _withActiveVariantMergeGuard(
-        () => mergedStyle.merge(fullyResolvedStyle),
-      );
-    }
-
-    return mergedStyle;
   }
 
   /// Resolves this attribute to its concrete value using the provided [BuildContext].

--- a/packages/mix/lib/src/core/style.dart
+++ b/packages/mix/lib/src/core/style.dart
@@ -29,7 +29,6 @@ abstract class Style<S extends Spec<S>> extends Mix<StyleSpec<S>>
   @internal
   static bool get isResolvingActiveVariants => _activeVariantMergeDepth > 0;
 
-  @internal
   static T _withActiveVariantMergeGuard<T>(T Function() fn) {
     _activeVariantMergeDepth++;
     try {

--- a/packages/mix/lib/src/core/style.dart
+++ b/packages/mix/lib/src/core/style.dart
@@ -24,11 +24,20 @@ sealed class StyleElement {
 /// Provides variant support, modifiers, and animation configuration for styled elements.
 abstract class Style<S extends Spec<S>> extends Mix<StyleSpec<S>>
     implements StyleElement {
-  static int _activeVariantResolutionDepth = 0;
+  static int _activeVariantMergeDepth = 0;
 
   @internal
-  static bool get isResolvingActiveVariants =>
-      _activeVariantResolutionDepth > 0;
+  static bool get isResolvingActiveVariants => _activeVariantMergeDepth > 0;
+
+  @internal
+  static T _withActiveVariantMergeGuard<T>(T Function() fn) {
+    _activeVariantMergeDepth++;
+    try {
+      return fn();
+    } finally {
+      _activeVariantMergeDepth--;
+    }
+  }
 
   final List<VariantStyle<S>>? $variants;
 
@@ -92,84 +101,80 @@ abstract class Style<S extends Spec<S>> extends Mix<StyleSpec<S>>
     BuildContext context, {
     required Set<NamedVariant> namedVariants,
   }) {
-    _activeVariantResolutionDepth++;
-    try {
-      // Filter variants that should be active in this context.
-      final activeVariants = ($variants ?? [])
-          .where(
-            (variantAttr) => switch (variantAttr.variant) {
-              (ContextVariant variant) => variant.when(context),
-              (NamedVariant variant) => namedVariants.contains(variant),
-              (ContextVariantBuilder _) => true,
-            },
-          )
-          .toList();
+    // Filter variants that should be active in this context.
+    final activeVariants = ($variants ?? [])
+        .where(
+          (variantAttr) => switch (variantAttr.variant) {
+            (ContextVariant variant) => variant.when(context),
+            (NamedVariant variant) => namedVariants.contains(variant),
+            (ContextVariantBuilder _) => true,
+          },
+        )
+        .toList();
 
-      // Preserve insertion order while still applying WidgetStateVariant last.
-      final prioritizedVariants = <VariantStyle<S>>[];
-      final widgetStateVariants = <VariantStyle<S>>[];
-      for (final variantAttr in activeVariants) {
-        if (variantAttr.variant is WidgetStateVariant) {
-          widgetStateVariants.add(variantAttr);
-        } else {
-          prioritizedVariants.add(variantAttr);
-        }
+    // Preserve insertion order while still applying WidgetStateVariant last.
+    final prioritizedVariants = <VariantStyle<S>>[];
+    final widgetStateVariants = <VariantStyle<S>>[];
+    for (final variantAttr in activeVariants) {
+      if (variantAttr.variant is WidgetStateVariant) {
+        widgetStateVariants.add(variantAttr);
+      } else {
+        prioritizedVariants.add(variantAttr);
       }
-      prioritizedVariants.addAll(widgetStateVariants);
-
-      // Extract the style from each active variant
-      final stylesToMerge =
-          <(Style<S>, bool)>[]; // (style, isFromStyleVariation)
-
-      for (final variantAttr in prioritizedVariants) {
-        final result = switch (variantAttr.variant) {
-          ContextVariantBuilder variant => (
-            variant.build(context) as Style<S>,
-            false,
-          ),
-          (ContextVariant() || NamedVariant()) => () {
-            // Check if the value is a StyleVariation
-            // ignore: avoid-unrelated-type-assertions
-            if (variantAttr.value is StyleVariation<S>) {
-              // ignore: avoid-unrelated-type-casts
-              final styleVariation = variantAttr.value as StyleVariation<S>;
-              // Only apply if this variant is active
-              if (namedVariants.contains(styleVariation.variantType)) {
-                return (
-                  styleVariation.styleBuilder(this, namedVariants, context),
-                  true,
-                );
-              }
-            }
-
-            return (variantAttr.value, false);
-          }(),
-        };
-        stylesToMerge.add(result);
-      }
-
-      // Start with current style as base
-      Style<S> mergedStyle = this;
-
-      // Merge each variant style, recursively resolving nested variants
-      for (final (variantStyle, isFromStyleVariation) in stylesToMerge) {
-        final fullyResolvedStyle = isFromStyleVariation
-            // For StyleVariation results, we don't recursively resolve variants
-            // since StyleVariation.styleBuilder should handle its own variant logic
-            // and return a final style. This prevents infinite recursion.
-            ? variantStyle
-            // For regular variants, recursively resolve any nested variants
-            : variantStyle.mergeActiveVariants(
-                context,
-                namedVariants: namedVariants,
-              );
-        mergedStyle = mergedStyle.merge(fullyResolvedStyle);
-      }
-
-      return mergedStyle;
-    } finally {
-      _activeVariantResolutionDepth--;
     }
+    prioritizedVariants.addAll(widgetStateVariants);
+
+    // Extract the style from each active variant
+    final stylesToMerge = <(Style<S>, bool)>[]; // (style, isFromStyleVariation)
+
+    for (final variantAttr in prioritizedVariants) {
+      final result = switch (variantAttr.variant) {
+        ContextVariantBuilder variant => (
+          variant.build(context) as Style<S>,
+          false,
+        ),
+        (ContextVariant() || NamedVariant()) => () {
+          // Check if the value is a StyleVariation
+          // ignore: avoid-unrelated-type-assertions
+          if (variantAttr.value is StyleVariation<S>) {
+            // ignore: avoid-unrelated-type-casts
+            final styleVariation = variantAttr.value as StyleVariation<S>;
+            // Only apply if this variant is active
+            if (namedVariants.contains(styleVariation.variantType)) {
+              return (
+                styleVariation.styleBuilder(this, namedVariants, context),
+                true,
+              );
+            }
+          }
+
+          return (variantAttr.value, false);
+        }(),
+      };
+      stylesToMerge.add(result);
+    }
+
+    // Start with current style as base
+    Style<S> mergedStyle = this;
+
+    // Merge each variant style, recursively resolving nested variants
+    for (final (variantStyle, isFromStyleVariation) in stylesToMerge) {
+      final fullyResolvedStyle = isFromStyleVariation
+          // For StyleVariation results, we don't recursively resolve variants
+          // since StyleVariation.styleBuilder should handle its own variant logic
+          // and return a final style. This prevents infinite recursion.
+          ? variantStyle
+          // For regular variants, recursively resolve any nested variants
+          : variantStyle.mergeActiveVariants(
+              context,
+              namedVariants: namedVariants,
+            );
+      mergedStyle = _withActiveVariantMergeGuard(
+        () => mergedStyle.merge(fullyResolvedStyle),
+      );
+    }
+
+    return mergedStyle;
   }
 
   /// Resolves this attribute to its concrete value using the provided [BuildContext].

--- a/packages/mix/lib/src/specs/box/box_style.g.dart
+++ b/packages/mix/lib/src/specs/box/box_style.g.dart
@@ -67,20 +67,43 @@ mixin _$BoxStylerMixin on Style<BoxSpec>, Diagnosticable {
     return merge(BoxStyler(modifier: value));
   }
 
+  @override
+  bool get hasBasePayload =>
+      $alignment != null ||
+      $clipBehavior != null ||
+      $constraints != null ||
+      $decoration != null ||
+      $foregroundDecoration != null ||
+      $margin != null ||
+      $padding != null ||
+      $transform != null ||
+      $transformAlignment != null ||
+      $modifier != null ||
+      $animation != null;
+
+  @override
+  BoxStyler copyWithVariants(List<VariantStyle<BoxSpec>>? variants) {
+    return BoxStyler.create(
+      alignment: $alignment,
+      clipBehavior: $clipBehavior,
+      constraints: $constraints,
+      decoration: $decoration,
+      foregroundDecoration: $foregroundDecoration,
+      margin: $margin,
+      padding: $padding,
+      transform: $transform,
+      transformAlignment: $transformAlignment,
+      variants: variants,
+      modifier: $modifier,
+      animation: $animation,
+    );
+  }
+
   /// Merges with another [BoxStyler].
   @override
   BoxStyler merge(BoxStyler? other) {
-    final hasContextVariantBuilders =
-        $variants?.any((v) => v.variant is ContextVariantBuilder) ?? false;
-    if (other != null &&
-        !Style.isResolvingActiveVariants &&
-        hasContextVariantBuilders &&
-        other.$variants == null) {
-      final builder = ContextVariantBuilder<BoxStyler>((_) => other);
-      return merge(
-        BoxStyler(variants: [VariantStyle<BoxSpec>(builder, other)]),
-      );
-    }
+    final deferred = deferMerge(other);
+    if (deferred != null) return deferred as BoxStyler;
 
     return BoxStyler.create(
       alignment: MixOps.merge($alignment, other?.$alignment),

--- a/packages/mix/lib/src/specs/box/box_style.g.dart
+++ b/packages/mix/lib/src/specs/box/box_style.g.dart
@@ -70,6 +70,18 @@ mixin _$BoxStylerMixin on Style<BoxSpec>, Diagnosticable {
   /// Merges with another [BoxStyler].
   @override
   BoxStyler merge(BoxStyler? other) {
+    final hasContextVariantBuilders =
+        $variants?.any((v) => v.variant is ContextVariantBuilder) ?? false;
+    if (other != null &&
+        !Style.isResolvingActiveVariants &&
+        hasContextVariantBuilders &&
+        other.$variants == null) {
+      final builder = ContextVariantBuilder<BoxStyler>((_) => other);
+      return merge(
+        BoxStyler(variants: [VariantStyle<BoxSpec>(builder, other)]),
+      );
+    }
+
     return BoxStyler.create(
       alignment: MixOps.merge($alignment, other?.$alignment),
       clipBehavior: MixOps.merge($clipBehavior, other?.$clipBehavior),

--- a/packages/mix/lib/src/specs/flex/flex_style.g.dart
+++ b/packages/mix/lib/src/specs/flex/flex_style.g.dart
@@ -77,20 +77,43 @@ mixin _$FlexStylerMixin on Style<FlexSpec>, Diagnosticable {
     return merge(FlexStyler(modifier: value));
   }
 
+  @override
+  bool get hasBasePayload =>
+      $clipBehavior != null ||
+      $crossAxisAlignment != null ||
+      $direction != null ||
+      $mainAxisAlignment != null ||
+      $mainAxisSize != null ||
+      $spacing != null ||
+      $textBaseline != null ||
+      $textDirection != null ||
+      $verticalDirection != null ||
+      $modifier != null ||
+      $animation != null;
+
+  @override
+  FlexStyler copyWithVariants(List<VariantStyle<FlexSpec>>? variants) {
+    return FlexStyler.create(
+      clipBehavior: $clipBehavior,
+      crossAxisAlignment: $crossAxisAlignment,
+      direction: $direction,
+      mainAxisAlignment: $mainAxisAlignment,
+      mainAxisSize: $mainAxisSize,
+      spacing: $spacing,
+      textBaseline: $textBaseline,
+      textDirection: $textDirection,
+      verticalDirection: $verticalDirection,
+      variants: variants,
+      modifier: $modifier,
+      animation: $animation,
+    );
+  }
+
   /// Merges with another [FlexStyler].
   @override
   FlexStyler merge(FlexStyler? other) {
-    final hasContextVariantBuilders =
-        $variants?.any((v) => v.variant is ContextVariantBuilder) ?? false;
-    if (other != null &&
-        !Style.isResolvingActiveVariants &&
-        hasContextVariantBuilders &&
-        other.$variants == null) {
-      final builder = ContextVariantBuilder<FlexStyler>((_) => other);
-      return merge(
-        FlexStyler(variants: [VariantStyle<FlexSpec>(builder, other)]),
-      );
-    }
+    final deferred = deferMerge(other);
+    if (deferred != null) return deferred as FlexStyler;
 
     return FlexStyler.create(
       clipBehavior: MixOps.merge($clipBehavior, other?.$clipBehavior),

--- a/packages/mix/lib/src/specs/flex/flex_style.g.dart
+++ b/packages/mix/lib/src/specs/flex/flex_style.g.dart
@@ -80,6 +80,18 @@ mixin _$FlexStylerMixin on Style<FlexSpec>, Diagnosticable {
   /// Merges with another [FlexStyler].
   @override
   FlexStyler merge(FlexStyler? other) {
+    final hasContextVariantBuilders =
+        $variants?.any((v) => v.variant is ContextVariantBuilder) ?? false;
+    if (other != null &&
+        !Style.isResolvingActiveVariants &&
+        hasContextVariantBuilders &&
+        other.$variants == null) {
+      final builder = ContextVariantBuilder<FlexStyler>((_) => other);
+      return merge(
+        FlexStyler(variants: [VariantStyle<FlexSpec>(builder, other)]),
+      );
+    }
+
     return FlexStyler.create(
       clipBehavior: MixOps.merge($clipBehavior, other?.$clipBehavior),
       crossAxisAlignment: MixOps.merge(

--- a/packages/mix/lib/src/specs/flexbox/flexbox_style.g.dart
+++ b/packages/mix/lib/src/specs/flexbox/flexbox_style.g.dart
@@ -10,20 +10,26 @@ mixin _$FlexBoxStylerMixin on Style<FlexBoxSpec>, Diagnosticable {
   Prop<StyleSpec<BoxSpec>>? get $box;
   Prop<StyleSpec<FlexSpec>>? get $flex;
 
+  @override
+  bool get hasBasePayload =>
+      $box != null || $flex != null || $modifier != null || $animation != null;
+
+  @override
+  FlexBoxStyler copyWithVariants(List<VariantStyle<FlexBoxSpec>>? variants) {
+    return FlexBoxStyler.create(
+      box: $box,
+      flex: $flex,
+      variants: variants,
+      modifier: $modifier,
+      animation: $animation,
+    );
+  }
+
   /// Merges with another [FlexBoxStyler].
   @override
   FlexBoxStyler merge(FlexBoxStyler? other) {
-    final hasContextVariantBuilders =
-        $variants?.any((v) => v.variant is ContextVariantBuilder) ?? false;
-    if (other != null &&
-        !Style.isResolvingActiveVariants &&
-        hasContextVariantBuilders &&
-        other.$variants == null) {
-      final builder = ContextVariantBuilder<FlexBoxStyler>((_) => other);
-      return merge(
-        FlexBoxStyler(variants: [VariantStyle<FlexBoxSpec>(builder, other)]),
-      );
-    }
+    final deferred = deferMerge(other);
+    if (deferred != null) return deferred as FlexBoxStyler;
 
     return FlexBoxStyler.create(
       box: MixOps.merge($box, other?.$box),

--- a/packages/mix/lib/src/specs/flexbox/flexbox_style.g.dart
+++ b/packages/mix/lib/src/specs/flexbox/flexbox_style.g.dart
@@ -13,6 +13,18 @@ mixin _$FlexBoxStylerMixin on Style<FlexBoxSpec>, Diagnosticable {
   /// Merges with another [FlexBoxStyler].
   @override
   FlexBoxStyler merge(FlexBoxStyler? other) {
+    final hasContextVariantBuilders =
+        $variants?.any((v) => v.variant is ContextVariantBuilder) ?? false;
+    if (other != null &&
+        !Style.isResolvingActiveVariants &&
+        hasContextVariantBuilders &&
+        other.$variants == null) {
+      final builder = ContextVariantBuilder<FlexBoxStyler>((_) => other);
+      return merge(
+        FlexBoxStyler(variants: [VariantStyle<FlexBoxSpec>(builder, other)]),
+      );
+    }
+
     return FlexBoxStyler.create(
       box: MixOps.merge($box, other?.$box),
       flex: MixOps.merge($flex, other?.$flex),

--- a/packages/mix/lib/src/specs/icon/icon_style.g.dart
+++ b/packages/mix/lib/src/specs/icon/icon_style.g.dart
@@ -101,20 +101,51 @@ mixin _$IconStylerMixin on Style<IconSpec>, Diagnosticable {
     return merge(IconStyler(modifier: value));
   }
 
+  @override
+  bool get hasBasePayload =>
+      $applyTextScaling != null ||
+      $blendMode != null ||
+      $color != null ||
+      $fill != null ||
+      $grade != null ||
+      $icon != null ||
+      $opacity != null ||
+      $opticalSize != null ||
+      $semanticsLabel != null ||
+      $shadows != null ||
+      $size != null ||
+      $textDirection != null ||
+      $weight != null ||
+      $modifier != null ||
+      $animation != null;
+
+  @override
+  IconStyler copyWithVariants(List<VariantStyle<IconSpec>>? variants) {
+    return IconStyler.create(
+      applyTextScaling: $applyTextScaling,
+      blendMode: $blendMode,
+      color: $color,
+      fill: $fill,
+      grade: $grade,
+      icon: $icon,
+      opacity: $opacity,
+      opticalSize: $opticalSize,
+      semanticsLabel: $semanticsLabel,
+      shadows: $shadows,
+      size: $size,
+      textDirection: $textDirection,
+      weight: $weight,
+      variants: variants,
+      modifier: $modifier,
+      animation: $animation,
+    );
+  }
+
   /// Merges with another [IconStyler].
   @override
   IconStyler merge(IconStyler? other) {
-    final hasContextVariantBuilders =
-        $variants?.any((v) => v.variant is ContextVariantBuilder) ?? false;
-    if (other != null &&
-        !Style.isResolvingActiveVariants &&
-        hasContextVariantBuilders &&
-        other.$variants == null) {
-      final builder = ContextVariantBuilder<IconStyler>((_) => other);
-      return merge(
-        IconStyler(variants: [VariantStyle<IconSpec>(builder, other)]),
-      );
-    }
+    final deferred = deferMerge(other);
+    if (deferred != null) return deferred as IconStyler;
 
     return IconStyler.create(
       applyTextScaling: MixOps.merge(

--- a/packages/mix/lib/src/specs/icon/icon_style.g.dart
+++ b/packages/mix/lib/src/specs/icon/icon_style.g.dart
@@ -104,6 +104,18 @@ mixin _$IconStylerMixin on Style<IconSpec>, Diagnosticable {
   /// Merges with another [IconStyler].
   @override
   IconStyler merge(IconStyler? other) {
+    final hasContextVariantBuilders =
+        $variants?.any((v) => v.variant is ContextVariantBuilder) ?? false;
+    if (other != null &&
+        !Style.isResolvingActiveVariants &&
+        hasContextVariantBuilders &&
+        other.$variants == null) {
+      final builder = ContextVariantBuilder<IconStyler>((_) => other);
+      return merge(
+        IconStyler(variants: [VariantStyle<IconSpec>(builder, other)]),
+      );
+    }
+
     return IconStyler.create(
       applyTextScaling: MixOps.merge(
         $applyTextScaling,

--- a/packages/mix/lib/src/specs/image/image_style.g.dart
+++ b/packages/mix/lib/src/specs/image/image_style.g.dart
@@ -116,6 +116,18 @@ mixin _$ImageStylerMixin on Style<ImageSpec>, Diagnosticable {
   /// Merges with another [ImageStyler].
   @override
   ImageStyler merge(ImageStyler? other) {
+    final hasContextVariantBuilders =
+        $variants?.any((v) => v.variant is ContextVariantBuilder) ?? false;
+    if (other != null &&
+        !Style.isResolvingActiveVariants &&
+        hasContextVariantBuilders &&
+        other.$variants == null) {
+      final builder = ContextVariantBuilder<ImageStyler>((_) => other);
+      return merge(
+        ImageStyler(variants: [VariantStyle<ImageSpec>(builder, other)]),
+      );
+    }
+
     return ImageStyler.create(
       alignment: MixOps.merge($alignment, other?.$alignment),
       centerSlice: MixOps.merge($centerSlice, other?.$centerSlice),

--- a/packages/mix/lib/src/specs/image/image_style.g.dart
+++ b/packages/mix/lib/src/specs/image/image_style.g.dart
@@ -113,20 +113,55 @@ mixin _$ImageStylerMixin on Style<ImageSpec>, Diagnosticable {
     return merge(ImageStyler(modifier: value));
   }
 
+  @override
+  bool get hasBasePayload =>
+      $alignment != null ||
+      $centerSlice != null ||
+      $color != null ||
+      $colorBlendMode != null ||
+      $excludeFromSemantics != null ||
+      $filterQuality != null ||
+      $fit != null ||
+      $gaplessPlayback != null ||
+      $height != null ||
+      $image != null ||
+      $isAntiAlias != null ||
+      $matchTextDirection != null ||
+      $repeat != null ||
+      $semanticLabel != null ||
+      $width != null ||
+      $modifier != null ||
+      $animation != null;
+
+  @override
+  ImageStyler copyWithVariants(List<VariantStyle<ImageSpec>>? variants) {
+    return ImageStyler.create(
+      alignment: $alignment,
+      centerSlice: $centerSlice,
+      color: $color,
+      colorBlendMode: $colorBlendMode,
+      excludeFromSemantics: $excludeFromSemantics,
+      filterQuality: $filterQuality,
+      fit: $fit,
+      gaplessPlayback: $gaplessPlayback,
+      height: $height,
+      image: $image,
+      isAntiAlias: $isAntiAlias,
+      matchTextDirection: $matchTextDirection,
+      repeat: $repeat,
+      semanticLabel: $semanticLabel,
+      width: $width,
+      variants: variants,
+      modifier: $modifier,
+      animation: $animation,
+    );
+  }
+
   /// Merges with another [ImageStyler].
   @override
   ImageStyler merge(ImageStyler? other) {
-    final hasContextVariantBuilders =
-        $variants?.any((v) => v.variant is ContextVariantBuilder) ?? false;
-    if (other != null &&
-        !Style.isResolvingActiveVariants &&
-        hasContextVariantBuilders &&
-        other.$variants == null) {
-      final builder = ContextVariantBuilder<ImageStyler>((_) => other);
-      return merge(
-        ImageStyler(variants: [VariantStyle<ImageSpec>(builder, other)]),
-      );
-    }
+    final deferred = deferMerge(other);
+    if (deferred != null) return deferred as ImageStyler;
 
     return ImageStyler.create(
       alignment: MixOps.merge($alignment, other?.$alignment),

--- a/packages/mix/lib/src/specs/stack/stack_style.g.dart
+++ b/packages/mix/lib/src/specs/stack/stack_style.g.dart
@@ -50,6 +50,18 @@ mixin _$StackStylerMixin on Style<StackSpec>, Diagnosticable {
   /// Merges with another [StackStyler].
   @override
   StackStyler merge(StackStyler? other) {
+    final hasContextVariantBuilders =
+        $variants?.any((v) => v.variant is ContextVariantBuilder) ?? false;
+    if (other != null &&
+        !Style.isResolvingActiveVariants &&
+        hasContextVariantBuilders &&
+        other.$variants == null) {
+      final builder = ContextVariantBuilder<StackStyler>((_) => other);
+      return merge(
+        StackStyler(variants: [VariantStyle<StackSpec>(builder, other)]),
+      );
+    }
+
     return StackStyler.create(
       alignment: MixOps.merge($alignment, other?.$alignment),
       clipBehavior: MixOps.merge($clipBehavior, other?.$clipBehavior),

--- a/packages/mix/lib/src/specs/stack/stack_style.g.dart
+++ b/packages/mix/lib/src/specs/stack/stack_style.g.dart
@@ -47,20 +47,33 @@ mixin _$StackStylerMixin on Style<StackSpec>, Diagnosticable {
     return merge(StackStyler(modifier: value));
   }
 
+  @override
+  bool get hasBasePayload =>
+      $alignment != null ||
+      $clipBehavior != null ||
+      $fit != null ||
+      $textDirection != null ||
+      $modifier != null ||
+      $animation != null;
+
+  @override
+  StackStyler copyWithVariants(List<VariantStyle<StackSpec>>? variants) {
+    return StackStyler.create(
+      alignment: $alignment,
+      clipBehavior: $clipBehavior,
+      fit: $fit,
+      textDirection: $textDirection,
+      variants: variants,
+      modifier: $modifier,
+      animation: $animation,
+    );
+  }
+
   /// Merges with another [StackStyler].
   @override
   StackStyler merge(StackStyler? other) {
-    final hasContextVariantBuilders =
-        $variants?.any((v) => v.variant is ContextVariantBuilder) ?? false;
-    if (other != null &&
-        !Style.isResolvingActiveVariants &&
-        hasContextVariantBuilders &&
-        other.$variants == null) {
-      final builder = ContextVariantBuilder<StackStyler>((_) => other);
-      return merge(
-        StackStyler(variants: [VariantStyle<StackSpec>(builder, other)]),
-      );
-    }
+    final deferred = deferMerge(other);
+    if (deferred != null) return deferred as StackStyler;
 
     return StackStyler.create(
       alignment: MixOps.merge($alignment, other?.$alignment),

--- a/packages/mix/lib/src/specs/stackbox/stackbox_style.g.dart
+++ b/packages/mix/lib/src/specs/stackbox/stackbox_style.g.dart
@@ -13,6 +13,18 @@ mixin _$StackBoxStylerMixin on Style<StackBoxSpec>, Diagnosticable {
   /// Merges with another [StackBoxStyler].
   @override
   StackBoxStyler merge(StackBoxStyler? other) {
+    final hasContextVariantBuilders =
+        $variants?.any((v) => v.variant is ContextVariantBuilder) ?? false;
+    if (other != null &&
+        !Style.isResolvingActiveVariants &&
+        hasContextVariantBuilders &&
+        other.$variants == null) {
+      final builder = ContextVariantBuilder<StackBoxStyler>((_) => other);
+      return merge(
+        StackBoxStyler(variants: [VariantStyle<StackBoxSpec>(builder, other)]),
+      );
+    }
+
     return StackBoxStyler.create(
       box: MixOps.merge($box, other?.$box),
       stack: MixOps.merge($stack, other?.$stack),

--- a/packages/mix/lib/src/specs/stackbox/stackbox_style.g.dart
+++ b/packages/mix/lib/src/specs/stackbox/stackbox_style.g.dart
@@ -10,20 +10,26 @@ mixin _$StackBoxStylerMixin on Style<StackBoxSpec>, Diagnosticable {
   Prop<StyleSpec<BoxSpec>>? get $box;
   Prop<StyleSpec<StackSpec>>? get $stack;
 
+  @override
+  bool get hasBasePayload =>
+      $box != null || $stack != null || $modifier != null || $animation != null;
+
+  @override
+  StackBoxStyler copyWithVariants(List<VariantStyle<StackBoxSpec>>? variants) {
+    return StackBoxStyler.create(
+      box: $box,
+      stack: $stack,
+      variants: variants,
+      modifier: $modifier,
+      animation: $animation,
+    );
+  }
+
   /// Merges with another [StackBoxStyler].
   @override
   StackBoxStyler merge(StackBoxStyler? other) {
-    final hasContextVariantBuilders =
-        $variants?.any((v) => v.variant is ContextVariantBuilder) ?? false;
-    if (other != null &&
-        !Style.isResolvingActiveVariants &&
-        hasContextVariantBuilders &&
-        other.$variants == null) {
-      final builder = ContextVariantBuilder<StackBoxStyler>((_) => other);
-      return merge(
-        StackBoxStyler(variants: [VariantStyle<StackBoxSpec>(builder, other)]),
-      );
-    }
+    final deferred = deferMerge(other);
+    if (deferred != null) return deferred as StackBoxStyler;
 
     return StackBoxStyler.create(
       box: MixOps.merge($box, other?.$box),

--- a/packages/mix/lib/src/specs/text/text_style.g.dart
+++ b/packages/mix/lib/src/specs/text/text_style.g.dart
@@ -105,6 +105,18 @@ mixin _$TextStylerMixin on Style<TextSpec>, Diagnosticable {
   /// Merges with another [TextStyler].
   @override
   TextStyler merge(TextStyler? other) {
+    final hasContextVariantBuilders =
+        $variants?.any((v) => v.variant is ContextVariantBuilder) ?? false;
+    if (other != null &&
+        !Style.isResolvingActiveVariants &&
+        hasContextVariantBuilders &&
+        other.$variants == null) {
+      final builder = ContextVariantBuilder<TextStyler>((_) => other);
+      return merge(
+        TextStyler(variants: [VariantStyle<TextSpec>(builder, other)]),
+      );
+    }
+
     return TextStyler.create(
       locale: MixOps.merge($locale, other?.$locale),
       maxLines: MixOps.merge($maxLines, other?.$maxLines),

--- a/packages/mix/lib/src/specs/text/text_style.g.dart
+++ b/packages/mix/lib/src/specs/text/text_style.g.dart
@@ -102,20 +102,53 @@ mixin _$TextStylerMixin on Style<TextSpec>, Diagnosticable {
     return merge(TextStyler(modifier: value));
   }
 
+  @override
+  bool get hasBasePayload =>
+      $locale != null ||
+      $maxLines != null ||
+      $overflow != null ||
+      $selectionColor != null ||
+      $semanticsLabel != null ||
+      $softWrap != null ||
+      $strutStyle != null ||
+      $style != null ||
+      $textAlign != null ||
+      $textDirection != null ||
+      $textDirectives != null ||
+      $textHeightBehavior != null ||
+      $textScaler != null ||
+      $textWidthBasis != null ||
+      $modifier != null ||
+      $animation != null;
+
+  @override
+  TextStyler copyWithVariants(List<VariantStyle<TextSpec>>? variants) {
+    return TextStyler.create(
+      locale: $locale,
+      maxLines: $maxLines,
+      overflow: $overflow,
+      selectionColor: $selectionColor,
+      semanticsLabel: $semanticsLabel,
+      softWrap: $softWrap,
+      strutStyle: $strutStyle,
+      style: $style,
+      textAlign: $textAlign,
+      textDirection: $textDirection,
+      textDirectives: $textDirectives,
+      textHeightBehavior: $textHeightBehavior,
+      textScaler: $textScaler,
+      textWidthBasis: $textWidthBasis,
+      variants: variants,
+      modifier: $modifier,
+      animation: $animation,
+    );
+  }
+
   /// Merges with another [TextStyler].
   @override
   TextStyler merge(TextStyler? other) {
-    final hasContextVariantBuilders =
-        $variants?.any((v) => v.variant is ContextVariantBuilder) ?? false;
-    if (other != null &&
-        !Style.isResolvingActiveVariants &&
-        hasContextVariantBuilders &&
-        other.$variants == null) {
-      final builder = ContextVariantBuilder<TextStyler>((_) => other);
-      return merge(
-        TextStyler(variants: [VariantStyle<TextSpec>(builder, other)]),
-      );
-    }
+    final deferred = deferMerge(other);
+    if (deferred != null) return deferred as TextStyler;
 
     return TextStyler.create(
       locale: MixOps.merge($locale, other?.$locale),

--- a/packages/mix/lib/src/style/abstracts/styler.dart
+++ b/packages/mix/lib/src/style/abstracts/styler.dart
@@ -3,6 +3,7 @@ import 'package:flutter/foundation.dart';
 import '../../core/spec.dart';
 import '../../core/style.dart';
 import '../mixins/animation_style_mixin.dart';
+import '../mixins/token_style_mixin.dart';
 import '../mixins/variant_style_mixin.dart';
 import '../mixins/widget_modifier_style_mixin.dart';
 import '../mixins/widget_state_variant_mixin.dart';
@@ -13,6 +14,7 @@ abstract class MixStyler<ST extends Style<SP>, SP extends Spec<SP>>
         Diagnosticable,
         WidgetModifierStyleMixin<ST, SP>,
         VariantStyleMixin<ST, SP>,
+        TokenStyleMixin<ST, SP>,
         WidgetStateVariantMixin<ST, SP>,
         AnimationStyleMixin<ST, SP> {
   const MixStyler({

--- a/packages/mix/lib/src/style/mixins/token_style_mixin.dart
+++ b/packages/mix/lib/src/style/mixins/token_style_mixin.dart
@@ -1,0 +1,14 @@
+import '../../core/spec.dart';
+import '../../core/style.dart';
+import '../../theme/tokens/mix_token.dart';
+import 'variant_style_mixin.dart';
+
+mixin TokenStyleMixin<T extends Style<S>, S extends Spec<S>>
+    on VariantStyleMixin<T, S> {
+  /// Applies style values produced from a resolved [MixToken].
+  ///
+  /// The token is resolved at build time using the current [BuildContext].
+  T useToken<U>(MixToken<U> token, T Function(U value) builder) {
+    return onBuilder((context) => builder(token.resolve(context)));
+  }
+}

--- a/packages/mix/lib/src/variants/variant.dart
+++ b/packages/mix/lib/src/variants/variant.dart
@@ -174,6 +174,26 @@ class ContextVariantBuilder<S extends Style<Object?>> extends Variant {
   S build(BuildContext context) => fn(context);
 }
 
+/// Internal variant carrying a deferred base-merge payload.
+///
+/// Uses identity-based keys to prevent merge-key collisions when multiple
+/// deferred merges are queued.
+@internal
+final class DeferredVariant<S extends Spec<S>> extends Variant {
+  final Style<S> payload;
+
+  const DeferredVariant(this.payload);
+
+  @override
+  String get key => 'deferred_${identityHashCode(this)}';
+
+  @override
+  bool operator ==(Object other) => identical(this, other);
+
+  @override
+  int get hashCode => identityHashCode(this);
+}
+
 // Helper functions for cleaner variant checking
 bool hasVariant(List<NamedVariant> activeVariants, NamedVariant variant) =>
     activeVariants.contains(variant);

--- a/packages/mix/test/helpers/testing_utils.dart
+++ b/packages/mix/test/helpers/testing_utils.dart
@@ -268,6 +268,19 @@ class MockStyle<T> extends Style<MockSpec<T>> {
   });
 
   @override
+  bool get hasBasePayload => true;
+
+  @override
+  MockStyle<T> copyWithVariants(List<VariantStyle<MockSpec<T>>>? variants) {
+    return MockStyle<T>(
+      value,
+      variants: variants,
+      modifier: $modifier,
+      animation: $animation,
+    );
+  }
+
+  @override
   MockStyle<T> merge(covariant MockStyle<T>? other) {
     if (other == null) return this;
     // For Prop types, use their merge method

--- a/packages/mix/test/src/core/style_defer_merge_test.dart
+++ b/packages/mix/test/src/core/style_defer_merge_test.dart
@@ -1,0 +1,164 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mix/mix.dart';
+
+import '../../helpers/testing_utils.dart';
+
+void main() {
+  group('Style.deferMerge', () {
+    test('returns null when no ContextVariantBuilder is present', () {
+      final style = BoxStyler().color(Colors.red);
+      final other = BoxStyler().paddingAll(8);
+
+      expect(style.deferMerge(other), isNull);
+    });
+
+    test('returns null during active variant resolution', () {
+      final deferredResults = <Style<MockSpec<Map<String, dynamic>>>?>[];
+
+      final style = _ProbeStyle(
+        variants: [
+          VariantStyle<MockSpec<Map<String, dynamic>>>(
+            ContextVariantBuilder<_ProbeStyle>((_) => _ProbeStyle(width: 10)),
+            _ProbeStyle(),
+          ),
+        ],
+        onDeferChecked: deferredResults.add,
+      );
+
+      style.mergeActiveVariants(MockBuildContext(), namedVariants: const {});
+
+      expect(deferredResults, hasLength(1));
+      expect(deferredResults.single, isNull);
+    });
+
+    test('deferred variants use identity-based keys', () {
+      final payload = BoxStyler().color(Colors.red);
+      final first = DeferredVariant<BoxSpec>(payload);
+      final second = DeferredVariant<BoxSpec>(payload);
+
+      expect(first.key, isNot(second.key));
+      expect(first, isNot(equals(second)));
+      expect(first.hashCode, isNot(second.hashCode));
+    });
+
+    test('cycle detection prevents recursive variant overflow', () {
+      late BoxStyler recursiveStyle;
+      recursiveStyle = BoxStyler(
+        variants: [
+          VariantStyle<BoxSpec>(
+            ContextVariantBuilder<BoxStyler>((_) => recursiveStyle),
+            BoxStyler(),
+          ),
+        ],
+      );
+
+      expect(
+        () => recursiveStyle.mergeActiveVariants(
+          MockBuildContext(),
+          namedVariants: const {},
+        ),
+        returnsNormally,
+      );
+    });
+
+    testWidgets(
+      'multiple sequential merges after useToken keep deferred variants and last overlap wins',
+      (tester) async {
+        const colorToken = ColorToken('test.defer.merge.sequence');
+
+        final style = BoxStyler()
+            .useToken(colorToken, BoxStyler().color)
+            .merge(BoxStyler().paddingAll(8).color(Colors.red))
+            .merge(BoxStyler().marginAll(4).color(Colors.blue));
+
+        final deferredCount =
+            style.$variants
+                ?.where((v) => v.variant is DeferredVariant<BoxSpec>)
+                .length ??
+            0;
+        expect(deferredCount, 2);
+
+        await tester.pumpWidget(
+          Directionality(
+            textDirection: TextDirection.ltr,
+            child: MixScope(
+              tokens: {colorToken: Colors.green},
+              child: Builder(
+                builder: (context) {
+                  final built = style.build(context);
+                  final spec = built.spec;
+                  final color = (spec.decoration as BoxDecoration?)?.color;
+
+                  expect(color, Colors.blue);
+                  expect(spec.padding, const EdgeInsets.all(8));
+                  expect(spec.margin, const EdgeInsets.all(4));
+
+                  return const SizedBox.shrink();
+                },
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  });
+}
+
+class _ProbeStyle extends Style<MockSpec<Map<String, dynamic>>> {
+  final double? width;
+  final void Function(Style<MockSpec<Map<String, dynamic>>>? deferred)?
+  onDeferChecked;
+
+  const _ProbeStyle({
+    this.width,
+    this.onDeferChecked,
+    super.variants = const [],
+    super.modifier,
+    super.animation,
+  });
+
+  @override
+  bool get hasBasePayload =>
+      width != null || $modifier != null || $animation != null;
+
+  @override
+  _ProbeStyle copyWithVariants(
+    List<VariantStyle<MockSpec<Map<String, dynamic>>>>? variants,
+  ) {
+    return _ProbeStyle(
+      width: width,
+      onDeferChecked: onDeferChecked,
+      variants: variants,
+      modifier: $modifier,
+      animation: $animation,
+    );
+  }
+
+  @override
+  _ProbeStyle merge(covariant _ProbeStyle? other) {
+    final deferred = deferMerge(other);
+    onDeferChecked?.call(deferred);
+    if (deferred != null) return deferred as _ProbeStyle;
+
+    return _ProbeStyle(
+      width: other?.width ?? width,
+      variants: MixOps.mergeVariants($variants, other?.$variants),
+      modifier: MixOps.mergeModifier($modifier, other?.$modifier),
+      animation: MixOps.mergeAnimation($animation, other?.$animation),
+      onDeferChecked: onDeferChecked,
+    );
+  }
+
+  @override
+  StyleSpec<MockSpec<Map<String, dynamic>>> resolve(BuildContext context) {
+    return StyleSpec(
+      spec: MockSpec<Map<String, dynamic>>(resolvedValue: {'width': width}),
+      animation: $animation,
+      widgetModifiers: $modifier?.resolve(context),
+    );
+  }
+
+  @override
+  List<Object?> get props => [width, $variants, $modifier, $animation];
+}

--- a/packages/mix/test/src/core/style_get_all_variants_test.dart
+++ b/packages/mix/test/src/core/style_get_all_variants_test.dart
@@ -599,26 +599,70 @@ void main() {
         expect((spec.resolvedValue as Map)['width'], 50.0);
       });
 
-      test('sorting is stable for non-WidgetStateVariant elements', () {
-        // Create multiple non-WidgetState variants to test stable sort
-        final variants = [
-          VariantStyle(
-            ContextVariant('context1', (context) => true),
-            _MockSpecAttribute(width: 100.0),
-          ),
-          VariantStyle(
-            const NamedVariant('named1'),
-            _MockSpecAttribute(width: 200.0),
-          ),
-          VariantStyle(
-            ContextVariant('context2', (context) => true),
-            _MockSpecAttribute(width: 300.0),
-          ),
-          VariantStyle(
-            const NamedVariant('named2'),
-            _MockSpecAttribute(width: 400.0),
-          ),
+      test('non-WidgetState variants preserve insertion order', () {
+        // This specific order is intentionally non-sequential and large enough
+        // to catch unstable ordering if equal-priority variants are re-sorted.
+        const order = [
+          48,
+          42,
+          46,
+          5,
+          20,
+          24,
+          36,
+          28,
+          23,
+          32,
+          13,
+          0,
+          30,
+          16,
+          31,
+          10,
+          11,
+          25,
+          9,
+          1,
+          41,
+          33,
+          26,
+          2,
+          29,
+          6,
+          35,
+          39,
+          18,
+          22,
+          14,
+          37,
+          19,
+          40,
+          38,
+          44,
+          49,
+          15,
+          43,
+          34,
+          3,
+          12,
+          7,
+          8,
+          45,
+          27,
+          21,
+          47,
+          17,
+          4,
         ];
+
+        final variants = order
+            .map(
+              (value) => VariantStyle(
+                ContextVariant('context$value', (context) => true),
+                _MockSpecAttribute(width: value.toDouble()),
+              ),
+            )
+            .toList();
 
         final testAttribute = _MockSpecAttribute(
           width: 50.0,
@@ -628,15 +672,11 @@ void main() {
         final context = MockBuildContext();
         final result = testAttribute.mergeActiveVariants(
           context,
-          namedVariants: {
-            const NamedVariant('named1'),
-            const NamedVariant('named2'),
-          },
+          namedVariants: {},
         );
 
-        // Should maintain original order, last applied is named2 (400)
         final spec = result.resolve(context);
-        expect((spec.resolvedValue as Map)['width'], 400.0);
+        expect((spec.resolvedValue as Map)['width'], 4.0);
       });
     });
 

--- a/packages/mix/test/src/core/style_get_all_variants_test.dart
+++ b/packages/mix/test/src/core/style_get_all_variants_test.dart
@@ -600,60 +600,8 @@ void main() {
       });
 
       test('non-WidgetState variants preserve insertion order', () {
-        // This specific order is intentionally non-sequential and large enough
-        // to catch unstable ordering if equal-priority variants are re-sorted.
-        const order = [
-          48,
-          42,
-          46,
-          5,
-          20,
-          24,
-          36,
-          28,
-          23,
-          32,
-          13,
-          0,
-          30,
-          16,
-          31,
-          10,
-          11,
-          25,
-          9,
-          1,
-          41,
-          33,
-          26,
-          2,
-          29,
-          6,
-          35,
-          39,
-          18,
-          22,
-          14,
-          37,
-          19,
-          40,
-          38,
-          44,
-          49,
-          15,
-          43,
-          34,
-          3,
-          12,
-          7,
-          8,
-          45,
-          27,
-          21,
-          47,
-          17,
-          4,
-        ];
+        // Non-sequential order to catch unstable sorting of equal-priority variants.
+        const order = [5, 3, 7, 1, 6, 2, 4];
 
         final variants = order
             .map(
@@ -675,6 +623,7 @@ void main() {
           namedVariants: {},
         );
 
+        // Last element in insertion order (4) wins via sequential merge.
         final spec = result.resolve(context);
         expect((spec.resolvedValue as Map)['width'], 4.0);
       });
@@ -779,6 +728,23 @@ class _MockSpecAttribute extends Style<MockSpec<Map<String, dynamic>>> {
     super.modifier,
     super.animation,
   });
+
+  @override
+  bool get hasBasePayload =>
+      width != 0.0 || height != null || $modifier != null || $animation != null;
+
+  @override
+  _MockSpecAttribute copyWithVariants(
+    List<VariantStyle<MockSpec<Map<String, dynamic>>>>? variants,
+  ) {
+    return _MockSpecAttribute(
+      width: width,
+      height: height,
+      variants: variants,
+      modifier: $modifier,
+      animation: $animation,
+    );
+  }
 
   @override
   StyleSpec<MockSpec<Map<String, dynamic>>> resolve(BuildContext context) {

--- a/packages/mix/test/src/core/style_nested_variants_test.dart
+++ b/packages/mix/test/src/core/style_nested_variants_test.dart
@@ -309,6 +309,23 @@ class _MockSpecAttribute extends Style<MockSpec<Map<String, dynamic>>> {
   });
 
   @override
+  bool get hasBasePayload =>
+      width != 0.0 || height != null || $modifier != null || $animation != null;
+
+  @override
+  _MockSpecAttribute copyWithVariants(
+    List<VariantStyle<MockSpec<Map<String, dynamic>>>>? variants,
+  ) {
+    return _MockSpecAttribute(
+      width: width,
+      height: height,
+      variants: variants,
+      modifier: $modifier,
+      animation: $animation,
+    );
+  }
+
+  @override
   StyleSpec<MockSpec<Map<String, dynamic>>> resolve(BuildContext context) {
     return StyleSpec(
       spec: MockSpec<Map<String, dynamic>>(

--- a/packages/mix/test/src/style/token_style_mixin_test.dart
+++ b/packages/mix/test/src/style/token_style_mixin_test.dart
@@ -117,6 +117,120 @@ void main() {
       expect(decoration?.color, Colors.red);
     });
 
+    testWidgets(
+      'explicit merge with base and onDark preserves light order and dark override',
+      (tester) async {
+        const colorToken = ColorToken('test.explicit.merge.dark.token');
+        final merged = BoxStyler()
+            .color(Colors.red)
+            .onDark(BoxStyler().color(Colors.black));
+        final style = BoxStyler()
+            .useToken(colorToken, BoxStyler().color)
+            .merge(merged);
+
+        Future<void> pumpWithBrightness(Brightness brightness) {
+          return tester.pumpWidget(
+            MediaQuery(
+              data: MediaQueryData(platformBrightness: brightness),
+              child: Directionality(
+                textDirection: TextDirection.ltr,
+                child: MixScope(
+                  tokens: {colorToken: Colors.green},
+                  child: Box(style: style),
+                ),
+              ),
+            ),
+          );
+        }
+
+        await pumpWithBrightness(Brightness.light);
+        var container = tester.widget<Container>(find.byType(Container));
+        var decoration = container.decoration as BoxDecoration?;
+        expect(decoration?.color, Colors.red);
+
+        await pumpWithBrightness(Brightness.dark);
+        container = tester.widget<Container>(find.byType(Container));
+        decoration = container.decoration as BoxDecoration?;
+        expect(decoration?.color, Colors.black);
+      },
+    );
+
+    testWidgets(
+      'explicit merge with base and onHovered preserves normal order and hovered override',
+      (tester) async {
+        const colorToken = ColorToken('test.explicit.merge.hovered.token');
+        final merged = BoxStyler()
+            .color(Colors.red)
+            .onHovered(BoxStyler().color(Colors.blue));
+        final style = BoxStyler()
+            .useToken(colorToken, BoxStyler().color)
+            .merge(merged);
+
+        Future<void> pumpWithStates(Set<WidgetState> states) {
+          return tester.pumpWidget(
+            Directionality(
+              textDirection: TextDirection.ltr,
+              child: MixScope(
+                tokens: {colorToken: Colors.green},
+                child: WidgetStateProvider(
+                  states: states,
+                  child: Box(style: style),
+                ),
+              ),
+            ),
+          );
+        }
+
+        await pumpWithStates(<WidgetState>{});
+        var container = tester.widget<Container>(find.byType(Container));
+        var decoration = container.decoration as BoxDecoration?;
+        expect(decoration?.color, Colors.red);
+
+        await pumpWithStates({WidgetState.hovered});
+        container = tester.widget<Container>(find.byType(Container));
+        decoration = container.decoration as BoxDecoration?;
+        expect(decoration?.color, Colors.blue);
+      },
+    );
+
+    testWidgets(
+      'explicit merge with variants-only style keeps token fallback',
+      (tester) async {
+        const colorToken = ColorToken(
+          'test.explicit.merge.variants.only.token',
+        );
+        final merged = BoxStyler().onDark(BoxStyler().color(Colors.black));
+        final style = BoxStyler()
+            .useToken(colorToken, BoxStyler().color)
+            .merge(merged);
+
+        Future<void> pumpWithBrightness(Brightness brightness) {
+          return tester.pumpWidget(
+            MediaQuery(
+              data: MediaQueryData(platformBrightness: brightness),
+              child: Directionality(
+                textDirection: TextDirection.ltr,
+                child: MixScope(
+                  tokens: {colorToken: Colors.green},
+                  child: Box(style: style),
+                ),
+              ),
+            ),
+          );
+        }
+
+        await pumpWithBrightness(Brightness.light);
+        var container = tester.widget<Container>(find.byType(Container));
+        var decoration = container.decoration as BoxDecoration?;
+        expect(decoration?.color, Colors.green);
+
+        await pumpWithBrightness(Brightness.dark);
+        container = tester.widget<Container>(find.byType(Container));
+        decoration = container.decoration as BoxDecoration?;
+        expect(decoration?.color, Colors.black);
+      },
+    );
+
     testWidgets('post-token animation and modifiers are preserved', (
       tester,
     ) async {

--- a/packages/mix/test/src/style/token_style_mixin_test.dart
+++ b/packages/mix/test/src/style/token_style_mixin_test.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mix/mix.dart';
+
+extension TokenWidgetTester on WidgetTester {
+  Future<void> pumpWithTokens(
+    Map<MixToken, Object> tokens, {
+    required Widget child,
+  }) {
+    return pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: MixScope(tokens: tokens, child: child),
+      ),
+    );
+  }
+}
+
+void main() {
+  group('TokenStyleMixin', () {
+    test('useToken registers a context variant builder', () {
+      const colorToken = ColorToken('test.color');
+      final style = BoxStyler().useToken(colorToken, BoxStyler().color);
+
+      expect(style.$variants, isNotNull);
+      expect(style.$variants, hasLength(1));
+      expect(style.$variants!.first.variant, isA<ContextVariantBuilder>());
+    });
+
+    testWidgets('resolves token value in widget tree', (tester) async {
+      const colorToken = ColorToken('test.primary');
+      const tokenColor = Colors.blue;
+
+      final style = BoxStyler().useToken(colorToken, BoxStyler().color);
+
+      await tester.pumpWithTokens({
+        colorToken: tokenColor,
+      }, child: Box(style: style));
+
+      final container = tester.widget<Container>(find.byType(Container));
+      final decoration = container.decoration as BoxDecoration?;
+      expect(decoration?.color, tokenColor);
+    });
+
+    testWidgets('property after useToken takes precedence', (tester) async {
+      const colorToken = ColorToken('test.after.token');
+
+      final style = BoxStyler()
+          .useToken(colorToken, BoxStyler().color)
+          .color(Colors.red);
+
+      await tester.pumpWithTokens({
+        colorToken: Colors.green,
+      }, child: Box(style: style));
+
+      final container = tester.widget<Container>(find.byType(Container));
+      final decoration = container.decoration as BoxDecoration?;
+      expect(decoration?.color, Colors.red);
+    });
+
+    testWidgets('property-token-property keeps last property winner', (
+      tester,
+    ) async {
+      const colorToken = ColorToken('test.middle.token');
+
+      final style = BoxStyler()
+          .color(Colors.blue)
+          .useToken(colorToken, BoxStyler().color)
+          .color(Colors.red);
+
+      await tester.pumpWithTokens({
+        colorToken: Colors.green,
+      }, child: Box(style: style));
+
+      final container = tester.widget<Container>(find.byType(Container));
+      final decoration = container.decoration as BoxDecoration?;
+      expect(decoration?.color, Colors.red);
+    });
+
+    testWidgets('post-token non-overlapping properties are preserved', (
+      tester,
+    ) async {
+      const colorToken = ColorToken('test.chain.token');
+      const testWidth = 123.0;
+
+      final style = BoxStyler()
+          .useToken(colorToken, BoxStyler().color)
+          .width(testWidth)
+          .color(Colors.red);
+
+      await tester.pumpWithTokens({
+        colorToken: Colors.green,
+      }, child: Box(style: style));
+
+      final container = tester.widget<Container>(find.byType(Container));
+      final decoration = container.decoration as BoxDecoration?;
+      expect(decoration?.color, Colors.red);
+      expect(container.constraints?.minWidth, testWidth);
+      expect(container.constraints?.maxWidth, testWidth);
+    });
+  });
+}

--- a/packages/mix/test/src/style/token_style_mixin_test.dart
+++ b/packages/mix/test/src/style/token_style_mixin_test.dart
@@ -99,6 +99,131 @@ void main() {
       expect(container.constraints?.maxWidth, testWidth);
     });
 
+    testWidgets('explicit merge after useToken preserves declaration order', (
+      tester,
+    ) async {
+      const colorToken = ColorToken('test.explicit.merge.token');
+
+      final style = BoxStyler()
+          .useToken(colorToken, BoxStyler().color)
+          .merge(BoxStyler().color(Colors.red));
+
+      await tester.pumpWithTokens({
+        colorToken: Colors.green,
+      }, child: Box(style: style));
+
+      final container = tester.widget<Container>(find.byType(Container));
+      final decoration = container.decoration as BoxDecoration?;
+      expect(decoration?.color, Colors.red);
+    });
+
+    testWidgets('post-token animation and modifiers are preserved', (
+      tester,
+    ) async {
+      const colorToken = ColorToken('test.animation.modifier.token');
+      const animation = CurveAnimationConfig(
+        duration: Duration(milliseconds: 120),
+        curve: Curves.linear,
+      );
+
+      final style = BoxStyler()
+          .useToken(colorToken, BoxStyler().color)
+          .animate(animation)
+          .wrap(WidgetModifierConfig.opacity(0.5));
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: MixScope(
+            tokens: {colorToken: Colors.green},
+            child: Builder(
+              builder: (context) {
+                final built = style.build(context);
+                expect(built.animation, animation);
+                expect(built.widgetModifiers, isNotNull);
+                expect(built.widgetModifiers, isNotEmpty);
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        ),
+      );
+    });
+
+    testWidgets('useToken chain composes with onHovered priority', (
+      tester,
+    ) async {
+      const colorToken = ColorToken('test.hovered.token');
+
+      final style = BoxStyler()
+          .useToken(colorToken, BoxStyler().color)
+          .color(Colors.red)
+          .onHovered(BoxStyler().color(Colors.blue));
+
+      Future<void> pumpWithStates(Set<WidgetState> states) {
+        return tester.pumpWidget(
+          Directionality(
+            textDirection: TextDirection.ltr,
+            child: MixScope(
+              tokens: {colorToken: Colors.green},
+              child: WidgetStateProvider(
+                states: states,
+                child: Box(style: style),
+              ),
+            ),
+          ),
+        );
+      }
+
+      await pumpWithStates({WidgetState.hovered});
+
+      var container = tester.widget<Container>(find.byType(Container));
+      var decoration = container.decoration as BoxDecoration?;
+      expect(decoration?.color, Colors.blue);
+
+      await pumpWithStates(<WidgetState>{});
+
+      container = tester.widget<Container>(find.byType(Container));
+      decoration = container.decoration as BoxDecoration?;
+      expect(decoration?.color, Colors.red);
+    });
+
+    testWidgets('useToken chain composes with onDark priority', (tester) async {
+      const colorToken = ColorToken('test.dark.token');
+
+      final style = BoxStyler()
+          .useToken(colorToken, BoxStyler().color)
+          .color(Colors.red)
+          .onDark(BoxStyler().color(Colors.black));
+
+      Future<void> pumpWithBrightness(Brightness brightness) {
+        return tester.pumpWidget(
+          MediaQuery(
+            data: MediaQueryData(platformBrightness: brightness),
+            child: Directionality(
+              textDirection: TextDirection.ltr,
+              child: MixScope(
+                tokens: {colorToken: Colors.green},
+                child: Box(style: style),
+              ),
+            ),
+          ),
+        );
+      }
+
+      await pumpWithBrightness(Brightness.dark);
+
+      var container = tester.widget<Container>(find.byType(Container));
+      var decoration = container.decoration as BoxDecoration?;
+      expect(decoration?.color, Colors.black);
+
+      await pumpWithBrightness(Brightness.light);
+
+      container = tester.widget<Container>(find.byType(Container));
+      decoration = container.decoration as BoxDecoration?;
+      expect(decoration?.color, Colors.red);
+    });
+
     testWidgets(
       'nested onBuilder output preserves post-token property precedence',
       (tester) async {

--- a/packages/mix/test/src/style/token_style_mixin_test.dart
+++ b/packages/mix/test/src/style/token_style_mixin_test.dart
@@ -98,5 +98,26 @@ void main() {
       expect(container.constraints?.minWidth, testWidth);
       expect(container.constraints?.maxWidth, testWidth);
     });
+
+    testWidgets(
+      'nested onBuilder output preserves post-token property precedence',
+      (tester) async {
+        const colorToken = ColorToken('test.nested.builder.token');
+
+        final style = BoxStyler().onBuilder((context) {
+          return BoxStyler()
+              .useToken(colorToken, BoxStyler().color)
+              .color(Colors.red);
+        });
+
+        await tester.pumpWithTokens({
+          colorToken: Colors.green,
+        }, child: Box(style: style));
+
+        final container = tester.widget<Container>(find.byType(Container));
+        final decoration = container.decoration as BoxDecoration?;
+        expect(decoration?.color, Colors.red);
+      },
+    );
   });
 }

--- a/packages/mix/test/src/variants/variant_mixin_test.dart
+++ b/packages/mix/test/src/variants/variant_mixin_test.dart
@@ -12,6 +12,18 @@ class TestVariantAttribute extends Style<BoxSpec>
   const TestVariantAttribute({super.variants, super.modifier, super.animation});
 
   @override
+  bool get hasBasePayload => $modifier != null || $animation != null;
+
+  @override
+  TestVariantAttribute copyWithVariants(List<VariantStyle<BoxSpec>>? variants) {
+    return TestVariantAttribute(
+      variants: variants,
+      modifier: $modifier,
+      animation: $animation,
+    );
+  }
+
+  @override
   TestVariantAttribute variant(Variant variant, TestVariantAttribute style) {
     return TestVariantAttribute(
       variants: [...?$variants, VariantStyle(variant, style)],

--- a/packages/mix_generator/lib/src/core/builders/styler_mixin_builder.dart
+++ b/packages/mix_generator/lib/src/core/builders/styler_mixin_builder.dart
@@ -94,6 +94,22 @@ class StylerMixinBuilder {
     buffer.writeln('  /// Merges with another [$stylerName].');
     buffer.writeln('  @override');
     buffer.writeln('  $stylerName merge($stylerName? other) {');
+    buffer.writeln('    final hasContextVariantBuilders =');
+    buffer.writeln(
+      '        \$variants?.any((v) => v.variant is ContextVariantBuilder) ?? false;',
+    );
+    buffer.writeln('    if (other != null &&');
+    buffer.writeln('        !Style.isResolvingActiveVariants &&');
+    buffer.writeln('        hasContextVariantBuilders &&');
+    buffer.writeln('        other.\$variants == null) {');
+    buffer.writeln('      final builder = ContextVariantBuilder<$stylerName>(');
+    buffer.writeln('        (_) => other,');
+    buffer.writeln('      );');
+    buffer.writeln(
+      '      return merge($stylerName(variants: [VariantStyle<$specName>(builder, other)]));',
+    );
+    buffer.writeln('    }');
+    buffer.writeln();
     buffer.writeln('    return $stylerName.create(');
 
     // Field merge assignments

--- a/packages/mix_generator/lib/src/core/builders/styler_mixin_builder.dart
+++ b/packages/mix_generator/lib/src/core/builders/styler_mixin_builder.dart
@@ -86,6 +86,43 @@ class StylerMixinBuilder {
     return buffer.toString();
   }
 
+  String _buildDeferredMergeHooks() {
+    final buffer = StringBuffer();
+
+    final deferredChecks = <String>[
+      ...fields.map((field) => '${field.declaredName} != null'),
+      '\$modifier != null',
+      '\$animation != null',
+    ];
+
+    buffer.writeln('  @override');
+    buffer.writeln('  bool get hasBasePayload =>');
+    for (int i = 0; i < deferredChecks.length; i++) {
+      final isLast = i == deferredChecks.length - 1;
+      final suffix = isLast ? ';' : ' ||';
+      buffer.writeln('      ${deferredChecks[i]}$suffix');
+    }
+    buffer.writeln();
+
+    buffer.writeln('  @override');
+    buffer.writeln(
+      '  $stylerName copyWithVariants(List<VariantStyle<$specName>>? variants) {',
+    );
+    buffer.writeln('    return $stylerName.create(');
+    for (final field in fields) {
+      final fieldName = field.declaredName;
+      final name = field.name;
+      buffer.writeln('      $name: $fieldName,');
+    }
+    buffer.writeln('      variants: variants,');
+    buffer.writeln('      modifier: \$modifier,');
+    buffer.writeln('      animation: \$animation,');
+    buffer.writeln('    );');
+    buffer.writeln('  }');
+
+    return buffer.toString();
+  }
+
   String _buildMerge() {
     if (!config.generateMerge) return '';
 
@@ -94,21 +131,8 @@ class StylerMixinBuilder {
     buffer.writeln('  /// Merges with another [$stylerName].');
     buffer.writeln('  @override');
     buffer.writeln('  $stylerName merge($stylerName? other) {');
-    buffer.writeln('    final hasContextVariantBuilders =');
-    buffer.writeln(
-      '        \$variants?.any((v) => v.variant is ContextVariantBuilder) ?? false;',
-    );
-    buffer.writeln('    if (other != null &&');
-    buffer.writeln('        !Style.isResolvingActiveVariants &&');
-    buffer.writeln('        hasContextVariantBuilders &&');
-    buffer.writeln('        other.\$variants == null) {');
-    buffer.writeln('      final builder = ContextVariantBuilder<$stylerName>(');
-    buffer.writeln('        (_) => other,');
-    buffer.writeln('      );');
-    buffer.writeln(
-      '      return merge($stylerName(variants: [VariantStyle<$specName>(builder, other)]));',
-    );
-    buffer.writeln('    }');
+    buffer.writeln('    final deferred = deferMerge(other);');
+    buffer.writeln('    if (deferred != null) return deferred as $stylerName;');
     buffer.writeln();
     buffer.writeln('    return $stylerName.create(');
 
@@ -264,6 +288,9 @@ class StylerMixinBuilder {
     if (config.generateSetters) {
       buffer.writeln(_buildBaseMethods());
     }
+
+    // Generate deferred-merge hooks
+    buffer.writeln(_buildDeferredMergeHooks());
 
     // Generate merge
     if (config.generateMerge) {

--- a/packages/mix_generator/test/core/builders/styler_mixin_builder_test.dart
+++ b/packages/mix_generator/test/core/builders/styler_mixin_builder_test.dart
@@ -57,6 +57,11 @@ void main() {
 
         expect(code, contains('@override'));
         expect(code, contains('BoxStyler merge(BoxStyler? other)'));
+        expect(code, contains('final deferred = deferMerge(other);'));
+        expect(
+          code,
+          contains('if (deferred != null) return deferred as BoxStyler;'),
+        );
         expect(code, contains('return BoxStyler.create('));
       });
 
@@ -151,6 +156,40 @@ void main() {
             'animation: MixOps.mergeAnimation(\$animation, other?.\$animation)',
           ),
         );
+      });
+    });
+
+    group('deferred merge hooks', () {
+      test('generates hasBasePayload with modifier and animation checks', () {
+        final builder = StylerMixinBuilder(
+          stylerName: 'BoxStyler',
+          specName: 'BoxSpec',
+          fields: [],
+          config: defaultConfig,
+        );
+        final code = builder.build();
+
+        expect(code, contains('bool get hasBasePayload =>'));
+        expect(code, contains('\$modifier != null ||'));
+        expect(code, contains('\$animation != null;'));
+      });
+
+      test('generates copyWithVariants', () {
+        final builder = StylerMixinBuilder(
+          stylerName: 'BoxStyler',
+          specName: 'BoxSpec',
+          fields: [],
+          config: defaultConfig,
+        );
+        final code = builder.build();
+
+        expect(
+          code,
+          contains(
+            'BoxStyler copyWithVariants(List<VariantStyle<BoxSpec>>? variants)',
+          ),
+        );
+        expect(code, contains('variants: variants,'));
       });
     });
 
@@ -262,6 +301,7 @@ void main() {
 
         expect(code, isNot(contains('BoxStyler merge(')));
         // Other methods should still be generated
+        expect(code, contains('bool get hasBasePayload =>'));
         expect(code, contains('StyleSpec<BoxSpec> resolve('));
         expect(code, contains('void debugFillProperties('));
         expect(code, contains('List<Object?> get props =>'));
@@ -332,10 +372,17 @@ void main() {
         );
         final code = builder.build();
 
-        // Only mixin declaration and closing brace
+        // Required deferred-merge hooks are still generated.
         expect(
           code,
           contains('mixin _\$BoxStylerMixin on Style<BoxSpec>, Diagnosticable'),
+        );
+        expect(code, contains('bool get hasBasePayload =>'));
+        expect(
+          code,
+          contains(
+            'BoxStyler copyWithVariants(List<VariantStyle<BoxSpec>>? variants)',
+          ),
         );
         expect(code, isNot(contains('BoxStyler merge(')));
         expect(code, isNot(contains('StyleSpec<BoxSpec> resolve(')));


### PR DESCRIPTION
## Summary

- Centralize deferred merge logic in `Style.deferMerge()` with `DeferredVariant` and `hasBasePayload`/`copyWithVariants` hooks, replacing duplicated inline guards in generated merge methods
- Add cycle detection via `_visitedStyles` to prevent infinite recursion in `mergeActiveVariants`
- Flatten double `MixOps.mergeVariants` nesting to `[...?$variants, ...?deferredVariants]` for readability
- Reduce over-specified 50-element insertion-order test to 7 elements — same invariant, less cognitive load

## Test plan

- [ ] All existing tests pass (`style_get_all_variants_test`, `token_style_mixin_test`, `style_nested_variants_test`, `style_defer_merge_test`)
- [ ] Verify insertion-order test still catches unstable sorting
- [ ] Verify `useToken` precedence chain: `useToken(...).color(red)` → red wins