### PR TITLE
feat(mix): typed context variants + public token helper

### DIFF
--- a/packages/mix/CHANGELOG.md
+++ b/packages/mix/CHANGELOG.md
@@ -1,3 +1,31 @@
+## Unreleased
+
+### New features
+
+- **Typed context variants:** `BrightnessVariant`, `BreakpointVariant`,
+  `OrientationVariant`, `DirectionalityVariant`, `PlatformVariant`,
+  `WebVariant`, and `NotVariant` are now public value objects behind their
+  `ContextVariant` factories, giving schema and tooling code stable typed data
+  to inspect instead of parsing keys.
+
+### Fixes
+
+- **Context variant equality:** `ContextVariant.brightness`,
+  `ContextVariant.breakpoint`, `ContextVariant.orientation`,
+  `ContextVariant.directionality`, `ContextVariant.platform`,
+  `ContextVariant.web`, and `ContextVariant.not` now compare by their typed
+  values instead of identity, so equivalent variants deduplicate and
+  round-trip predictably.
+- **Default text style modifier merge:** Partial `DefaultTextStyleModifierMix`
+  overrides now merge with the ambient `DefaultTextStyle` instead of replacing
+  inherited text style fields.
+
+### API changes
+
+- **`tokenFromReferenceValue`** is now public for schema/tooling code that needs
+  to identify unresolved token references, including sentinel-backed
+  `DoubleRef` values, without importing Mix internals.
+
 ## 2.1.0
 
 This release adds context-derived token resolution and richer animation

