### PR TITLE
chore: release mix_generator 2.1.1

### DIFF
--- a/packages/mix_generator/CHANGELOG.md
+++ b/packages/mix_generator/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.1.1
+
+ - **FEAT**: Support `@MixableField(setterType:)` on `@MixableModifier` fields. Generated `ModifierMix` constructors accept the declared Mix type and wrap values with `Prop.maybeMix` (#950).
+ - **FEAT**: Support `@MixableField(setterType:)` on `@MixableSpec` fields. Generated spec stylers expose Mix-typed setters and field factories for nested `StyleSpec` fields (#951).
+
 ## 2.1.0
 
  - **FEAT**: Add `@MixableModifier` generator. Annotate a `WidgetModifier` subclass

--- a/packages/mix_generator/pubspec.yaml
+++ b/packages/mix_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mix_generator
 description: A code generator for Mix, an expressive way to effortlessly build design systems in Flutter.
-version: 2.1.0
+version: 2.1.1
 homepage: https://github.com/btwld/mix
 repository: https://github.com/btwld/mix/tree/main/packages/mix_generator
 
@@ -8,7 +8,7 @@ environment:
   sdk: ">=3.11.0 <4.0.0"
   
 dependencies:
-  mix_annotations: ^2.1.0
+  mix_annotations: ^2.1.1
   dart_style: ^3.0.0
   source_gen: ">=3.0.0 <5.0.0"
   analyzer: '>=9.0.0 <11.0.0'


### PR DESCRIPTION
## Summary
- Bump `mix_generator` to **2.1.1**
- Support `@MixableField(setterType:)` on `@MixableModifier` and `@MixableSpec` fields (#950, #951)
- Require `mix_annotations` `^2.1.1`

## Test plan
- [x] Version and changelog updated
- [ ] After merge, tag `mix_generator-v2.1.1` to publish to pub.dev


Made with [Cursor](https://cursor.com)