### PR TITLE
feat(mix_generator): support @MixableField(setterType:) on @MixableSpec fields

### DIFF
--- a/packages/mix_annotations/lib/src/annotations.dart
+++ b/packages/mix_annotations/lib/src/annotations.dart
@@ -71,6 +71,9 @@ const mixableStyler = MixableStyler();
 /// can expose its `Styler` so it accepts fluent values (e.g.
 /// `UIAppBarStyler.container(BoxStyler().paddingAll(8))`).
 ///
+/// When used on a `@MixableSpec` field, `setterType` must be a Mix/Styler type
+/// (i.e. assignable to `Mix<...>`), because generated constructors wrap the
+/// argument with `Prop.maybeMix(...)`.
 /// Example usage:
 /// ```dart
 /// @MixableField(ignoreSetter: true)

--- a/packages/mix_annotations/lib/src/annotations.dart
+++ b/packages/mix_annotations/lib/src/annotations.dart
@@ -66,6 +66,11 @@ const mixableStyler = MixableStyler();
 /// [factoryName] optionally overrides the generated field factory name.
 /// [skipFactory] prevents spec-driven stylers from generating a field factory.
 ///
+/// For spec-driven stylers ([MixableSpec]), [setterType] also drives the
+/// generated field factory and `Prop` wrapping: a nested `StyleSpec<S>` field
+/// can expose its `Styler` so it accepts fluent values (e.g.
+/// `UIAppBarStyler.container(BoxStyler().paddingAll(8))`).
+///
 /// Example usage:
 /// ```dart
 /// @MixableField(ignoreSetter: true)
@@ -73,6 +78,9 @@ const mixableStyler = MixableStyler();
 ///
 /// @MixableField(setterType: List<ShadowMix>)
 /// final Prop<List<Shadow>>? $shadows;