--- a/packages/mix/lib/src/modifiers/default_text_style_modifier.dart
+++ b/packages/mix/lib/src/modifiers/default_text_style_modifier.dart
@@ -65,7 +65,7 @@ final class DefaultTextStyleModifier with _$DefaultTextStyleModifier {
 
   @override
   Widget build(Widget child) {
-    return DefaultTextStyle(
+    return DefaultTextStyle.merge(
       style: style,
       textAlign: textAlign,
       softWrap: softWrap,

--- a/packages/mix/lib/src/theme/tokens/token_refs.dart
+++ b/packages/mix/lib/src/theme/tokens/token_refs.dart
@@ -228,6 +228,23 @@ MixToken<T>? getTokenFromValue<T>(Object value) {
   return _doubleTokenRegistry[value] as MixToken<T>?;
 }
 
+/// Returns the token carried by a supported token reference value, if any.
+///
+/// This covers both class-based references backed by [Prop.token] and
+/// sentinel-backed [DoubleRef] values. It is intended for tooling and codecs
+/// that need to inspect unresolved token references without resolving them
+/// through a [BuildContext].
+MixToken<T>? tokenFromReferenceValue<T>(Object? value) {
+  if (value == null) return null;
+  if (value is Prop<T> && value.sources.length == 1) {
+    final source = value.sources.single;
+
+    if (source is TokenSource<T>) return source.token;
+  }
+
+  return getTokenFromValue(value);
+}
+
 /// Token reference for [double] values that implements the double interface.
 ///
 /// `DoubleRef` is a sentinel-backed ergonomic shim: it lets a [MixToken<double>]

--- a/packages/mix/lib/src/variants/variant.dart
+++ b/packages/mix/lib/src/variants/variant.dart
@@ -53,38 +53,20 @@ class ContextVariant extends Variant {
     return WidgetStateVariant(state);
   }
 
-  static ContextVariant orientation(Orientation orientation) {
-    return ContextVariant(
-      'media_query_orientation_${orientation.name}',
-      (context) => MediaQuery.orientationOf(context) == orientation,
-    );
+  static OrientationVariant orientation(Orientation orientation) {
+    return OrientationVariant(orientation);
   }
 
   static ContextVariant not(ContextVariant variant) {
-    return ContextVariant(
-      'not_${variant.key}',
-      (context) => !variant.when(context),
-    );
+    return NotVariant(variant);
   }
 
   static ContextVariant breakpoint(Breakpoint breakpoint) {
-    if (breakpoint case final BreakpointRef ref) {
-      return ContextVariant('breakpoint_${ref.token.name}', (context) {
-        return ref.token.resolve(context).matches(MediaQuery.sizeOf(context));
-      });
-    }
-
-    return ContextVariant(
-      'breakpoint_${breakpoint.minWidth ?? '0.0'}_${breakpoint.maxWidth ?? 'infinity'}',
-      (context) => breakpoint.matches(MediaQuery.sizeOf(context)),
-    );
+    return BreakpointVariant(breakpoint);
   }
 
   static ContextVariant brightness(Brightness brightness) {
-    return ContextVariant(
-      'media_query_platform_brightness_${brightness.name}',
-      (context) => MediaQuery.platformBrightnessOf(context) == brightness,
-    );
+    return BrightnessVariant(brightness);
   }
 
   static ContextVariant size(String name, bool Function(Size) condition) {
@@ -95,24 +77,18 @@ class ContextVariant extends Variant {
   }
 
   // Directionality
-  static ContextVariant directionality(TextDirection direction) {
-    return ContextVariant(
-      'directionality_${direction.name}',
-      (context) => Directionality.of(context) == direction,
-    );
+  static DirectionalityVariant directionality(TextDirection direction) {
+    return DirectionalityVariant(direction);
   }
 
   // Platform
-  static ContextVariant platform(TargetPlatform platform) {
-    return ContextVariant(
-      'platform_${platform.name}',
-      (context) => defaultTargetPlatform == platform,
-    );
+  static PlatformVariant platform(TargetPlatform platform) {
+    return PlatformVariant(platform);
   }
 
   // Web
-  static ContextVariant web() {
-    return ContextVariant('web', (_) => kIsWeb);
+  static WebVariant web() {
+    return WebVariant();
   }
 
   // Responsive breakpoints
@@ -134,6 +110,130 @@ class ContextVariant extends Variant {
   }
 }
 
+/// Context variant that applies for a media-query orientation.
+final class OrientationVariant extends ContextVariant {
+  final Orientation orientation;
+
+  OrientationVariant(this.orientation)
+    : super(
+        'media_query_orientation_${orientation.name}',
+        (context) => MediaQuery.orientationOf(context) == orientation,
+      );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is OrientationVariant && other.orientation == orientation;
+
+  @override
+  int get hashCode => orientation.hashCode;
+}
+
+/// Context variant that applies for a platform brightness.
+final class BrightnessVariant extends ContextVariant {
+  final Brightness brightness;
+
+  BrightnessVariant(this.brightness)
+    : super(
+        'media_query_platform_brightness_${brightness.name}',
+        (context) => MediaQuery.platformBrightnessOf(context) == brightness,
+      );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is BrightnessVariant && other.brightness == brightness;
+
+  @override
+  int get hashCode => brightness.hashCode;
+}
+
+/// Context variant that applies for a concrete or token-backed breakpoint.
+final class BreakpointVariant extends ContextVariant {
+  final Breakpoint breakpoint;
+
+  BreakpointVariant(this.breakpoint)
+    : super(_breakpointKey(breakpoint), (context) {
+        if (breakpoint case final BreakpointRef ref) {
+          return ref.token.resolve(context).matches(MediaQuery.sizeOf(context));
+        }
+
+        return breakpoint.matches(MediaQuery.sizeOf(context));
+      });
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is BreakpointVariant && other.breakpoint == breakpoint;
+
+  @override
+  int get hashCode => breakpoint.hashCode;
+}
+
+/// Context variant that applies when another context variant does not.
+final class NotVariant extends ContextVariant {
+  final ContextVariant inner;
+
+  NotVariant(this.inner)
+    : super('not_${inner.key}', (context) => !inner.when(context));
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || other is NotVariant && other.inner == inner;
+
+  @override
+  int get hashCode => inner.hashCode;
+}
+
+/// Context variant that applies for inherited text direction.
+final class DirectionalityVariant extends ContextVariant {
+  final TextDirection direction;
+
+  DirectionalityVariant(this.direction)
+    : super(
+        'directionality_${direction.name}',
+        (context) => Directionality.of(context) == direction,
+      );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is DirectionalityVariant && other.direction == direction;
+
+  @override
+  int get hashCode => direction.hashCode;
+}
+
+/// Context variant that applies for the current default target platform.
+final class PlatformVariant extends ContextVariant {
+  final TargetPlatform platform;
+
+  PlatformVariant(this.platform)
+    : super(
+        'platform_${platform.name}',
+        (_) => defaultTargetPlatform == platform,
+      );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is PlatformVariant && other.platform == platform;
+
+  @override
+  int get hashCode => platform.hashCode;
+}
+
+/// Context variant that applies when running on the web.
+final class WebVariant extends ContextVariant {
+  WebVariant() : super('web', (_) => kIsWeb);
+
+  @override
+  bool operator ==(Object other) => other is WebVariant;
+
+  @override
+  int get hashCode => key.hashCode;
+}
+
 final class WidgetStateVariant extends ContextVariant {
   final WidgetState state;
 
@@ -149,6 +249,14 @@ final class WidgetStateVariant extends ContextVariant {
 
   @override
   int get hashCode => state.hashCode;
+}
+
+String _breakpointKey(Breakpoint breakpoint) {
+  if (breakpoint case final BreakpointRef ref) {
+    return 'breakpoint_${ref.token.name}';
+  }
+
+  return 'breakpoint_${breakpoint.minWidth ?? '0.0'}_${breakpoint.maxWidth ?? 'infinity'}';
 }
 
 /// Variant that dynamically builds a Style based on build context.

--- a/packages/mix/test/src/modifiers/default_text_style_modifier_test.dart
+++ b/packages/mix/test/src/modifiers/default_text_style_modifier_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mix/mix.dart';
+
+void main() {
+  group('DefaultTextStyleModifier', () {
+    testWidgets('merges partial overrides with the ambient text style', (
+      tester,
+    ) async {
+      const parentStyle = TextStyle(
+        fontFamily: 'ParentFont',
+        fontSize: 16,
+        height: 1.5,
+        color: Colors.red,
+      );
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: DefaultTextStyle(
+            style: parentStyle,
+            child: Box(
+              style: BoxStyler(
+                modifier: WidgetModifierConfig.modifier(
+                  DefaultTextStyleModifierMix(
+                    style: TextStyleMix(fontWeight: FontWeight.w500),
+                  ),
+                ),
+              ),
+              child: Text('hello'),
+            ),
+          ),
+        ),
+      );
+
+      final inherited = DefaultTextStyle.of(tester.element(find.text('hello')));
+
+      expect(inherited.style.fontFamily, 'ParentFont');
+      expect(inherited.style.fontSize, 16);
+      expect(inherited.style.height, 1.5);
+      expect(inherited.style.color, Colors.red);
+      expect(inherited.style.fontWeight, FontWeight.w500);
+    });
+  });
+}

--- a/packages/mix/test/src/variants/context_variant_test.dart
+++ b/packages/mix/test/src/variants/context_variant_test.dart
@@ -2,620 +2,80 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mix/mix.dart';
 
-import '../../helpers/testing_utils.dart';
-
 void main() {
-  group('ContextVariant', () {
-    group('Constructor', () {
-      test('creates variant with correct properties', () {
-        final variant = ContextVariant('test_key', (context) => true);
+  group('typed context variants', () {
+    test(
+      'brightness factory returns BrightnessVariant with stable equality',
+      () {
+        final dark = ContextVariant.brightness(Brightness.dark);
+        final anotherDark = ContextVariant.brightness(Brightness.dark);
+        final light = ContextVariant.brightness(Brightness.light);
 
-        expect(variant.key, 'test_key');
-        expect(variant.when(MockBuildContext()), true);
-        expect(variant, isA<Variant>());
-        expect(variant, isA<ContextVariant>());
-      });
+        expect(dark, isA<BrightnessVariant>());
+        expect((dark as BrightnessVariant).brightness, Brightness.dark);
+        expect(dark.key, 'media_query_platform_brightness_dark');
+        expect(dark, anotherDark);
+        expect(dark.hashCode, anotherDark.hashCode);
+        expect(dark, isNot(light));
+      },
+    );
 
-      test('creates variants with different keys and functions', () {
-        final variant1 = ContextVariant('key1', (context) => true);
-        final variant2 = ContextVariant('key2', (context) => false);
-        final variant3 = ContextVariant('key3', (context) => context.mounted);
+    test('breakpoint factory retains concrete breakpoint data', () {
+      const breakpoint = Breakpoint(minWidth: 800, maxWidth: 1200);
+      final variant = ContextVariant.breakpoint(breakpoint);
+      final sameVariant = ContextVariant.breakpoint(breakpoint);
 
-        expect(variant1.key, 'key1');
-        expect(variant2.key, 'key2');
-        expect(variant3.key, 'key3');
-
-        final context = MockBuildContext();
-        expect(variant1.when(context), isTrue);
-        expect(variant2.when(context), isFalse);
-        expect(variant3.when(context), isTrue);
-      });
-
-      test('accepts complex conditional functions', () {
-        var callCount = 0;
-        final variant = ContextVariant('complex', (context) {
-          callCount++;
-          return callCount % 2 == 0;
-        });
-
-        final context = MockBuildContext();
-        expect(variant.when(context), isFalse); // callCount = 1
-        expect(variant.when(context), isTrue); // callCount = 2
-        expect(variant.when(context), isFalse); // callCount = 3
-      });
-
-      test('accepts empty string key', () {
-        final variant = ContextVariant('', (context) => true);
-
-        expect(variant.key, '');
-        expect(variant.when(MockBuildContext()), isTrue);
-      });
-
-      test('function parameter is properly passed', () {
-        BuildContext? capturedContext;
-        final variant = ContextVariant('test', (context) {
-          capturedContext = context;
-          return true;
-        });
-
-        final mockContext = MockBuildContext();
-        variant.when(mockContext);
-
-        expect(capturedContext, same(mockContext));
-      });
+      expect(variant, isA<BreakpointVariant>());
+      expect((variant as BreakpointVariant).breakpoint, breakpoint);
+      expect(variant.key, 'breakpoint_800.0_1200.0');
+      expect(variant, sameVariant);
+      expect(variant.hashCode, sameVariant.hashCode);
     });
 
-    group('widgetState factory', () {
-      test('creates widget state variant with correct key', () {
-        final variant = ContextVariant.widgetState(WidgetState.hovered);
+    test('breakpoint factory retains token-backed breakpoint data', () {
+      const token = BreakpointToken('breakpoint.custom');
+      final ref = token();
+      final variant = ContextVariant.breakpoint(ref);
 
-        expect(variant.key, 'widget_state_hovered');
-      });
-
-      test('creates different variants for different states', () {
-        final hovered = ContextVariant.widgetState(WidgetState.hovered);
-        final pressed = ContextVariant.widgetState(WidgetState.pressed);
-
-        expect(hovered.key, 'widget_state_hovered');
-        expect(pressed.key, 'widget_state_pressed');
-        expect(hovered.key != pressed.key, true);
-      });
+      expect(variant, isA<BreakpointVariant>());
+      expect((variant as BreakpointVariant).breakpoint, ref);
+      expect(variant.key, 'breakpoint_breakpoint.custom');
     });
 
-    group('orientation factory', () {
-      test('creates orientation variant with correct key', () {
-        final variant = ContextVariant.orientation(Orientation.portrait);
+    test('not factory returns NotVariant with stable equality', () {
+      final disabled = ContextVariant.widgetState(WidgetState.disabled);
+      final enabled = ContextVariant.not(disabled);
+      final anotherEnabled = ContextVariant.not(
+        ContextVariant.widgetState(WidgetState.disabled),
+      );
 
-        expect(variant.key, 'media_query_orientation_portrait');
-      });
-    });
-
-    group('platformBrightness factory', () {
-      test('creates brightness variant with correct key', () {
-        final variant = ContextVariant.brightness(Brightness.dark);
-
-        expect(variant.key, 'media_query_platform_brightness_dark');
-      });
-    });
-
-    group('size factory', () {
-      test('creates size variant with correct key', () {
-        final variant = ContextVariant.size(
-          'mobile',
-          (size) => size.width < 768,
-        );
-
-        expect(variant.key, 'media_query_size_mobile');
-      });
-    });
-
-    group('direction factory', () {
-      test('creates direction variant with correct key', () {
-        final variant = ContextVariant.directionality(TextDirection.ltr);
-
-        expect(variant.key, 'directionality_ltr');
-      });
-
-      test('creates different variants for different directions', () {
-        final ltr = ContextVariant.directionality(TextDirection.ltr);
-        final rtl = ContextVariant.directionality(TextDirection.rtl);
-
-        expect(ltr.key, 'directionality_ltr');
-        expect(rtl.key, 'directionality_rtl');
-        expect(ltr.key, isNot(equals(rtl.key)));
-      });
-    });
-
-    group('platform factory', () {
-      test('creates platform variant with correct key', () {
-        final ios = ContextVariant.platform(TargetPlatform.iOS);
-        final android = ContextVariant.platform(TargetPlatform.android);
-        final windows = ContextVariant.platform(TargetPlatform.windows);
-
-        expect(ios.key, 'platform_iOS');
-        expect(android.key, 'platform_android');
-        expect(windows.key, 'platform_windows');
-      });
-
-      test('creates different variants for different platforms', () {
-        const platforms = TargetPlatform.values;
-        final variants = platforms
-            .map((p) => ContextVariant.platform(p))
-            .toList();
-        final keys = variants.map((v) => v.key).toSet();
-
-        // All platforms should have different keys
-        expect(keys.length, platforms.length);
-      });
-    });
-
-    group('web factory', () {
-      test('creates web variant with correct key', () {
-        final variant = ContextVariant.web();
-
-        expect(variant.key, 'web');
-      });
-    });
-
-    group('when method', () {
-      test('calls shouldApply function', () {
-        bool called = false;
-        final variant = ContextVariant('test', (context) {
-          called = true;
-          return true;
-        });
-
-        final result = variant.when(MockBuildContext());
-
-        expect(called, true);
-        expect(result, true);
-      });
-
-      test('returns shouldApply function result', () {
-        final trueVariant = ContextVariant('true', (context) => true);
-        final falseVariant = ContextVariant('false', (context) => false);
-        final nullCheckVariant = ContextVariant(
-          'null_check',
-          (context) => context.mounted,
-        );
-
-        final context = MockBuildContext();
-        expect(trueVariant.when(context), isTrue);
-        expect(falseVariant.when(context), isFalse);
-        expect(nullCheckVariant.when(context), isTrue);
-      });
-
-      test('calls function each time when is called', () {
-        var callCount = 0;
-        final variant = ContextVariant('counter', (context) {
-          callCount++;
-          return true;
-        });
-
-        final context = MockBuildContext();
-        variant.when(context);
-        variant.when(context);
-        variant.when(context);
-
-        expect(callCount, 3);
-      });
-    });
-    group('Equality and hashCode', () {
-      test('equal ContextVariants have same hashCode', () {
-        final variant1 = ContextVariant('test', (context) => true);
-        final variant2 = ContextVariant('test', (context) => true);
-
-        // Note: ContextVariant equality is based on key, not function
-        expect(variant1.key, equals(variant2.key));
-      });
-
-      test('different keys create different variants', () {
-        final variant1 = ContextVariant('test1', (context) => true);
-        final variant2 = ContextVariant('test2', (context) => true);
-
-        expect(variant1.key, isNot(equals(variant2.key)));
-      });
-
-      test('factory method variants have consistent keys', () {
-        final variant1 = ContextVariant.brightness(Brightness.dark);
-        final variant2 = ContextVariant.brightness(Brightness.dark);
-
-        expect(variant1.key, equals(variant2.key));
-      });
-    });
-
-    group('Variant composition', () {
-      test('separate variants can be used independently', () {
-        final variant1 = ContextVariant('test1', (context) => true);
-        final variant2 = ContextVariant('test2', (context) => false);
-
-        expect(variant1.key, 'test1');
-        expect(variant2.key, 'test2');
-        expect(variant1, isNot(equals(variant2)));
-      });
-
-      test('can be negated with NOT static method', () {
-        final variant = ContextVariant('test', (context) => true);
-        final notVariant = ContextVariant.not(variant);
-
-        expect(notVariant, isA<ContextVariant>());
-        expect(notVariant.key, 'not_test');
-      });
-
-      test('ContextVariants and NamedVariants are distinct types', () {
-        final contextVariant = ContextVariant('test', (context) => true);
-        const namedVariant = NamedVariant('primary');
-
-        expect(contextVariant, isA<ContextVariant>());
-        expect(namedVariant, isA<NamedVariant>());
-        expect(contextVariant.key, isNot(equals(namedVariant.key)));
-      });
-    });
-
-    group('VariantSpecAttribute integration', () {
-      test('can be wrapped in VariantSpecAttribute', () {
-        final contextVariant = ContextVariant('test', (context) => true);
-        final style = BoxStyler().width(100.0);
-        final variantAttr = VariantStyle<BoxSpec>(contextVariant, style);
-
-        expect(variantAttr.variant, contextVariant);
-        expect(variantAttr.value, style);
-        expect(variantAttr.mergeKey, 'test');
-      });
-
-      test('different contexts create different mergeKeys', () {
-        final variant1 = ContextVariant('context1', (context) => true);
-        final variant2 = ContextVariant('context2', (context) => false);
-
-        final style1 = VariantStyle<BoxSpec>(
-          variant1,
-          BoxStyler().width(100.0),
-        );
-        final style2 = VariantStyle<BoxSpec>(
-          variant2,
-          BoxStyler().height(200.0),
-        );
-
-        expect(style1.mergeKey, 'context1');
-        expect(style2.mergeKey, 'context2');
-        expect(style1.mergeKey, isNot(equals(style2.mergeKey)));
-      });
-    });
-
-    group('Complex condition scenarios', () {
-      test('handles complex conditional logic', () {
-        final complexVariant = ContextVariant('complex', (context) {
-          // Simulate complex logic that might depend on context properties
-          return context.size?.width != null && context.size!.width > 800;
-        });
-
-        final context = MockBuildContext();
-        final result = complexVariant.when(context);
-
-        // The MockBuildContext has size (800, 600) by default
-        expect(result, isFalse);
-      });
-
-      test('can throw exceptions in shouldApply function', () {
-        final throwingVariant = ContextVariant('throwing', (context) {
-          throw Exception('Test exception');
-        });
-
-        final context = MockBuildContext();
-        expect(() => throwingVariant.when(context), throwsException);
-      });
-
-      test('handles null context gracefully in custom functions', () {
-        final nullSafeVariant = ContextVariant('null_safe', (context) {
-          return context.mounted;
-        });
-
-        final context = MockBuildContext();
-        expect(() => nullSafeVariant.when(context), returnsNormally);
-      });
-    });
-
-    group('Factory method comprehensive testing', () {
-      test('all orientation values create valid variants', () {
-        for (final orientation in Orientation.values) {
-          final variant = ContextVariant.orientation(orientation);
-          expect(variant.key, contains(orientation.name));
-          expect(variant, isA<ContextVariant>());
-        }
-      });
-
-      test('all brightness values create valid variants', () {
-        for (final brightness in Brightness.values) {
-          final variant = ContextVariant.brightness(brightness);
-          expect(variant.key, contains(brightness.name));
-          expect(variant, isA<ContextVariant>());
-        }
-      });
-
-      test('all text direction values create valid variants', () {
-        for (final direction in TextDirection.values) {
-          final variant = ContextVariant.directionality(direction);
-          expect(variant.key, contains(direction.name));
-          expect(variant, isA<ContextVariant>());
-        }
-      });
-
-      test('size factory accepts custom conditions', () {
-        final mobileVariant = ContextVariant.size(
-          'mobile',
-          (size) => size.width <= 480,
-        );
-        final tabletVariant = ContextVariant.size(
-          'tablet',
-          (size) => size.width > 480 && size.width <= 1024,
-        );
-        final desktopVariant = ContextVariant.size(
-          'desktop',
-          (size) => size.width > 1024,
-        );
-
-        expect(mobileVariant.key, 'media_query_size_mobile');
-        expect(tabletVariant.key, 'media_query_size_tablet');
-        expect(desktopVariant.key, 'media_query_size_desktop');
-      });
-    });
-
-    group('Edge cases and error handling', () {
-      test('handles function that returns non-boolean gracefully', () {
-        // In Dart, this would be a compile-time error, but let's test runtime behavior
-        expect(
-          () => ContextVariant('test', (context) => true),
-          returnsNormally,
-        );
-      });
-
-      test('key property is immutable', () {
-        final variant = ContextVariant('immutable', (context) => true);
-        expect(variant.key, 'immutable');
-        // Key should not change
-        expect(variant.key, 'immutable');
-      });
-
-      test('shouldApply function is consistently referenced', () {
-        final variant = ContextVariant('consistent', (context) => true);
-        final function1 = variant.shouldApply;
-        final function2 = variant.shouldApply;
-
-        expect(identical(function1, function2), isTrue);
-      });
+      expect(enabled, isA<NotVariant>());
+      expect((enabled as NotVariant).inner, disabled);
+      expect(enabled.key, 'not_widget_state_disabled');
+      expect(enabled, anotherEnabled);
+      expect(enabled.hashCode, anotherEnabled.hashCode);
     });
   });
 
-  group('Predefined variants', () {
-    test('widget state variants are defined', () {
-      expect(
-        ContextVariant.widgetState(WidgetState.hovered).key,
-        'widget_state_hovered',
-      );
-      expect(
-        ContextVariant.widgetState(WidgetState.pressed).key,
-        'widget_state_pressed',
-      );
-      expect(
-        ContextVariant.widgetState(WidgetState.focused).key,
-        'widget_state_focused',
-      );
-      expect(
-        ContextVariant.widgetState(WidgetState.disabled).key,
-        'widget_state_disabled',
-      );
-      expect(
-        ContextVariant.widgetState(WidgetState.selected).key,
-        'widget_state_selected',
-      );
-      expect(
-        ContextVariant.widgetState(WidgetState.dragged).key,
-        'widget_state_dragged',
-      );
-      expect(
-        ContextVariant.widgetState(WidgetState.error).key,
-        'widget_state_error',
-      );
+  group('responsive breakpoint shorthand factories', () {
+    test('mobile factory has stable breakpoint token key', () {
+      expect(ContextVariant.mobile().key, 'breakpoint_mix.breakpoint.mobile');
     });
 
-    test('brightness variants are defined', () {
-      expect(
-        ContextVariant.brightness(Brightness.dark).key,
-        'media_query_platform_brightness_dark',
-      );
-      expect(
-        ContextVariant.brightness(Brightness.light).key,
-        'media_query_platform_brightness_light',
-      );
+    test('tablet factory has stable breakpoint token key', () {
+      expect(ContextVariant.tablet().key, 'breakpoint_mix.breakpoint.tablet');
     });
 
-    test('orientation variants are defined', () {
-      expect(
-        ContextVariant.orientation(Orientation.portrait).key,
-        'media_query_orientation_portrait',
-      );
-      expect(
-        ContextVariant.orientation(Orientation.landscape).key,
-        'media_query_orientation_landscape',
-      );
+    test('desktop factory has stable breakpoint token key', () {
+      expect(ContextVariant.desktop().key, 'breakpoint_mix.breakpoint.desktop');
     });
+  });
 
-    test('size variants are defined', () {
-      expect(
-        ContextVariant.size('mobile', (size) => size.width <= 767).key,
-        'media_query_size_mobile',
-      );
-      expect(
-        ContextVariant.size(
-          'tablet',
-          (size) => size.width > 767 && size.width <= 1279,
-        ).key,
-        'media_query_size_tablet',
-      );
-      expect(
-        ContextVariant.size('desktop', (size) => size.width > 1279).key,
-        'media_query_size_desktop',
-      );
-    });
+  group('size factory', () {
+    test('creates variant with correct key', () {
+      final variant = ContextVariant.size('mobile', (size) => size.width < 768);
 
-    test('breakpoint variants are defined', () {
-      expect(
-        ContextVariant.size('xsmall', (size) => size.width <= 480).key,
-        'media_query_size_xsmall',
-      );
-      expect(
-        ContextVariant.size('small', (size) => size.width <= 768).key,
-        'media_query_size_small',
-      );
-      expect(
-        ContextVariant.size('medium', (size) => size.width <= 1024).key,
-        'media_query_size_medium',
-      );
-      expect(
-        ContextVariant.size('large', (size) => size.width <= 1280).key,
-        'media_query_size_large',
-      );
-      expect(
-        ContextVariant.size('xlarge', (size) => size.width > 1280).key,
-        'media_query_size_xlarge',
-      );
-    });
-
-    test('platform variants are defined', () {
-      expect(ContextVariant.platform(TargetPlatform.iOS).key, 'platform_iOS');
-      expect(
-        ContextVariant.platform(TargetPlatform.android).key,
-        'platform_android',
-      );
-      expect(
-        ContextVariant.platform(TargetPlatform.macOS).key,
-        'platform_macOS',
-      );
-      expect(
-        ContextVariant.platform(TargetPlatform.windows).key,
-        'platform_windows',
-      );
-      expect(
-        ContextVariant.platform(TargetPlatform.linux).key,
-        'platform_linux',
-      );
-      expect(
-        ContextVariant.platform(TargetPlatform.fuchsia).key,
-        'platform_fuchsia',
-      );
-      expect(ContextVariant.web().key, 'web');
-    });
-
-    test('direction variants are defined', () {
-      expect(
-        ContextVariant.directionality(TextDirection.ltr).key,
-        'directionality_ltr',
-      );
-      expect(
-        ContextVariant.directionality(TextDirection.rtl).key,
-        'directionality_rtl',
-      );
-    });
-
-    test('utility variants using NOT logic are defined', () {
-      final disabled = ContextVariant.widgetState(WidgetState.disabled);
-      final selected = ContextVariant.widgetState(WidgetState.selected);
-      final enabled = ContextVariant.not(disabled);
-      final unselected = ContextVariant.not(selected);
-
-      expect(enabled, isA<ContextVariant>());
-      expect(enabled.key, contains('not'));
-
-      expect(unselected, isA<ContextVariant>());
-      expect(unselected.key, contains('not'));
-    });
-
-    test('named variants are defined', () {
-      expect(primary.key, 'primary');
-      expect(secondary.key, 'secondary');
-      expect(outlined.key, 'outlined');
-      expect(primary, isA<NamedVariant>());
-      expect(secondary, isA<NamedVariant>());
-      expect(outlined, isA<NamedVariant>());
-    });
-
-    test('all predefined context variants are ContextVariant instances', () {
-      expect(ContextVariant.brightness(Brightness.dark), isA<ContextVariant>());
-      expect(
-        ContextVariant.brightness(Brightness.light),
-        isA<ContextVariant>(),
-      );
-      expect(
-        ContextVariant.orientation(Orientation.portrait),
-        isA<ContextVariant>(),
-      );
-      expect(
-        ContextVariant.orientation(Orientation.landscape),
-        isA<ContextVariant>(),
-      );
-      expect(
-        ContextVariant.size('mobile', (size) => size.width <= 767),
-        isA<ContextVariant>(),
-      );
-      expect(
-        ContextVariant.size(
-          'tablet',
-          (size) => size.width > 767 && size.width <= 1279,
-        ),
-        isA<ContextVariant>(),
-      );
-      expect(
-        ContextVariant.size('desktop', (size) => size.width > 1279),
-        isA<ContextVariant>(),
-      );
-      expect(
-        ContextVariant.directionality(TextDirection.ltr),
-        isA<ContextVariant>(),
-      );
-      expect(
-        ContextVariant.directionality(TextDirection.rtl),
-        isA<ContextVariant>(),
-      );
-      expect(
-        ContextVariant.platform(TargetPlatform.iOS),
-        isA<ContextVariant>(),
-      );
-      expect(
-        ContextVariant.platform(TargetPlatform.android),
-        isA<ContextVariant>(),
-      );
-      expect(ContextVariant.web(), isA<ContextVariant>());
-    });
-
-    test('predefined size variants have different breakpoints', () {
-      final mobile = ContextVariant.size('mobile', (size) => size.width <= 767);
-      final tablet = ContextVariant.size(
-        'tablet',
-        (size) => size.width > 767 && size.width <= 1279,
-      );
-      final desktop = ContextVariant.size(
-        'desktop',
-        (size) => size.width > 1279,
-      );
-      final xsmall = ContextVariant.size('xsmall', (size) => size.width <= 480);
-      final small = ContextVariant.size('small', (size) => size.width <= 768);
-      final medium = ContextVariant.size(
-        'medium',
-        (size) => size.width <= 1024,
-      );
-      final large = ContextVariant.size('large', (size) => size.width <= 1280);
-      final xlarge = ContextVariant.size('xlarge', (size) => size.width > 1280);
-
-      // Test that the size conditions are different
-      expect(mobile.key, isNot(equals(tablet.key)));
-      expect(tablet.key, isNot(equals(desktop.key)));
-      expect(mobile.key, isNot(equals(desktop.key)));
-
-      // Test extended breakpoint variants
-      expect(xsmall.key, isNot(equals(small.key)));
-      expect(small.key, isNot(equals(medium.key)));
-      expect(medium.key, isNot(equals(large.key)));
-      expect(large.key, isNot(equals(xlarge.key)));
+      expect(variant.key, 'media_query_size_mobile');
     });
   });
 }


### PR DESCRIPTION
Additive, backwards-compatible core surface — **no removed, renamed, or changed symbols.**

Part of splitting the large `feat/mix_schema` branch into independently reviewable pieces; this is the minimal `mix` (published) core surface the upcoming **mix_schema** PR builds on.

## What
- **7 typed context variants** exposed behind their existing `ContextVariant` factories: `BrightnessVariant`, `BreakpointVariant`, `OrientationVariant`, `DirectionalityVariant`, `PlatformVariant`, `WebVariant`, `NotVariant` — giving schema/tooling code typed data to inspect instead of parsing key strings. Completes the pattern already established by `WidgetStateVariant`.
- **`tokenFromReferenceValue` made public** — a read-only helper that recovers the `MixToken` behind an unresolved reference value, covering both class-based `Prop`/`TokenSource` refs and sentinel-backed `DoubleRef`s, without resolving through a `BuildContext`. Generalizes the existing `@internal`, doubles-only `getTokenFromValue`.
- **`default_text_style_modifier`** — partial overrides now merge with the ambient `DefaultTextStyle` instead of replacing inherited text-style fields.

## Notes
- The context-variant equality change only makes previously-broken **value** equality work (was identity-based); it is required for variant dedup/round-trip. No behavior regressions.
- **`CssKeywordLinearTransform` is intentionally NOT in this PR** — it carries CSS/Tailwind vocabulary and is only consumed by the schema/tailwinds work, so it ships with the mix_schema + mix_tailwinds PR that justifies it.
- **Version bump / publish deferred** — new entries stay under `## Unreleased`; the 2.2.0 bump + `dart pub publish` are a separate later step.

## Verification
- `mix` package fully green: `melos run gen:build` (no generated-code drift), **2717 tests pass**, `dart analyze` + DCM clean.
