### PR TITLE
chore: release mix_annotations 2.1.1

### DIFF
--- a/packages/mix_annotations/CHANGELOG.md
+++ b/packages/mix_annotations/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.1
+
+ - **DOCS**: Document `@MixableField(setterType:)` usage for `@MixableSpec` and `@MixableModifier` fields (#950, #951).
+
 ## 2.1.0
 
  - **FEAT**: Add `@MixableModifier` annotation. Annotate a `WidgetModifier` subclass to generate its modifier mixin and `ModifierMix` class via `mix_generator` (#924).

--- a/packages/mix_annotations/pubspec.yaml
+++ b/packages/mix_annotations/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mix_annotations
 description: Annotations for mix and mix_generator
-version: 2.1.0
+version: 2.1.1
 repository: https://github.com/btwld/mix/tree/main/packages/mix_annotations
 
 environment:


### PR DESCRIPTION
## Summary
- Bump `mix_annotations` to **2.1.1**
- Document `@MixableField(setterType:)` usage for `@MixableSpec` and `@MixableModifier` fields (#950, #951)

## Test plan
- [x] Version and changelog updated
- [ ] After merge, tag `mix_annotations-v2.1.1` to publish to pub.dev


Made with [Cursor](https://cursor.com)