+///
+/// @MixableField(setterType: BoxStyler)
+/// final StyleSpec<BoxSpec>? container;
 /// ```
 class MixableField {
   /// Whether to skip generating a setter for this field.

--- a/packages/mix_generator/lib/src/core/builders/spec_styler_class_builder.dart
+++ b/packages/mix_generator/lib/src/core/builders/spec_styler_class_builder.dart
@@ -53,10 +53,7 @@ class SpecStylerClassBuilder {
   String? _propFactory(FieldModel field) {
     if (isRawListField(field.name)) return null;
 
-    // An explicit `setterType` override always denotes a Mix/Styler counterpart
-    // (e.g. `BoxStyler` for a `StyleSpec<BoxSpec>` field), since the field
-    // storage `Prop<X>` only accepts `X` directly or a `Mix<X>`. Wrap it with
-    // `Prop.maybeMix`.
+    // `_setterTypeOverride` validates that overrides are Mix/Styler types.
     if (_hasSetterTypeOverride(field)) return 'Prop.maybeMix';
 
     if (_listMixParamType(field) != null) return null;
@@ -84,12 +81,83 @@ class SpecStylerClassBuilder {
     final element = specElement.getField(field.name);
     if (element == null) return null;
 
-    return type_helpers.visibleTypeCodeForField(
+    final typeCode = type_helpers.visibleTypeCodeForField(
       element,
       visibleFrom: element.library,
       type: type,
       usage: 'setter type',
     );
+
+    _validateSetterTypeOverride(field, element, type, typeCode);
+
+    return typeCode;
+  }
+
+  void _validateSetterTypeOverride(
+    FieldModel field,
+    FieldElement element,
+    DartType setterType,
+    String setterTypeCode,
+  ) {
+    final mixType = _mixBindingFor(setterType);
+    final fieldValueType = element.library.typeSystem.promoteToNonNull(
+      element.type,
+    );
+    final expectedType = type_helpers.visibleTypeCodeForField(
+      element,
+      visibleFrom: element.library,
+      type: fieldValueType,
+      usage: 'field value type',
+    );
+    if (mixType == null) {
+      fail(
+        element,
+        '@MixableField(setterType: $setterTypeCode) on `${field.name}` must '
+        'be assignable to `Mix<$expectedType>` for @MixableSpec fields.',
+        todo:
+            'Use a Mix/Styler type that resolves to `$expectedType`, or '
+            'remove `setterType`.',
+      );
+    }
+
+    final mixValueType = mixType.typeArguments.single;
+    final acceptsFieldType =
+        !_isInvalidMixValueType(mixValueType) &&
+        element.library.typeSystem.isAssignableTo(
+          mixValueType,
+          fieldValueType,
+          strictCasts: false,
+        );
+    if (acceptsFieldType) return;
+
+    final actualType = type_helpers.visibleTypeCodeForField(
+      element,
+      visibleFrom: element.library,
+      type: mixValueType,
+      usage: 'setter type Mix value',
+    );
+    fail(
+      element,
+      '@MixableField(setterType: $setterTypeCode) on `${field.name}` resolves '
+      'to `Mix<$actualType>`, but the field stores `$expectedType`.',
+      todo: 'Use a Mix/Styler type that resolves to `$expectedType`.',
+    );
+  }
+
+  bool _isInvalidMixValueType(DartType type) {
+    return type is DynamicType || type.nullabilitySuffix == .question;
+  }
+
+  InterfaceType? _mixBindingFor(DartType type) {
+    if (type is! InterfaceType) return null;
+
+    if (mixChecker.isExactlyType(type)) return type;
+
+    for (final supertype in type.allSupertypes) {
+      if (mixChecker.isExactlyType(supertype)) return supertype;
+    }
+
+    return null;
   }
 
   String? _listElementMixType(FieldModel field) {

--- a/packages/mix_generator/lib/src/core/builders/spec_styler_class_builder.dart
+++ b/packages/mix_generator/lib/src/core/builders/spec_styler_class_builder.dart
@@ -13,6 +13,7 @@ import '../helpers/widget_call_planner.dart';
 import '../models/annotation_config.dart';
 import '../models/field_model.dart';
 import '../models/styler_field_model.dart';
+import '../models/type_helpers.dart' as type_helpers;
 import '../resolvers/known_mix_symbol_resolver.dart';
 import 'styler_api_planner.dart';
 import 'styler_forwarder_factory.dart';
@@ -44,6 +45,7 @@ class SpecStylerClassBuilder {
   }
 
   String _publicParamType(FieldModel field) =>
+      _setterTypeOverride(field) ??
       _listMixParamType(field) ??
       mixTypeFor(field.typeName) ??
       _fieldValueType(field);
@@ -51,9 +53,43 @@ class SpecStylerClassBuilder {
   String? _propFactory(FieldModel field) {
     if (isRawListField(field.name)) return null;
 
+    // An explicit `setterType` override always denotes a Mix/Styler counterpart
+    // (e.g. `BoxStyler` for a `StyleSpec<BoxSpec>` field), since the field
+    // storage `Prop<X>` only accepts `X` directly or a `Mix<X>`. Wrap it with
+    // `Prop.maybeMix`.
+    if (_hasSetterTypeOverride(field)) return 'Prop.maybeMix';
+
     if (_listMixParamType(field) != null) return null;
 
     return mixTypeFor(field.typeName) == null ? 'Prop.maybe' : 'Prop.maybeMix';
+  }
+
+  /// Whether [field] declares a `@MixableField(setterType:)` override.
+  bool _hasSetterTypeOverride(FieldModel field) =>
+      _setterTypeValue(field) != null;
+
+  /// The resolved `@MixableField(setterType:)` type for [field], or `null`.
+  DartType? _setterTypeValue(FieldModel field) =>
+      _mixableFieldReader(field.name)?.peek('setterType')?.typeValue;
+
+  /// Dart code for a field's `setterType` override, or `null` when unset.
+  ///
+  /// Lets a field whose runtime type has no automatic Mix counterpart
+  /// (e.g. a nested `StyleSpec<BoxSpec>`) expose its Mix/Styler type
+  /// (`BoxStyler`) in the generated setter, factory, and constructor.
+  String? _setterTypeOverride(FieldModel field) {
+    final type = _setterTypeValue(field);
+    if (type == null) return null;
+
+    final element = specElement.getField(field.name);
+    if (element == null) return null;
+
+    return type_helpers.visibleTypeCodeForField(
+      element,
+      visibleFrom: element.library,
+      type: type,
+      usage: 'setter type',
+    );
   }
 
   String? _listElementMixType(FieldModel field) {
@@ -603,7 +639,10 @@ class SpecStylerClassBuilder {
   }
 
   String _createArgument(FieldModel field) {
-    final listMixWrapperType = _listMixWrapperType(field);
+    // A `setterType` override takes precedence over curated list wrapping.
+    final listMixWrapperType = _hasSetterTypeOverride(field)
+        ? null
+        : _listMixWrapperType(field);
     if (listMixWrapperType != null) {
       return '         ${field.name}: ${field.name} != null ? Prop.mix($listMixWrapperType(${field.name})) : null,';
     }

--- a/packages/mix_generator/test/integration/spec_styler_generator_smoke_test.dart
+++ b/packages/mix_generator/test/integration/spec_styler_generator_smoke_test.dart
@@ -1119,10 +1119,8 @@ void main() {
       );
     });
 
-    test(
-      'uses MixableField setterType for nested styler fields',
-      () async {
-        const input = '''
+    test('uses MixableField setterType for nested styler fields', () async {
+      const input = '''
         library spike;
         import 'package:mix/mix.dart';
         import 'package:mix_annotations/mix_annotations.dart';
@@ -1142,28 +1140,23 @@ void main() {
         }
       ''';
 
-        await testBuilder(
-          _specStylerPartBuilder(),
-          {
-            ...mixAnnotationsSources,
-            ..._mixSources,
-            'mix|lib/spike.dart': input,
-          },
-          outputs: {
-            'mix|lib/spike.g.dart': decodedMatches(
-              allOf([
-                contains('factory HostStyler.container(InnerStyler value)'),
-                contains('HostStyler container(InnerStyler value)'),
-                contains('InnerStyler? container,'),
-                contains('container: Prop.maybeMix(container)'),
-                isNot(contains('StyleSpec<InnerSpec> value')),
-                isNot(contains('Prop.maybe(container)')),
-              ]),
-            ),
-          },
-        );
-      },
-    );
+      await testBuilder(
+        _specStylerPartBuilder(),
+        {...mixAnnotationsSources, ..._mixSources, 'mix|lib/spike.dart': input},
+        outputs: {
+          'mix|lib/spike.g.dart': decodedMatches(
+            allOf([
+              contains('factory HostStyler.container(InnerStyler value)'),
+              contains('HostStyler container(InnerStyler value)'),
+              contains('InnerStyler? container,'),
+              contains('container: Prop.maybeMix(container)'),
+              isNot(contains('StyleSpec<InnerSpec> value')),
+              isNot(contains('Prop.maybe(container)')),
+            ]),
+          ),
+        },
+      );
+    });
 
     test('uses host imports needed by field type arguments', () async {
       const boxSpec = '''

--- a/packages/mix_generator/test/integration/spec_styler_generator_smoke_test.dart
+++ b/packages/mix_generator/test/integration/spec_styler_generator_smoke_test.dart
@@ -1119,6 +1119,52 @@ void main() {
       );
     });
 
+    test(
+      'uses MixableField setterType for nested styler fields',
+      () async {
+        const input = '''
+        library spike;
+        import 'package:mix/mix.dart';
+        import 'package:mix_annotations/mix_annotations.dart';
+        part 'spike.g.dart';
+
+        final class InnerSpec extends Spec<InnerSpec> {
+          const InnerSpec();
+        }
+
+        class InnerStyler {}
+
+        @MixableSpec()
+        final class HostSpec extends Spec<HostSpec> {
+          @MixableField(setterType: InnerStyler)
+          final StyleSpec<InnerSpec>? container;
+          const HostSpec({this.container});
+        }
+      ''';
+
+        await testBuilder(
+          _specStylerPartBuilder(),
+          {
+            ...mixAnnotationsSources,
+            ..._mixSources,
+            'mix|lib/spike.dart': input,
+          },
+          outputs: {
+            'mix|lib/spike.g.dart': decodedMatches(
+              allOf([
+                contains('factory HostStyler.container(InnerStyler value)'),
+                contains('HostStyler container(InnerStyler value)'),
+                contains('InnerStyler? container,'),
+                contains('container: Prop.maybeMix(container)'),
+                isNot(contains('StyleSpec<InnerSpec> value')),
+                isNot(contains('Prop.maybe(container)')),
+              ]),
+            ),
+          },
+        );
+      },
+    );
+
     test('uses host imports needed by field type arguments', () async {
       const boxSpec = '''
           import 'package:mix/mix.dart';

--- a/packages/mix_generator/test/integration/spec_styler_generator_smoke_test.dart
+++ b/packages/mix_generator/test/integration/spec_styler_generator_smoke_test.dart
@@ -8,6 +8,86 @@ import 'package:test/test.dart';
 import '../core/test_helpers.dart';
 
 const _mixSources = {'mix|lib/mix.dart': _mixStub};
+const _setterTypeMixSources = {
+  'mix|lib/src/core/mix_element.dart': '''
+    abstract class Mix<T> {
+      const Mix();
+    }
+  ''',
+  'mix|lib/mix.dart': '''
+    import 'package:flutter/foundation.dart';
+
+    import 'src/core/mix_element.dart';
+
+    export 'src/core/mix_element.dart';
+
+    abstract class Spec<T extends Spec<T>> {
+      const Spec();
+    }
+
+    class StyleSpec<S extends Spec<S>> {
+      const StyleSpec({
+        required S spec,
+        Object? animation,
+        Object? widgetModifiers,
+      });
+    }
+
+    abstract class Style<S extends Spec<S>> extends Mix<StyleSpec<S>> {
+      final List<VariantStyle<S>>? \$variants;
+      final WidgetModifierConfig? \$modifier;
+      final AnimationConfig? \$animation;
+
+      const Style({
+        List<VariantStyle<S>>? variants,
+        WidgetModifierConfig? modifier,
+        AnimationConfig? animation,
+      }) : \$variants = variants,
+           \$modifier = modifier,
+           \$animation = animation;
+    }
+
+    abstract class MixStyler<ST extends Style<SP>, SP extends Spec<SP>>
+        extends Style<SP> with Diagnosticable {
+      const MixStyler({super.variants, super.modifier, super.animation});
+    }
+
+    class AnimationConfig {}
+
+    class WidgetModifierConfig {
+      Object? resolve(Object context) => null;
+    }
+
+    class VariantStyle<S extends Spec<S>> {}
+
+    class Prop<T> {
+      static Prop<T>? maybe<T>(T? value) => null;
+      static Prop<T>? maybeMix<T>(Mix<T>? value) => null;
+      static Prop<T>? mix<T>(Mix<T> value) => null;
+    }
+
+    class MixOps {
+      static Prop<T>? merge<T>(Prop<T>? a, Prop<T>? b) => null;
+
+      static List<VariantStyle<S>>? mergeVariants<S extends Spec<S>>(
+        List<VariantStyle<S>>? a,
+        List<VariantStyle<S>>? b,
+      ) => null;
+
+      static WidgetModifierConfig? mergeModifier(
+        WidgetModifierConfig? a,
+        WidgetModifierConfig? b,
+      ) => null;
+
+      static AnimationConfig? mergeAnimation(
+        AnimationConfig? a,
+        AnimationConfig? b,
+      ) => null;
+
+      static T? resolve<T>(Object context, Prop<T>? prop) => null;
+    }
+  ''',
+};
 const _mixSourcesWithStyleWidget = {
   ..._mixSources,
   'mix|lib/src/core/style_widget.dart': '''
@@ -1122,6 +1202,50 @@ void main() {
     test('uses MixableField setterType for nested styler fields', () async {
       const input = '''
         library spike;
+        import 'package:flutter/foundation.dart';
+        import 'package:flutter/widgets.dart';
+        import 'package:mix/mix.dart';
+        import 'package:mix_annotations/mix_annotations.dart';
+        part 'spike.g.dart';
+
+        final class InnerSpec extends Spec<InnerSpec> {
+          const InnerSpec();
+        }
+
+        class InnerStyler extends Style<InnerSpec> with Diagnosticable {}
+
+        @MixableSpec()
+        final class HostSpec extends Spec<HostSpec> {
+          @MixableField(setterType: InnerStyler)
+          final StyleSpec<InnerSpec>? container;
+          const HostSpec({this.container});
+        }
+      ''';
+
+      await expectGeneratorOutputResolves(
+        builder: _specStylerPartBuilder(),
+        sources: {
+          ...mixAnnotationsSources,
+          ..._flutterResolveStubs,
+          ..._setterTypeMixSources,
+          'mix|lib/spike.dart': input,
+        },
+        inputAsset: 'mix|lib/spike.dart',
+        outputAsset: 'mix|lib/spike.g.dart',
+        outputMatcher: allOf([
+          contains('factory HostStyler.container(InnerStyler value)'),
+          contains('HostStyler container(InnerStyler value)'),
+          contains('InnerStyler? container,'),
+          contains('container: Prop.maybeMix(container)'),
+          isNot(contains('StyleSpec<InnerSpec> value')),
+          isNot(contains('Prop.maybe(container)')),
+        ]),
+      );
+    });
+
+    test('rejects spec setterType that is not Mix-compatible', () async {
+      const input = '''
+        library spike;
         import 'package:mix/mix.dart';
         import 'package:mix_annotations/mix_annotations.dart';
         part 'spike.g.dart';
@@ -1140,21 +1264,175 @@ void main() {
         }
       ''';
 
-      await testBuilder(
-        _specStylerPartBuilder(),
-        {...mixAnnotationsSources, ..._mixSources, 'mix|lib/spike.dart': input},
-        outputs: {
-          'mix|lib/spike.g.dart': decodedMatches(
-            allOf([
-              contains('factory HostStyler.container(InnerStyler value)'),
-              contains('HostStyler container(InnerStyler value)'),
-              contains('InnerStyler? container,'),
-              contains('container: Prop.maybeMix(container)'),
-              isNot(contains('StyleSpec<InnerSpec> value')),
-              isNot(contains('Prop.maybe(container)')),
-            ]),
-          ),
-        },
+      final message = await _expectSpecStylerValidationError({
+        ...mixAnnotationsSources,
+        ..._flutterResolveStubs,
+        ..._setterTypeMixSources,
+        'mix|lib/spike.dart': input,
+      });
+
+      expect(
+        message,
+        allOf([
+          contains('@MixableField(setterType: InnerStyler)'),
+          contains('must be assignable to `Mix<StyleSpec<InnerSpec>>`'),
+        ]),
+      );
+    });
+
+    test('rejects spec setterType with the wrong Mix value type', () async {
+      const input = '''
+        library spike;
+        import 'package:mix/mix.dart';
+        import 'package:mix_annotations/mix_annotations.dart';
+        part 'spike.g.dart';
+
+        final class InnerSpec extends Spec<InnerSpec> {
+          const InnerSpec();
+        }
+
+        final class OtherSpec extends Spec<OtherSpec> {
+          const OtherSpec();
+        }
+
+        class OtherStyler extends Style<OtherSpec> {}
+
+        @MixableSpec()
+        final class HostSpec extends Spec<HostSpec> {
+          @MixableField(setterType: OtherStyler)
+          final StyleSpec<InnerSpec>? container;
+          const HostSpec({this.container});
+        }
+      ''';
+
+      final message = await _expectSpecStylerValidationError({
+        ...mixAnnotationsSources,
+        ..._flutterResolveStubs,
+        ..._setterTypeMixSources,
+        'mix|lib/spike.dart': input,
+      });
+
+      expect(
+        message,
+        allOf([
+          contains('@MixableField(setterType: OtherStyler)'),
+          contains('resolves to `Mix<StyleSpec<OtherSpec>>`'),
+          contains('but the field stores `StyleSpec<InnerSpec>`'),
+        ]),
+      );
+    });
+
+    test('rejects spec setterType with a nullable Mix value type', () async {
+      const input = '''
+        library spike;
+        import 'package:mix/mix.dart';
+        import 'package:mix_annotations/mix_annotations.dart';
+        part 'spike.g.dart';
+
+        final class InnerSpec extends Spec<InnerSpec> {
+          const InnerSpec();
+        }
+
+        class NullableStyler extends Mix<StyleSpec<InnerSpec>?> {}
+
+        @MixableSpec()
+        final class HostSpec extends Spec<HostSpec> {
+          @MixableField(setterType: NullableStyler)
+          final StyleSpec<InnerSpec>? container;
+          const HostSpec({this.container});
+        }
+      ''';
+
+      final message = await _expectSpecStylerValidationError({
+        ...mixAnnotationsSources,
+        ..._flutterResolveStubs,
+        ..._setterTypeMixSources,
+        'mix|lib/spike.dart': input,
+      });
+
+      expect(
+        message,
+        allOf([
+          contains('@MixableField(setterType: NullableStyler)'),
+          contains('resolves to `Mix<StyleSpec<InnerSpec>?>`'),
+          contains('but the field stores `StyleSpec<InnerSpec>`'),
+        ]),
+      );
+    });
+
+    test('rejects spec setterType with a dynamic Mix value type', () async {
+      const input = '''
+        library spike;
+        import 'package:mix/mix.dart';
+        import 'package:mix_annotations/mix_annotations.dart';
+        part 'spike.g.dart';
+
+        final class InnerSpec extends Spec<InnerSpec> {
+          const InnerSpec();
+        }
+
+        class DynamicStyler extends Mix<dynamic> {}
+
+        @MixableSpec()
+        final class HostSpec extends Spec<HostSpec> {
+          @MixableField(setterType: DynamicStyler)
+          final StyleSpec<InnerSpec>? container;
+          const HostSpec({this.container});
+        }
+      ''';
+
+      final message = await _expectSpecStylerValidationError({
+        ...mixAnnotationsSources,
+        ..._flutterResolveStubs,
+        ..._setterTypeMixSources,
+        'mix|lib/spike.dart': input,
+      });
+
+      expect(
+        message,
+        allOf([
+          contains('@MixableField(setterType: DynamicStyler)'),
+          contains('resolves to `Mix<dynamic>`'),
+          contains('but the field stores `StyleSpec<InnerSpec>`'),
+        ]),
+      );
+    });
+
+    test('rejects raw spec Mix setterType', () async {
+      const input = '''
+        library spike;
+        import 'package:mix/mix.dart';
+        import 'package:mix_annotations/mix_annotations.dart';
+        part 'spike.g.dart';
+
+        final class InnerSpec extends Spec<InnerSpec> {
+          const InnerSpec();
+        }
+
+        class RawStyler extends Mix {}
+
+        @MixableSpec()
+        final class HostSpec extends Spec<HostSpec> {
+          @MixableField(setterType: RawStyler)
+          final StyleSpec<InnerSpec>? container;
+          const HostSpec({this.container});
+        }
+      ''';
+
+      final message = await _expectSpecStylerValidationError({
+        ...mixAnnotationsSources,
+        ..._flutterResolveStubs,
+        ..._setterTypeMixSources,
+        'mix|lib/spike.dart': input,
+      });
+
+      expect(
+        message,
+        allOf([
+          contains('@MixableField(setterType: RawStyler)'),
+          contains('resolves to `Mix<dynamic>`'),
+          contains('but the field stores `StyleSpec<InnerSpec>`'),
+        ]),
       );
     });
 


### PR DESCRIPTION
## Summary
- Closes #949.
- The spec-driven styler generator now honors `@MixableField(setterType: ...)`. A nested `StyleSpec<S>` field can expose its `Styler` type in the generated setter, field factory, and constructor.
- Previously `@MixableSpec` ignored `setterType` entirely and always emitted the raw `StyleSpec<S>` type, so fluent nested styling was impossible.

### Before
```dart
factory UIAppBarStyler.container(StyleSpec<BoxSpec> value) =>
    UIAppBarStyler().container(value);
// UIAppBarStyler.container(BoxStyler().paddingAll(8)) ❌ won't compile
```

### After
```dart
@MixableSpec()
final class UIAppBarSpec ... {
  @MixableField(setterType: BoxStyler)
  final StyleSpec<BoxSpec>? container;
}
```
generates:
```dart
factory UIAppBarStyler.container(BoxStyler value) =>
    UIAppBarStyler().container(value);
// constructor wraps with Prop.maybeMix(container)
```

## Implementation
In `spec_styler_class_builder.dart`:
- `_publicParamType` now returns the `setterType` override first (feeds the setter, field factory, and constructor param).
- `_propFactory` / `_createArgument` wrap an override with `Prop.maybeMix` (a `Styler` is a `Mix<StyleSpec<S>>`), bypassing curated list wrapping.

A `setterType` override on a spec field is only meaningful for a `Mix`/`Styler` type, since the field storage `Prop<X>` only accepts `X` directly or a `Mix<X>` — hence the unconditional `Prop.maybeMix`.

## Test plan
- [x] Added integration test: `SpecStylerGenerator smoke uses MixableField setterType for nested styler fields`.
- [x] `dart test` (mix_generator): 260 tests pass.
- [x] Regenerated the real `mix` package with `build_runner` — **zero** `.g.dart` diffs, confirming no regression to existing specs (no spec currently uses `setterType`).
- [x] `dart analyze` on changed files: no issues.

## Related
Sibling of #948 / PR #950 (same `setterType` support for `@MixableModifier`). Independent branch off `main`.

Made with [Cursor](https://cursor.com)