### PR TITLE
refactor: dedupe generator + lint tooling

### DIFF
--- a/packages/mix_generator/lib/src/core/builders/spec_styler_class_builder.dart
+++ b/packages/mix_generator/lib/src/core/builders/spec_styler_class_builder.dart
@@ -8,7 +8,6 @@ import '../checkers.dart';
 import '../curated/styler_surface_metadata.dart';
 import '../curated/type_metadata.dart';
 import '../errors.dart';
-import '../helpers/type_hierarchy.dart';
 import '../helpers/widget_call_planner.dart';
 import '../models/annotation_config.dart';
 import '../models/field_model.dart';
@@ -603,45 +602,14 @@ class SpecStylerClassBuilder {
       );
     }
 
-    final widgetClass = fn.enclosingElement;
-    final widgetName = requireName(
-      widgetClass,
-      orFailWith: '@MixableSpec(target:) widget class must have a name.',
+    final widgetName = mixableSpecTargetWidgetName(fn);
+    validateMixableSpecTargetConstructor(
+      constructor: fn,
+      widgetName: widgetName,
+      specElement: specElement,
+      specName: specName,
+      anchor: specElement,
     );
-    final styleWidgetSupertype = findSupertypeMatching(
-      widgetClass.thisType,
-      styleWidgetChecker,
-    );
-    if (styleWidgetSupertype == null) {
-      fail(
-        specElement,
-        'Widget $widgetName must extend StyleWidget<$specName> '
-        'to be used as @MixableSpec(target:).',
-      );
-    }
-
-    final widgetSpecArg = styleWidgetSupertype.typeArguments.first;
-    if (widgetSpecArg is! InterfaceType ||
-        widgetSpecArg.element != specElement) {
-      fail(
-        specElement,
-        'Spec generic mismatch: $specName annotated, but '
-        '$widgetName extends StyleWidget<${widgetSpecArg.getDisplayString()}>.',
-      );
-    }
-
-    final optionalPositional = optionalPositionalNames(fn.formalParameters);
-    if (optionalPositional.isNotEmpty) {
-      fail(
-        specElement,
-        '@MixableSpec(target:) does not support optional positional target '
-        'constructor parameters on $widgetName: '
-        '[${optionalPositional.join(', ')}].',
-        todo: 'Convert these parameters to required positional or named.',
-      );
-    }
-
-    _requireStyleParameter(fn, widgetName);
 
     final result = extractCallParams(
       fn,
@@ -657,22 +625,6 @@ class SpecStylerClassBuilder {
       widgetName: widgetName,
       params: result.params,
       forwardsKey: result.forwardsKey,
-    );
-  }
-
-  void _requireStyleParameter(
-    ConstructorElement constructor,
-    String widgetName,
-  ) {
-    for (final parameter in constructor.formalParameters) {
-      if (parameter.name == 'style' && parameter.isNamed) return;
-    }
-
-    fail(
-      specElement,
-      '@MixableSpec(target:) requires $widgetName to expose a named '
-      '`style` constructor parameter so the generated call() can pass '
-      '`style: this`.',
     );
   }
 

--- a/packages/mix_generator/lib/src/core/helpers/widget_call_planner.dart
+++ b/packages/mix_generator/lib/src/core/helpers/widget_call_planner.dart
@@ -2,10 +2,12 @@
 library;
 
 import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/type.dart';
 
 import '../checkers.dart';
 import '../errors.dart';
 import '../models/mix_widget_model.dart';
+import 'type_hierarchy.dart';
 import 'library_scope.dart';
 
 const reservedParamNames = {
@@ -26,6 +28,66 @@ List<String> optionalPositionalNames(
       .where((p) => p.isOptionalPositional)
       .map((p) => p.name ?? '<unnamed>')
       .toList();
+}
+
+String mixableSpecTargetWidgetName(ConstructorElement constructor) {
+  return requireName(
+    constructor.enclosingElement,
+    orFailWith: '@MixableSpec(target:) widget class must have a name.',
+  );
+}
+
+void validateMixableSpecTargetConstructor({
+  required ConstructorElement constructor,
+  required String widgetName,
+  required InterfaceElement specElement,
+  required String specName,
+  required Element anchor,
+}) {
+  final styleWidgetSupertype = findSupertypeMatching(
+    constructor.enclosingElement.thisType,
+    styleWidgetChecker,
+  );
+  if (styleWidgetSupertype == null) {
+    fail(
+      anchor,
+      'Widget $widgetName must extend StyleWidget<$specName> '
+      'to be used as @MixableSpec(target:).',
+    );
+  }
+
+  final widgetSpecArg = styleWidgetSupertype.typeArguments.first;
+  if (widgetSpecArg is! InterfaceType || widgetSpecArg.element != specElement) {
+    fail(
+      anchor,
+      'Spec generic mismatch: $specName annotated, but '
+      '$widgetName extends StyleWidget<${widgetSpecArg.getDisplayString()}>.',
+    );
+  }
+
+  final optionalPositional = optionalPositionalNames(
+    constructor.formalParameters,
+  );
+  if (optionalPositional.isNotEmpty) {
+    fail(
+      anchor,
+      '@MixableSpec(target:) does not support optional positional target '
+      'constructor parameters on $widgetName: '
+      '[${optionalPositional.join(', ')}].',
+      todo: 'Convert these parameters to required positional or named.',
+    );
+  }
+
+  for (final parameter in constructor.formalParameters) {
+    if (parameter.name == 'style' && parameter.isNamed) return;
+  }
+
+  fail(
+    anchor,
+    '@MixableSpec(target:) requires $widgetName to expose a named '
+    '`style` constructor parameter so the generated call() can pass '
+    '`style: this`.',
+  );
 }
 
 ({List<WidgetCallParam> params, bool forwardsKey}) extractCallParams(

--- a/packages/mix_generator/lib/src/core/helpers/widget_call_planner.dart
+++ b/packages/mix_generator/lib/src/core/helpers/widget_call_planner.dart
@@ -7,8 +7,8 @@ import 'package:analyzer/dart/element/type.dart';
 import '../checkers.dart';
 import '../errors.dart';
 import '../models/mix_widget_model.dart';
-import 'type_hierarchy.dart';
 import 'library_scope.dart';
+import 'type_hierarchy.dart';
 
 const reservedParamNames = {
   'build',

--- a/packages/mix_generator/lib/src/styler_generator.dart
+++ b/packages/mix_generator/lib/src/styler_generator.dart
@@ -95,10 +95,7 @@ class StylerGenerator extends GeneratorForAnnotation<MixableStyler> {
     }
 
     final widgetClass = fn.enclosingElement;
-    final widgetName = requireName(
-      widgetClass,
-      orFailWith: '@MixableSpec(target:) widget class must have a name.',
-    );
+    final widgetName = mixableSpecTargetWidgetName(fn);
     final hiddenWidgetType = firstInvisibleTypeName(
       widgetClass.thisType,
       stylerElement.library,
@@ -113,40 +110,13 @@ class StylerGenerator extends GeneratorForAnnotation<MixableStyler> {
       );
     }
 
-    final styleWidgetSupertype = findSupertypeMatching(
-      widgetClass.thisType,
-      styleWidgetChecker,
+    validateMixableSpecTargetConstructor(
+      constructor: fn,
+      widgetName: widgetName,
+      specElement: specElement,
+      specName: specName,
+      anchor: specElement,
     );
-    if (styleWidgetSupertype == null) {
-      fail(
-        specElement,
-        'Widget $widgetName must extend StyleWidget<$specName> '
-        'to be used as @MixableSpec(target:).',
-      );
-    }
-
-    final widgetSpecArg = styleWidgetSupertype.typeArguments.first;
-    if (widgetSpecArg is! InterfaceType ||
-        widgetSpecArg.element != specElement) {
-      fail(
-        specElement,
-        'Spec generic mismatch: $specName annotated, but '
-        '$widgetName extends StyleWidget<${widgetSpecArg.getDisplayString()}>.',
-      );
-    }
-
-    final optionalPositional = optionalPositionalNames(fn.formalParameters);
-    if (optionalPositional.isNotEmpty) {
-      fail(
-        specElement,
-        '@MixableSpec(target:) does not support optional positional target '
-        'constructor parameters on $widgetName: '
-        '[${optionalPositional.join(', ')}].',
-        todo: 'Convert these parameters to required positional or named.',
-      );
-    }
-
-    _requireStyleParameter(fn, widgetName, specElement);
 
     final result = extractCallParams(
       fn,
@@ -163,23 +133,6 @@ class StylerGenerator extends GeneratorForAnnotation<MixableStyler> {
       params: result.params,
       forwardsKey: result.forwardsKey,
       indent: '  ',
-    );
-  }
-
-  void _requireStyleParameter(
-    ConstructorElement constructor,
-    String widgetName,
-    Element anchor,
-  ) {
-    for (final parameter in constructor.formalParameters) {
-      if (parameter.name == 'style' && parameter.isNamed) return;
-    }
-
-    fail(
-      anchor,
-      '@MixableSpec(target:) requires $widgetName to expose a named '
-      '`style` constructor parameter so the generated call() can pass '
-      '`style: this`.',
     );
   }
 

--- a/packages/mix_lint/lib/src/rules/mix_avoid_defining_tokens_within_scope.dart
+++ b/packages/mix_lint/lib/src/rules/mix_avoid_defining_tokens_within_scope.dart
@@ -5,6 +5,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/error/error.dart';
 
+import '../utils/ast_helpers.dart';
 import '../utils/type_helpers.dart';
 
 class MixAvoidDefiningTokensWithinScope extends AnalysisRule {
@@ -46,19 +47,13 @@ class _Visitor extends SimpleAstVisitor<void> {
   void visitInstanceCreationExpression(InstanceCreationExpression node) {
     if (!isMixTokenType(node.staticType)) return;
 
-    // Walk up the AST to find a MixScope ancestor.
-    // Stop at statement/declaration boundaries.
-    AstNode? current = node.parent;
-    while (current != null &&
-        current is! Statement &&
-        current is! Declaration) {
-      if (current is InstanceCreationExpression &&
-          isMixScopeType(current.staticType)) {
+    for (final ancestor in ancestorsBeforeStatementOrDeclaration(node)) {
+      if (ancestor is InstanceCreationExpression &&
+          isMixScopeType(ancestor.staticType)) {
         rule.reportAtNode(node);
 
         return;
       }
-      current = current.parent;
     }
   }
 }

--- a/packages/mix_lint/lib/src/rules/mix_avoid_defining_tokens_within_style.dart
+++ b/packages/mix_lint/lib/src/rules/mix_avoid_defining_tokens_within_style.dart
@@ -5,6 +5,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/error/error.dart';
 
+import '../utils/ast_helpers.dart';
 import '../utils/type_helpers.dart';
 
 class MixAvoidDefiningTokensWithinStyle extends AnalysisRule {
@@ -45,24 +46,19 @@ class _Visitor extends SimpleAstVisitor<void> {
   void visitInstanceCreationExpression(InstanceCreationExpression node) {
     if (!isMixTokenType(node.staticType)) return;
 
-    // Walk up the AST to see if this token is inside a Styler method chain.
-    // Stop at statement/declaration boundaries.
-    AstNode? current = node.parent;
-    while (current != null &&
-        current is! Statement &&
-        current is! Declaration) {
-      if (current is MethodInvocation && isMixStylerType(current.staticType)) {
+    for (final ancestor in ancestorsBeforeStatementOrDeclaration(node)) {
+      if (ancestor is MethodInvocation &&
+          isMixStylerType(ancestor.staticType)) {
         rule.reportAtNode(node);
 
         return;
       }
-      if (current is InstanceCreationExpression &&
-          isMixStylerType(current.staticType)) {
+      if (ancestor is InstanceCreationExpression &&
+          isMixStylerType(ancestor.staticType)) {
         rule.reportAtNode(node);
 
         return;
       }
-      current = current.parent;
     }
   }
 }

--- a/packages/mix_lint/lib/src/rules/mix_avoid_empty_variants.dart
+++ b/packages/mix_lint/lib/src/rules/mix_avoid_empty_variants.dart
@@ -5,6 +5,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/error/error.dart';
 
+import '../utils/ast_helpers.dart';
 import '../utils/type_helpers.dart';
 
 class MixAvoidEmptyVariants extends AnalysisRule {
@@ -41,30 +42,11 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   const _Visitor(this.rule);
 
-  /// Collects the linear chain of [MethodInvocation]s directly following [ice].
-  /// Stops when the chain branches into non-target contexts (e.g. argument lists).
-  List<MethodInvocation> _collectChain(InstanceCreationExpression ice) {
-    final chain = <MethodInvocation>[];
-    AstNode? current = ice;
-
-    while (true) {
-      final parent = current!.parent;
-      if (parent is MethodInvocation && parent.target == current) {
-        chain.add(parent);
-        current = parent;
-      } else {
-        break;
-      }
-    }
-
-    return chain;
-  }
-
   @override
   void visitInstanceCreationExpression(InstanceCreationExpression node) {
     if (!isMixStylerType(node.staticType)) return;
 
-    final chain = _collectChain(node);
+    final chain = collectDirectMethodChain(node);
     if (chain.isEmpty) return;
 
     final allVariants = chain.every(

--- a/packages/mix_lint/lib/src/rules/mix_avoid_token_ref_outside_mix.dart
+++ b/packages/mix_lint/lib/src/rules/mix_avoid_token_ref_outside_mix.dart
@@ -71,6 +71,7 @@ class _Visitor extends SimpleAstVisitor<void> {
     switch (_classify(consumer)) {
       case .notMix:
         rule.reportAtNode(callable);
+        break;
       case .mix:
       case .unknown:
         break;

--- a/packages/mix_lint/lib/src/rules/mix_avoid_token_ref_outside_mix.dart
+++ b/packages/mix_lint/lib/src/rules/mix_avoid_token_ref_outside_mix.dart
@@ -29,7 +29,7 @@ class MixAvoidTokenRefOutsideMix extends AnalysisRule {
         'A token reference (e.g. token() or token.mix()) is a sentinel that only '
         "resolves inside Mix's pipeline. Pass it to a Mix styler/utility, or use "
         'token.resolve(context) to read the concrete value.',
-    severity: DiagnosticSeverity.WARNING,
+    severity: .WARNING,
   );
 
   MixAvoidTokenRefOutsideMix()
@@ -61,22 +61,6 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   const _Visitor(this.rule);
 
-  @override
-  void visitFunctionExpressionInvocation(FunctionExpressionInvocation node) {
-    // Implicit call: `token()`, `ColorToken('x')()`.
-    if (!isMixTokenType(node.function.staticType)) return;
-    _check(node);
-  }
-
-  @override
-  void visitMethodInvocation(MethodInvocation node) {
-    // Explicit ref producers: `token.call()` and `token.mix()`.
-    final name = node.methodName.name;
-    if (name != 'call' && name != 'mix') return;
-    if (!isMixTokenType(node.target?.staticType)) return;
-    _check(node);
-  }
-
   /// Reports [callable] (a token reference expression) when it is passed as an
   /// argument to a non-Mix API. Stays silent when the reference is not an
   /// argument or when the consumer cannot be resolved.
@@ -85,10 +69,10 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (consumer == null) return;
 
     switch (_classify(consumer)) {
-      case _Verdict.notMix:
+      case .notMix:
         rule.reportAtNode(callable);
-      case _Verdict.mix:
-      case _Verdict.unknown:
+      case .mix:
+      case .unknown:
         break;
     }
   }
@@ -123,12 +107,13 @@ class _Visitor extends SimpleAstVisitor<void> {
       // Instance receiver (e.g. `BoxStyler().color(...)`).
       final receiverType = consumer.target?.staticType;
       if (receiverType is InterfaceType) {
-        if (isMixType(receiverType)) return _Verdict.mix;
+        if (isMixType(receiverType)) return .mix;
 
         // A resolved non-type receiver: judge by enclosing element below, but
         // a plain instance receiver that is not Mix is a clear escape.
         final enclosing = _enclosingVerdict(consumer.methodName.element);
-        return enclosing == _Verdict.mix ? _Verdict.mix : _Verdict.notMix;
+
+        return enclosing == .mix ? .mix : .notMix;
       }
 
       // Static method (`EdgeInsetsGeometryMix.all(...)`) or top-level function.
@@ -137,34 +122,50 @@ class _Visitor extends SimpleAstVisitor<void> {
 
     // A function-typed value is being invoked (e.g. a closure variable). We
     // cannot tell whether it came from Mix, so stay silent.
-    return _Verdict.unknown;
+    return .unknown;
   }
 
   /// Classifies a callee [element] by its enclosing type, falling back to the
   /// declaring library URI for top-level functions.
   _Verdict _enclosingVerdict(Element? element) {
-    if (element == null) return _Verdict.unknown;
+    if (element == null) return .unknown;
 
     final enclosing = element.enclosingElement;
     if (enclosing is InterfaceElement) {
-      return isMixType(enclosing.thisType) ? _Verdict.mix : _Verdict.notMix;
+      return isMixType(enclosing.thisType) ? .mix : .notMix;
     }
 
     // Top-level / free function: allow only when declared in `package:mix`.
     final uri = element.library?.uri;
-    if (uri == null) return _Verdict.unknown;
+    if (uri == null) return .unknown;
 
-    return _isMixPackageUri(uri) ? _Verdict.mix : _Verdict.notMix;
+    return _isMixPackageUri(uri) ? .mix : .notMix;
   }
 
   _Verdict _verdictForType(DartType? type) {
-    if (type is! InterfaceType) return _Verdict.unknown;
+    if (type is! InterfaceType) return .unknown;
 
-    return isMixType(type) ? _Verdict.mix : _Verdict.notMix;
+    return isMixType(type) ? .mix : .notMix;
   }
 
   bool _isMixPackageUri(Uri uri) =>
       uri.scheme == 'package' &&
       uri.pathSegments.isNotEmpty &&
       uri.pathSegments.first == 'mix';
+
+  @override
+  void visitFunctionExpressionInvocation(FunctionExpressionInvocation node) {
+    // Implicit call: `token()`, `ColorToken('x')()`.
+    if (!isMixTokenType(node.function.staticType)) return;
+    _check(node);
+  }
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    // Explicit ref producers: `token.call()` and `token.mix()`.
+    final name = node.methodName.name;
+    if (name != 'call' && name != 'mix') return;
+    if (!isMixTokenType(node.target?.staticType)) return;
+    _check(node);
+  }
 }

--- a/packages/mix_lint/lib/src/rules/mix_max_number_of_attributes_per_style.dart
+++ b/packages/mix_lint/lib/src/rules/mix_max_number_of_attributes_per_style.dart
@@ -5,6 +5,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/error/error.dart';
 
+import '../utils/ast_helpers.dart';
 import '../utils/type_helpers.dart';
 
 class MixMaxNumberOfAttributesPerStyle extends AnalysisRule {
@@ -47,28 +48,11 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   const _Visitor(this.rule, this.maxNumber);
 
-  List<MethodInvocation> _collectChain(InstanceCreationExpression ice) {
-    final chain = <MethodInvocation>[];
-    AstNode? current = ice;
-
-    while (true) {
-      final parent = current!.parent;
-      if (parent is MethodInvocation && parent.target == current) {
-        chain.add(parent);
-        current = parent;
-      } else {
-        break;
-      }
-    }
-
-    return chain;
-  }
-
   @override
   void visitInstanceCreationExpression(InstanceCreationExpression node) {
     if (!isMixStylerType(node.staticType)) return;
 
-    final chain = _collectChain(node);
+    final chain = collectDirectMethodChain(node);
     if (chain.length > maxNumber) {
       rule.reportAtNode(node);
     }

--- a/packages/mix_lint/lib/src/utils/ast_helpers.dart
+++ b/packages/mix_lint/lib/src/utils/ast_helpers.dart
@@ -1,0 +1,29 @@
+import 'package:analyzer/dart/ast/ast.dart';
+
+/// Collects the linear method chain directly following [root].
+///
+/// Stops when the chain branches into another context, such as an argument list.
+List<MethodInvocation> collectDirectMethodChain(
+  InstanceCreationExpression root,
+) {
+  final chain = <MethodInvocation>[];
+  AstNode current = root;
+
+  while (true) {
+    final parent = current.parent;
+    if (parent is! MethodInvocation || parent.target != current) break;
+
+    chain.add(parent);
+    current = parent;
+  }
+
+  return chain;
+}
+
+Iterable<AstNode> ancestorsBeforeStatementOrDeclaration(AstNode node) sync* {
+  AstNode? current = node.parent;
+  while (current != null && current is! Statement && current is! Declaration) {
+    yield current;
+    current = current.parent;
+  }
+}


### PR DESCRIPTION
## Summary

This PR splits behavior-preserving, output-neutral tooling refactors out of
the larger `feat/mix_schema` work so they can be reviewed independently.

## Changes

- `mix_generator`: extracts duplicated `@MixableSpec(target:)` target
  validation into shared helpers in `widget_call_planner.dart`.
- `mix_lint`: adds shared AST-walk helpers and applies them across the
  existing lint rules.
- Modernizes `mix_avoid_token_ref_outside_mix.dart` to Dart dot-shorthand and
  adds an explicit switch terminator from review feedback.

## Behavior Notes

- No generated output behavior changes intended.
- No lint-rule behavior changes intended.

## Verification

- `melos run gen:build`
  - Passed with no unstaged generated-file drift after codegen.
- `melos run ci --no-select`
  - Passed.
- `melos run analyze --no-select`
  - Passed.
