### PR TITLE
fix(generator): support generic @MixWidget call methods

### DIFF
--- a/packages/mix_generator/CHANGELOG.md
+++ b/packages/mix_generator/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.1.2
+
+ - **FIX**: Allow `@MixWidget` to generate widgets from generic styler
+   `call<T>()` methods, preserving type parameter bounds and forwarding type
+   arguments to the styler call.
+
 ## 2.1.1
 
  - **FEAT**: Support `@MixableField(setterType:)` on `@MixableModifier` fields. Generated `ModifierMix` constructors accept the declared Mix type and wrap values with `Prop.maybeMix` (#950).

--- a/packages/mix_generator/lib/src/core/builders/mix_widget_builder.dart
+++ b/packages/mix_generator/lib/src/core/builders/mix_widget_builder.dart
@@ -70,14 +70,12 @@ class MixWidgetBuilder {
         : model.factoryReference;
 
     final callArgs = _callArgs();
+    final callTarget = '$invocation.call${model.typeParameterInvocation}';
+
     if (callArgs.isEmpty) {
-      buffer.writeln(
-        '    return $invocation.call${model.typeParameterInvocation}();',
-      );
+      buffer.writeln('    return $callTarget();');
     } else {
-      buffer.writeln(
-        '    return $invocation.call${model.typeParameterInvocation}(',
-      );
+      buffer.writeln('    return $callTarget(');
       for (final arg in callArgs) {
         buffer.writeln('      $arg,');
       }

--- a/packages/mix_generator/lib/src/core/builders/mix_widget_builder.dart
+++ b/packages/mix_generator/lib/src/core/builders/mix_widget_builder.dart
@@ -71,9 +71,13 @@ class MixWidgetBuilder {
 
     final callArgs = _callArgs();
     if (callArgs.isEmpty) {
-      buffer.writeln('    return $invocation.call();');
+      buffer.writeln(
+        '    return $invocation.call${model.typeParameterInvocation}();',
+      );
     } else {
-      buffer.writeln('    return $invocation.call(');
+      buffer.writeln(
+        '    return $invocation.call${model.typeParameterInvocation}(',
+      );
       for (final arg in callArgs) {
         buffer.writeln('      $arg,');
       }
@@ -115,7 +119,10 @@ class MixWidgetBuilder {
       buffer.writeln(model.doc);
     }
 
-    buffer.writeln('class ${model.widgetName} extends StatelessWidget {');
+    buffer.writeln(
+      'class ${model.widgetName}${model.typeParameterDeclaration} '
+      'extends StatelessWidget {',
+    );
 
     _writeConstructor(buffer);
     buffer.writeln();

--- a/packages/mix_generator/lib/src/core/models/mix_widget_model.dart
+++ b/packages/mix_generator/lib/src/core/models/mix_widget_model.dart
@@ -36,6 +36,21 @@ class WidgetCallParam {
   });
 }
 
+/// One type parameter forwarded from a styler `call<T>()` method.
+class WidgetCallTypeParam {
+  /// The type parameter name.
+  final String name;
+
+  /// Dart source code for the explicit bound, if one exists.
+  final String? boundCode;
+
+  const WidgetCallTypeParam({required this.name, this.boundCode});
+
+  /// Code used in a generated class declaration.
+  String get declarationCode =>
+      boundCode == null ? name : '$name extends $boundCode';
+}
+
 /// The complete shape of a generated `@MixWidget` class.
 class MixWidgetModel {
   /// The generated `StatelessWidget` class name (e.g. `Card`).
@@ -62,6 +77,9 @@ class MixWidgetModel {
   /// positionals first, then named parameters.
   final List<WidgetCallParam> callParams;
 
+  /// Type parameters declared by the styler `call()` method.
+  final List<WidgetCallTypeParam> callTypeParams;
+
   /// `true` when the styler's `call()` declares a `Key? key` named parameter
   /// and the generated `build()` forwards `key: this.key`.
   final bool stylerCallForwardsKey;
@@ -76,6 +94,7 @@ class MixWidgetModel {
     required this.isFunctionFactory,
     required this.factoryParams,
     required this.callParams,
+    this.callTypeParams = const [],
     required this.stylerCallForwardsKey,
     this.doc,
   });
@@ -86,4 +105,18 @@ class MixWidgetModel {
   /// The builder applies Dart constructor syntax ordering when emitting code:
   /// all positional params first, then named params.
   List<WidgetCallParam> get allParams => [...factoryParams, ...callParams];
+
+  /// Type parameter declaration suffix for the generated widget class.
+  String get typeParameterDeclaration {
+    if (callTypeParams.isEmpty) return '';
+
+    return '<${callTypeParams.map((p) => p.declarationCode).join(', ')}>';
+  }
+
+  /// Type argument suffix for forwarding to the styler `call()` method.
+  String get typeParameterInvocation {
+    if (callTypeParams.isEmpty) return '';
+
+    return '<${callTypeParams.map((p) => p.name).join(', ')}>';
+  }
 }

--- a/packages/mix_generator/lib/src/core/models/mix_widget_model.dart
+++ b/packages/mix_generator/lib/src/core/models/mix_widget_model.dart
@@ -99,6 +99,12 @@ class MixWidgetModel {
     this.doc,
   });
 
+  String _typeParameterSuffix(String Function(WidgetCallTypeParam) render) {
+    if (callTypeParams.isEmpty) return '';
+
+    return '<${callTypeParams.map(render).join(', ')}>';
+  }
+
   /// All constructor parameters in source-group order: factory params first,
   /// then styler `call()` params.
   ///
@@ -107,16 +113,9 @@ class MixWidgetModel {
   List<WidgetCallParam> get allParams => [...factoryParams, ...callParams];
 
   /// Type parameter declaration suffix for the generated widget class.
-  String get typeParameterDeclaration {
-    if (callTypeParams.isEmpty) return '';
-
-    return '<${callTypeParams.map((p) => p.declarationCode).join(', ')}>';
-  }
+  String get typeParameterDeclaration =>
+      _typeParameterSuffix((p) => p.declarationCode);
 
   /// Type argument suffix for forwarding to the styler `call()` method.
-  String get typeParameterInvocation {
-    if (callTypeParams.isEmpty) return '';
-
-    return '<${callTypeParams.map((p) => p.name).join(', ')}>';
-  }
+  String get typeParameterInvocation => _typeParameterSuffix((p) => p.name);
 }

--- a/packages/mix_generator/lib/src/mix_widget_generator.dart
+++ b/packages/mix_generator/lib/src/mix_widget_generator.dart
@@ -137,6 +137,7 @@ class MixWidgetGenerator extends GeneratorForAnnotation<MixWidget> {
       isFunctionFactory: false,
       factoryParams: const [],
       callParams: call.params,
+      callTypeParams: _extractCallTypeParams(callMethod, library: library),
       stylerCallForwardsKey: call.forwardsKey,
       doc: variable.documentationComment,
     );
@@ -194,6 +195,7 @@ class MixWidgetGenerator extends GeneratorForAnnotation<MixWidget> {
       isFunctionFactory: true,
       factoryParams: factoryParams,
       callParams: call.params,
+      callTypeParams: _extractCallTypeParams(callMethod, library: library),
       stylerCallForwardsKey: call.forwardsKey,
       doc: function.documentationComment,
     );
@@ -227,8 +229,8 @@ class MixWidgetGenerator extends GeneratorForAnnotation<MixWidget> {
   }
 
   /// Looks up the styler's `call()` method (including inherited members) and
-  /// validates the contract: non-generic, returns a `Widget`, no optional
-  /// positional parameters.
+  /// validates the contract: returns a `Widget`, no optional positional
+  /// parameters.
   MethodElement _requireCallMethod(
     Element anchor,
     InterfaceType stylerType, {
@@ -247,14 +249,6 @@ class MixWidgetGenerator extends GeneratorForAnnotation<MixWidget> {
         todo:
             'Add a `Widget call({...}) { return ...; }` to $stylerName so '
             'the generated widget knows how to render.',
-      );
-    }
-
-    if (call.typeParameters.isNotEmpty) {
-      fail(
-        anchor,
-        '$_annotationLabel requires a non-generic `call()` on $stylerName.',
-        todo: 'Remove type parameters from the `call()` method.',
       );
     }
 
@@ -277,6 +271,46 @@ class MixWidgetGenerator extends GeneratorForAnnotation<MixWidget> {
     }
 
     return call;
+  }
+
+  List<WidgetCallTypeParam> _extractCallTypeParams(
+    MethodElement callMethod, {
+    required LibraryElement library,
+  }) {
+    return [
+      for (final typeParameter in callMethod.typeParameters)
+        _callTypeParam(typeParameter, library: library),
+    ];
+  }
+
+  WidgetCallTypeParam _callTypeParam(
+    TypeParameterElement typeParameter, {
+    required LibraryElement library,
+  }) {
+    final name = requireName(
+      typeParameter,
+      orFailWith: '$_annotationLabel call type parameter must have a name.',
+    );
+    final bound = typeParameter.bound;
+
+    if (bound == null) {
+      return WidgetCallTypeParam(name: name);
+    }
+
+    final hiddenType = firstInvisibleTypeName(bound, library);
+    if (hiddenType != null) {
+      fail(
+        typeParameter,
+        'Call type parameter `$name` has bound `$hiddenType`, but that type '
+        'is not visible from the annotated library.',
+        todo: 'Import or re-export `$hiddenType` where the annotation lives.',
+      );
+    }
+
+    return WidgetCallTypeParam(
+      name: name,
+      boundCode: typeCode(bound, visibleFrom: library),
+    );
   }
 
   List<WidgetCallParam> _extractFactoryParams(

--- a/packages/mix_generator/lib/src/mix_widget_generator.dart
+++ b/packages/mix_generator/lib/src/mix_widget_generator.dart
@@ -229,8 +229,8 @@ class MixWidgetGenerator extends GeneratorForAnnotation<MixWidget> {
   }
 
   /// Looks up the styler's `call()` method (including inherited members) and
-  /// validates the contract: returns a `Widget`, no optional positional
-  /// parameters.
+  /// validates the contract: returns a `Widget`-assignable type, no optional
+  /// positional parameters.
   MethodElement _requireCallMethod(
     Element anchor,
     InterfaceType stylerType, {
@@ -252,7 +252,7 @@ class MixWidgetGenerator extends GeneratorForAnnotation<MixWidget> {
       );
     }
 
-    if (!widgetChecker.isAssignableFromType(call.returnType)) {
+    if (_widgetAssignableReturnType(call.returnType) == null) {
       fail(
         anchor,
         '$_annotationLabel requires $stylerName.call() to return a Widget '
@@ -271,6 +271,20 @@ class MixWidgetGenerator extends GeneratorForAnnotation<MixWidget> {
     }
 
     return call;
+  }
+
+  /// A generic `call<T extends Widget>()` reports its return as `T`; validate
+  /// that shape against the bound so generated `build()` still returns Widget.
+  DartType? _widgetAssignableReturnType(DartType returnType) {
+    if (returnType is TypeParameterType) {
+      return _widgetAssignableReturnType(returnType.bound);
+    }
+
+    if (widgetChecker.isAssignableFromType(returnType)) {
+      return returnType;
+    }
+
+    return null;
   }
 
   List<WidgetCallTypeParam> _extractCallTypeParams(
@@ -388,7 +402,7 @@ class MixWidgetGenerator extends GeneratorForAnnotation<MixWidget> {
     MethodElement callMethod,
     LibraryElement hostLibrary,
   ) {
-    final returnType = callMethod.returnType;
+    final returnType = _widgetAssignableReturnType(callMethod.returnType);
     if (returnType is! InterfaceType) return;
 
     final widgetType = findSupertypeMatching(returnType, widgetChecker);

--- a/packages/mix_generator/pubspec.yaml
+++ b/packages/mix_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mix_generator
 description: A code generator for Mix, an expressive way to effortlessly build design systems in Flutter.
-version: 2.1.1
+version: 2.1.2
 homepage: https://github.com/btwld/mix
 repository: https://github.com/btwld/mix/tree/main/packages/mix_generator
 

--- a/packages/mix_generator/test/core/builders/mix_widget_builder_test.dart
+++ b/packages/mix_generator/test/core/builders/mix_widget_builder_test.dart
@@ -176,6 +176,64 @@ void main() {
       expect(code, isNot(contains('key: this.key')));
     });
 
+    test('generic styler call emits generic widget and forwards type args', () {
+      final builder = MixWidgetBuilder(
+        const MixWidgetModel(
+          widgetName: 'FortalRadio',
+          factoryReference: 'fortalRadioStyle',
+          isFunctionFactory: true,
+          factoryParams: [],
+          callParams: [
+            WidgetCallParam(
+              name: 'value',
+              typeCode: 'T',
+              isPositional: false,
+              isRequired: true,
+            ),
+          ],
+          callTypeParams: [WidgetCallTypeParam(name: 'T')],
+          stylerCallForwardsKey: true,
+        ),
+      );
+
+      final code = builder.build();
+
+      expect(code, contains('class FortalRadio<T> extends StatelessWidget'));
+      expect(code, contains('required this.value'));
+      expect(code, contains('final T value;'));
+      expect(code, contains('return fortalRadioStyle().call<T>('));
+      expect(code, contains('value: this.value,'));
+    });
+
+    test('generic styler call preserves bounds', () {
+      final builder = MixWidgetBuilder(
+        const MixWidgetModel(
+          widgetName: 'BoundedRadio',
+          factoryReference: 'boundedRadioStyle',
+          isFunctionFactory: false,
+          factoryParams: [],
+          callParams: [
+            WidgetCallParam(
+              name: 'value',
+              typeCode: 'T',
+              isPositional: false,
+              isRequired: true,
+            ),
+          ],
+          callTypeParams: [WidgetCallTypeParam(name: 'T', boundCode: 'Enum')],
+          stylerCallForwardsKey: false,
+        ),
+      );
+
+      final code = builder.build();
+
+      expect(
+        code,
+        contains('class BoundedRadio<T extends Enum> extends StatelessWidget'),
+      );
+      expect(code, contains('return boundedRadioStyle.call<T>('));
+    });
+
     test('doc comment carries over to the generated class', () {
       final builder = MixWidgetBuilder(
         const MixWidgetModel(

--- a/packages/mix_generator/test/integration/generator_smoke_test.dart
+++ b/packages/mix_generator/test/integration/generator_smoke_test.dart
@@ -985,6 +985,48 @@ RadioStyler fortalRadioStyle({Variant variant = Variant.surface}) =>
       },
     );
 
+    test('generic styler call can return its widget type parameter', () async {
+      const source = r'''
+library widget_case;
+
+import 'package:flutter/widgets.dart';
+import 'package:mix_annotations/mix_annotations.dart';
+import 'package:mix/src/core/style.dart';
+
+part 'widget_case.g.dart';
+
+class BoxSpec { const BoxSpec(); }
+
+class TypedStyler extends Style<BoxSpec> {
+  const TypedStyler();
+
+  T call<T extends Widget>({Key? key, required T child}) => child;
+}
+
+@MixWidget(name: 'TypedHost')
+final typedStyle = const TypedStyler();
+''';
+
+      await expectGeneratorOutputResolves(
+        builder: partBuilder(const MixWidgetGenerator()),
+        sources: {
+          ...mixAnnotationsSources,
+          ...widgetStub,
+          'mix|lib/src/core/style.dart': styleStub,
+          'mix_generator|lib/widget_case.dart': source,
+        },
+        inputAsset: 'mix_generator|lib/widget_case.dart',
+        outputAsset: 'mix_generator|lib/widget_case.g.dart',
+        outputMatcher: allOf([
+          contains('class TypedHost<T extends Widget> extends StatelessWidget'),
+          contains('required this.child'),
+          contains('final T child;'),
+          contains('return typedStyle.call<T>('),
+          contains('child: this.child'),
+        ]),
+      );
+    });
+
     test('positional call param surfaces as a positional widget arg', () async {
       const source = r'''
 library widget_case;

--- a/packages/mix_generator/test/integration/generator_smoke_test.dart
+++ b/packages/mix_generator/test/integration/generator_smoke_test.dart
@@ -917,6 +917,74 @@ final inheritedStyle = const StringStyler();
       );
     });
 
+    test(
+      'generic styler call emits generic widget and forwards call type',
+      () async {
+        const source = r'''
+library widget_case;
+
+import 'package:flutter/widgets.dart';
+import 'package:mix_annotations/mix_annotations.dart';
+import 'package:mix/src/core/style.dart';
+
+part 'widget_case.g.dart';
+
+class BoxSpec { const BoxSpec(); }
+
+class RadioValue {}
+
+enum Variant { surface }
+
+class RadioStyler extends Style<BoxSpec> {
+  const RadioStyler();
+
+  Widget call<T extends RadioValue>({
+    Key? key,
+    required T value,
+    required List<T> values,
+  }) => const _Stub();
+}
+
+class _Stub extends StatelessWidget {
+  const _Stub();
+  @override
+  Widget build(BuildContext context) => const _Stub();
+}
+
+@MixWidget(name: 'FortalRadio')
+RadioStyler fortalRadioStyle({Variant variant = Variant.surface}) =>
+    const RadioStyler();
+''';
+
+        await expectGeneratorOutputResolves(
+          builder: partBuilder(const MixWidgetGenerator()),
+          sources: {
+            ...mixAnnotationsSources,
+            ...widgetStub,
+            'mix|lib/src/core/style.dart': styleStub,
+            'mix_generator|lib/widget_case.dart': source,
+          },
+          inputAsset: 'mix_generator|lib/widget_case.dart',
+          outputAsset: 'mix_generator|lib/widget_case.g.dart',
+          outputMatcher: allOf([
+            contains(
+              'class FortalRadio<T extends RadioValue> extends StatelessWidget',
+            ),
+            contains('this.variant = Variant.surface'),
+            contains('required this.value'),
+            contains('required this.values'),
+            contains('final T value;'),
+            contains('final List<T> values;'),
+            contains('return fortalRadioStyle('),
+            contains('variant: this.variant'),
+            contains('.call<T>('),
+            contains('value: this.value'),
+            contains('values: this.values'),
+          ]),
+        );
+      },
+    );
+
     test('positional call param surfaces as a positional widget arg', () async {
       const source = r'''
 library widget_case;

--- a/packages/mix_generator/test/integration/generator_validation_test.dart
+++ b/packages/mix_generator/test/integration/generator_validation_test.dart
@@ -223,6 +223,33 @@ final brokenStyle = const BadStyler();
     );
 
     test(
+      'MixWidgetGenerator rejects generic call returns with non-widget bounds',
+      () async {
+        const libSource = r'''
+library widget_validation;
+
+import 'package:mix_annotations/mix_annotations.dart';
+import 'package:mix/src/core/style.dart';
+
+class BoxSpec { const BoxSpec(); }
+
+class BadStyler extends Style<BoxSpec> {
+  const BadStyler();
+  T call<T extends Object>({required T value}) => value;
+}
+
+@MixWidget()
+final brokenStyle = const BadStyler();
+''';
+
+        final errors = await _expectMixWidgetValidationError(libSource);
+
+        expect(errors, contains('return a Widget subtype'));
+        expect(errors, contains('returns `T`'));
+      },
+    );
+
+    test(
       'MixWidgetGenerator rejects optional positional factory params',
       () async {
         const libSource = r'''
@@ -708,6 +735,33 @@ final cardStyle = const BoxStyler();
 
       expect(errors, contains('visible unprefixed'));
     });
+
+    test(
+      'MixWidgetGenerator rejects prefixed Flutter imports for generic returns',
+      () async {
+        const libSource = r'''
+library widget_validation;
+
+import 'package:flutter/widgets.dart' as fw;
+import 'package:mix_annotations/mix_annotations.dart';
+import 'package:mix/src/core/style.dart';
+
+class BoxSpec { const BoxSpec(); }
+
+class BoxStyler extends Style<BoxSpec> {
+  const BoxStyler();
+  T call<T extends fw.Widget>({fw.Key? key, required T child}) => child;
+}
+
+@MixWidget()
+final cardStyle = const BoxStyler();
+''';
+
+        final errors = await _expectMixWidgetValidationError(libSource);
+
+        expect(errors, contains('visible unprefixed'));
+      },
+    );
 
     test('MixWidgetGenerator rejects invalid name overrides', () async {
       const cases = {

--- a/packages/mix_generator/test/integration/generator_validation_test.dart
+++ b/packages/mix_generator/test/integration/generator_validation_test.dart
@@ -249,6 +249,64 @@ final brokenStyle = const BadStyler();
       },
     );
 
+    test('MixWidgetGenerator rejects a call type parameter bound that is not '
+        'visible from the annotated library', () async {
+      const libSource = r'''
+library widget_validation;
+
+import 'package:flutter/widgets.dart';
+import 'package:mix_annotations/mix_annotations.dart';
+import 'radio_styler.dart';
+
+@MixWidget()
+final radioStyle = const RadioStyler();
+''';
+
+      final errors = await _expectMixWidgetValidationError(
+        libSource,
+        extraSources: {
+          // `RadioValue` is only reachable through `radio_styler.dart`'s own
+          // import, not re-exported — so it stays invisible from
+          // `widget_validation.dart`, which imports `radio_styler.dart` but
+          // never `hidden_bound.dart` directly.
+          'mix_generator|lib/hidden_bound.dart': r'''
+library hidden_bound;
+
+class RadioValue {}
+''',
+          'mix_generator|lib/radio_styler.dart': r'''
+library radio_styler;
+
+import 'package:flutter/widgets.dart';
+import 'package:mix/src/core/style.dart';
+
+import 'hidden_bound.dart';
+
+class BoxSpec { const BoxSpec(); }
+
+class RadioStyler extends Style<BoxSpec> {
+  const RadioStyler();
+
+  Widget call<T extends RadioValue>({Key? key, required T value}) =>
+      const _Stub();
+}
+
+class _Stub extends StatelessWidget {
+  const _Stub();
+  @override
+  Widget build(BuildContext context) => const _Stub();
+}
+''',
+        },
+      );
+
+      expect(
+        errors,
+        contains('Call type parameter `T` has bound `RadioValue`'),
+      );
+      expect(errors, contains('not visible from the annotated library'));
+    });
+
     test(
       'MixWidgetGenerator rejects optional positional factory params',
       () async {


### PR DESCRIPTION
## Summary
- allow `@MixWidget` to generate widgets from generic styler `call<T>()` methods
- preserve call type parameter bounds on the generated widget class
- forward generic type arguments when invoking the styler call method

## Why
Remix needs generated Fortal widgets for generic radio and accordion APIs, e.g. `FortalRadio<T>` and `FortalAccordion<T>`. The published generator rejects generic `call()` methods today, which blocks reproducible code generation and pushes consumers toward hand-written widget drift.

Fixes #957.

## Validation
- `fvm dart pub get`
- `fvm dart test` from `packages/mix_generator` passes, 277 tests
