### PR TITLE
refactor(mix_generator): simplify generator internals

### DIFF
--- a/packages/mix_generator/README.md
+++ b/packages/mix_generator/README.md
@@ -34,10 +34,11 @@ The generator emits several surfaces with deliberately different shapes, chosen 
 - **`@MixableSpec(target: Widget.new)`** also emits a full generated Styler class into the same `.g.dart` part file as the spec mixin. The generated class owns fields, constructors, factories, fluent methods, `call()`, merge, resolve, diagnostics, and props.
 - **`@MixableStyler`** emits a legacy *slim* mixin (`mixin _$<Name>Mixin on Style<S>, Diagnosticable`) that fills in per-field plumbing for handwritten styler classes.
 - **`@Mixable`** emits a *slim* mixin (`mixin _$<Name>Mixin on Mix<T>[, DefaultValue<T>][, Diagnosticable]`) for the same reason — Mix subclasses commonly compose intermediate base classes (e.g., `class BoxConstraintsMix extends ConstraintsMix<BoxConstraints>`) and the user keeps that inheritance chain.
+- **`@MixableModifier`** emits a self-contained modifier mixin (`mixin _$<Name> implements WidgetModifier<T>, Diagnosticable`) plus its corresponding `<Name>Mix` class.
 
 If the asymmetry feels surprising, the rule is: rich/full shape for pure-data specs and their generated stylers; slim shape for types whose `extends` chain carries shared state or behavior.
 
-A fourth annotation, **`@MixWidget`**, generates a full `StatelessWidget` class (not a mixin) that wraps a top-level `Style<S>` factory — see the [`@MixWidget`](#from-mixwidget--widget-wrapper) section below.
+The **`@MixWidget`** annotation generates a full `StatelessWidget` class (not a mixin) that wraps a top-level `Style<S>` factory — see the [`@MixWidget`](#from-mixwidget--widget-wrapper) section below.
 
 ### From `@MixableSpec` — Spec mixin
 
@@ -130,6 +131,33 @@ final class BoxConstraintsMix extends ConstraintsMix<BoxConstraints>
   // ...
 }
 ```
+
+### From `@MixableModifier` — modifier mixin and ModifierMix
+
+Generates a self-contained `_$<Name>` mixin for an immutable
+`WidgetModifier`, plus a `<Name>Mix` class that can be used in styles. The mixin
+provides `type`, `copyWith`, optional `lerp`, value equality, diagnostics, and
+the `build` contract. The Mix class provides constructors, `resolve`, `merge`,
+diagnostics, and `props`.
+
+```dart
+part 'opacity_modifier.g.dart';
+
+@MixableModifier()
+final class OpacityModifier with _$OpacityModifier {
+  @override
+  final double opacity;
+
+  const OpacityModifier([double? opacity]) : opacity = opacity ?? 1.0;
+
+  @override
+  Widget build(Widget child) => Opacity(opacity: opacity, child: child);
+}
+```
+
+Pass `lerp: false` when the modifier implements custom interpolation. A field
+may use `@MixableField(setterType: SomeMix)` when its style-facing value should
+be a Mix type; the setter type must resolve to the field's runtime value type.
 
 ### From `@MixWidget` — widget wrapper
 

--- a/packages/mix_generator/lib/mix_generator.dart
+++ b/packages/mix_generator/lib/mix_generator.dart
@@ -9,6 +9,8 @@
 ///   `variants`, `wrap`, `modifier`), `merge`, `resolve`,
 ///   `debugFillProperties`, `props`.
 /// - Mix mixin `_$XMixin`: `merge`, `resolve`, `props`.
+/// - Modifier mixin `_$XModifier` and `XModifierMix`: immutable modifier
+///   contract plus style-facing resolve/merge plumbing.
 /// - Widget wrapper `class X extends StatelessWidget` for a `Style<S>`
 ///   factory annotated with `@MixWidget`.
 library;
@@ -39,30 +41,31 @@ export 'src/modifier_generator.dart';
 export 'src/spec_styler_generator.dart';
 export 'src/styler_generator.dart';
 
-/// Builder factory for `mix_generator`.
-///
-/// Generates `_$XSpec` mixins for `@MixableSpec` classes, including `type`,
-/// `copyWith`, `lerp`, `props`, and `debugFillProperties` overrides.
-Builder mixGenerator(BuilderOptions _) {
+Builder _sharedPartBuilder(Generator generator, String partId) {
   return SharedPartBuilder(
-    [SpecGenerator()],
-    'mix_generator',
+    [generator],
+    partId,
     formatOutput: (code, version) {
       return DartFormatter(languageVersion: version).format(code);
     },
   );
 }
 
+/// Builder factory for `mix_generator`.
+///
+/// Generates `_$XSpec` mixins for `@MixableSpec` classes, including `type`,
+/// `copyWith`, `lerp`, `props`, and `debugFillProperties` overrides.
+Builder mixGenerator(BuilderOptions _) {
+  return _sharedPartBuilder(const SpecGenerator(), 'mix_generator');
+}
+
 /// Builder factory for `spec_styler_generator`.
 ///
 /// Generates full Styler classes from `@MixableSpec` classes.
 Builder specStylerGenerator(BuilderOptions _) {
-  return SharedPartBuilder(
-    [const SpecStylerGenerator()],
+  return _sharedPartBuilder(
+    const SpecStylerGenerator(),
     'spec_styler_generator',
-    formatOutput: (code, version) {
-      return DartFormatter(languageVersion: version).format(code);
-    },
   );
 }
 
@@ -71,51 +74,27 @@ Builder specStylerGenerator(BuilderOptions _) {
 /// Generates legacy `_$XStylerMixin` implementations for handwritten
 /// `@MixableStyler` classes.
 Builder stylerGenerator(BuilderOptions _) {
-  return SharedPartBuilder(
-    [StylerGenerator()],
-    'styler_generator',
-    formatOutput: (code, version) {
-      return DartFormatter(languageVersion: version).format(code);
-    },
-  );
+  return _sharedPartBuilder(const StylerGenerator(), 'styler_generator');
 }
 
 /// Builder factory for `mixable_generator`.
 ///
 /// Generates `_$XMixin` implementations for `@Mixable` classes.
 Builder mixableGenerator(BuilderOptions _) {
-  return SharedPartBuilder(
-    [MixableGenerator()],
-    'mixable_generator',
-    formatOutput: (code, version) {
-      return DartFormatter(languageVersion: version).format(code);
-    },
-  );
+  return _sharedPartBuilder(const MixableGenerator(), 'mixable_generator');
 }
 
 /// Builder factory for `mix_widget_generator`.
 ///
 /// Generates `StatelessWidget` wrappers for `@MixWidget` top-level factories.
 Builder mixWidgetGenerator(BuilderOptions _) {
-  return SharedPartBuilder(
-    [MixWidgetGenerator()],
-    'mix_widget_generator',
-    formatOutput: (code, version) {
-      return DartFormatter(languageVersion: version).format(code);
-    },
-  );
+  return _sharedPartBuilder(const MixWidgetGenerator(), 'mix_widget_generator');
 }
 
 /// Builder factory for `modifier_generator`.
 ///
-/// Generates `_$XModifierMethods` mixins and `XModifierMix` classes for
+/// Generates `_$XModifier` mixins and `XModifierMix` classes for
 /// `@MixableModifier` `WidgetModifier` subclasses.
 Builder modifierGenerator(BuilderOptions _) {
-  return SharedPartBuilder(
-    [ModifierGenerator()],
-    'modifier_generator',
-    formatOutput: (code, version) {
-      return DartFormatter(languageVersion: version).format(code);
-    },
-  );
+  return _sharedPartBuilder(const ModifierGenerator(), 'modifier_generator');
 }

--- a/packages/mix_generator/lib/src/core/builders/modifier_mixin_builder.dart
+++ b/packages/mix_generator/lib/src/core/builders/modifier_mixin_builder.dart
@@ -6,6 +6,7 @@ library;
 
 import 'modifier_mix_builder.dart';
 import '../helpers/field_emitter.dart';
+import '../helpers/generated_contract_emitter.dart';
 import '../resolvers/diagnostic_resolver.dart';
 import '../resolvers/lerp_resolver.dart';
 
@@ -119,76 +120,7 @@ class ModifierMixinBuilder {
   }
 
   String _buildProps() {
-    final buffer = StringBuffer();
-
-    buffer.writeln('  @override');
-    buffer.write('  List<Object?> get props => [');
-
-    if (fields.isEmpty) {
-      buffer.writeln('];');
-    } else {
-      final fieldNames = fields.map((f) => f.name).join(', ');
-      buffer.writeln('$fieldNames];');
-    }
-
-    return buffer.toString();
-  }
-
-  /// Emits `==`, `hashCode`, `stringify`, and `getDiff` overrides that
-  /// delegate to the shared Equatable helpers.
-  String _buildEquatableSurface() {
-    final buffer = StringBuffer();
-
-    buffer.writeln('  @override');
-    buffer.writeln('  bool operator ==(Object other) {');
-    buffer.writeln('    return identical(this, other) ||');
-    buffer.writeln('        other is $modifierName &&');
-    buffer.writeln('            runtimeType == other.runtimeType &&');
-    buffer.writeln('            propsEquals(props, other.props);');
-    buffer.writeln('  }');
-    buffer.writeln();
-    buffer.writeln('  @override');
-    buffer.writeln('  int get hashCode => propsHash(runtimeType, props);');
-    buffer.writeln();
-    buffer.writeln('  @override');
-    buffer.writeln('  bool get stringify => true;');
-    buffer.writeln();
-    buffer.writeln('  @override');
-    buffer.writeln('  Map<String, String> getDiff(Equatable other) {');
-    buffer.writeln('    if (this == other) return const {};');
-    buffer.writeln();
-    buffer.writeln('    return propsDiff(props, other.props);');
-    buffer.writeln('  }');
-
-    return buffer.toString();
-  }
-
-  /// Emits Diagnosticable's concrete bodies because the mixin implements
-  /// Diagnosticable rather than inheriting from it.
-  String _buildDiagnosticableSurface() {
-    final buffer = StringBuffer();
-
-    buffer.writeln('  @override');
-    buffer.writeln("  String toStringShort() => '\$runtimeType';");
-    buffer.writeln();
-    buffer.writeln('  @override');
-    buffer.writeln(
-      '  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) =>',
-    );
-    buffer.writeln(
-      '      toDiagnosticsNode(style: DiagnosticsTreeStyle.singleLine)',
-    );
-    buffer.writeln('          .toString(minLevel: minLevel);');
-    buffer.writeln();
-    buffer.writeln('  @override');
-    buffer.writeln(
-      '  DiagnosticsNode toDiagnosticsNode({String? name, DiagnosticsTreeStyle? style}) =>',
-    );
-    buffer.writeln(
-      '      DiagnosticableNode<Diagnosticable>(name: name, value: this, style: style);',
-    );
-
-    return buffer.toString();
+    return _fieldEmitter().inlineProps(propCode: (field) => field.name);
   }
 
   /// The mixin name (e.g., AlignModifier -> _$AlignModifier).
@@ -216,8 +148,8 @@ class ModifierMixinBuilder {
 
     // props
     buffer.writeln(_buildProps());
-    buffer.writeln(_buildEquatableSurface());
-    buffer.writeln(_buildDiagnosticableSurface());
+    buffer.writeln(buildEquatableSurface(modifierName));
+    buffer.writeln(buildDiagnosticableSurface());
     buffer.writeln(_buildBuildContract());
 
     // debugFillProperties

--- a/packages/mix_generator/lib/src/core/builders/spec_mixin_builder.dart
+++ b/packages/mix_generator/lib/src/core/builders/spec_mixin_builder.dart
@@ -1,6 +1,7 @@
 import '../models/annotation_config.dart';
 import '../models/field_model.dart';
 import '../helpers/field_emitter.dart';
+import '../helpers/generated_contract_emitter.dart';
 import '../resolvers/diagnostic_resolver.dart';
 import '../resolvers/lerp_resolver.dart';
 
@@ -81,83 +82,14 @@ class SpecMixinBuilder {
   }
 
   String _buildProps() {
-    final buffer = StringBuffer();
-
     // `@override`: `Equatable` (mixed into `Spec<T>`) declares `props` abstractly.
-    buffer.writeln('  @override');
-    buffer.write('  List<Object?> get props => [');
-
-    if (fields.isEmpty) {
-      buffer.writeln('];');
-    } else {
-      final fieldNames = fields.map((f) => f.name).join(', ');
-      buffer.writeln('$fieldNames];');
-    }
-
-    return buffer.toString();
+    return _fieldEmitter().inlineProps(propCode: (field) => field.name);
   }
 
   String _buildTypeGetter() {
     final buffer = StringBuffer();
     buffer.writeln('  @override');
     buffer.writeln('  Type get type => $specName;');
-
-    return buffer.toString();
-  }
-
-  /// Emits `==`, `hashCode`, `stringify`, and `getDiff` overrides that
-  /// delegate to `propsEquals`, `propsHash`, and `propsDiff`.
-  String _buildEquatableSurface() {
-    final buffer = StringBuffer();
-
-    buffer.writeln('  @override');
-    buffer.writeln('  bool operator ==(Object other) {');
-    buffer.writeln('    return identical(this, other) ||');
-    buffer.writeln('        other is $specName &&');
-    buffer.writeln('            runtimeType == other.runtimeType &&');
-    buffer.writeln('            propsEquals(props, other.props);');
-    buffer.writeln('  }');
-    buffer.writeln();
-    buffer.writeln('  @override');
-    buffer.writeln('  int get hashCode => propsHash(runtimeType, props);');
-    buffer.writeln();
-    buffer.writeln('  @override');
-    buffer.writeln('  bool get stringify => true;');
-    buffer.writeln();
-    buffer.writeln('  @override');
-    buffer.writeln('  Map<String, String> getDiff(Equatable other) {');
-    buffer.writeln('    if (this == other) return const {};');
-    buffer.writeln();
-    buffer.writeln('    return propsDiff(props, other.props);');
-    buffer.writeln('  }');
-
-    return buffer.toString();
-  }
-
-  /// Emits Diagnosticable's concrete bodies — the mixin `implements`
-  /// Diagnosticable rather than extending it, so no inheritance covers them.
-  String _buildDiagnosticableSurface() {
-    final buffer = StringBuffer();
-
-    buffer.writeln('  @override');
-    buffer.writeln("  String toStringShort() => '\$runtimeType';");
-    buffer.writeln();
-    buffer.writeln('  @override');
-    buffer.writeln(
-      '  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) =>',
-    );
-    buffer.writeln(
-      '      toDiagnosticsNode(style: DiagnosticsTreeStyle.singleLine)',
-    );
-    buffer.writeln('          .toString(minLevel: minLevel);');
-    buffer.writeln();
-    buffer.writeln('  @override');
-    buffer.writeln(
-      '  DiagnosticsNode toDiagnosticsNode({String? name, DiagnosticsTreeStyle? style}) =>',
-    );
-    buffer.writeln(
-      '      DiagnosticableNode<Diagnosticable>(name: name, value: this, style: style);',
-    );
 
     return buffer.toString();
   }
@@ -219,9 +151,9 @@ class SpecMixinBuilder {
     if (config.generateProps) {
       buffer.writeln(_buildProps());
     }
-    buffer.writeln(_buildEquatableSurface());
+    buffer.writeln(buildEquatableSurface(specName));
 
-    buffer.writeln(_buildDiagnosticableSurface());
+    buffer.writeln(buildDiagnosticableSurface());
     buffer.writeln(_buildDebugFillProperties());
 
     buffer.writeln('}');

--- a/packages/mix_generator/lib/src/core/builders/spec_styler_class_builder.dart
+++ b/packages/mix_generator/lib/src/core/builders/spec_styler_class_builder.dart
@@ -590,41 +590,13 @@ class SpecStylerClassBuilder {
   }
 
   String? _buildCallMethod() {
-    final reader = annotation.peek('target');
-    if (reader == null || reader.isNull) return null;
-
-    final fn = reader.objectValue.toFunctionValue();
-    if (fn is! ConstructorElement) {
-      fail(
-        specElement,
-        '@MixableSpec(target:) must be a constructor tear-off '
-        '(e.g., Box.new).',
-      );
-    }
-
-    final widgetName = mixableSpecTargetWidgetName(fn);
-    validateMixableSpecTargetConstructor(
-      constructor: fn,
-      widgetName: widgetName,
+    return buildMixableSpecTargetCall(
+      annotation: annotation,
       specElement: specElement,
       specName: specName,
-      anchor: specElement,
-    );
-
-    final result = extractCallParams(
-      fn,
-      anchor: specElement,
-      library: specElement.library,
-      factoryReference: stylerName,
-      excludeNames: const {'style', 'styleSpec'},
-      annotationLabel: '@MixableSpec(target:)',
-      keyOwner: 'the target constructor',
-    );
-
-    return renderWidgetCall(
-      widgetName: widgetName,
-      params: result.params,
-      forwardsKey: result.forwardsKey,
+      stylerName: stylerName,
+      hostElement: specElement,
+      hostLibrary: specElement.library,
     );
   }
 

--- a/packages/mix_generator/lib/src/core/helpers/field_emitter.dart
+++ b/packages/mix_generator/lib/src/core/helpers/field_emitter.dart
@@ -84,4 +84,11 @@ class FieldEmitter<T> {
 
     return buffer.toString();
   }
+
+  /// Emits a compact `props` getter containing [fields].
+  String inlineProps({required String Function(T field) propCode}) {
+    final values = fields.map(propCode).join(', ');
+
+    return '  @override\n  List<Object?> get props => [$values];\n';
+  }
 }

--- a/packages/mix_generator/lib/src/core/helpers/generated_contract_emitter.dart
+++ b/packages/mix_generator/lib/src/core/helpers/generated_contract_emitter.dart
@@ -1,0 +1,57 @@
+/// Shared emitters for generated value and diagnostic contracts.
+library;
+
+/// Emits the Equatable-compatible value surface for [concreteType].
+String buildEquatableSurface(String concreteType) {
+  final buffer = StringBuffer();
+
+  buffer.writeln('  @override');
+  buffer.writeln('  bool operator ==(Object other) {');
+  buffer.writeln('    return identical(this, other) ||');
+  buffer.writeln('        other is $concreteType &&');
+  buffer.writeln('            runtimeType == other.runtimeType &&');
+  buffer.writeln('            propsEquals(props, other.props);');
+  buffer.writeln('  }');
+  buffer.writeln();
+  buffer.writeln('  @override');
+  buffer.writeln('  int get hashCode => propsHash(runtimeType, props);');
+  buffer.writeln();
+  buffer.writeln('  @override');
+  buffer.writeln('  bool get stringify => true;');
+  buffer.writeln();
+  buffer.writeln('  @override');
+  buffer.writeln('  Map<String, String> getDiff(Equatable other) {');
+  buffer.writeln('    if (this == other) return const {};');
+  buffer.writeln();
+  buffer.writeln('    return propsDiff(props, other.props);');
+  buffer.writeln('  }');
+
+  return buffer.toString();
+}
+
+/// Emits Diagnosticable's concrete surface for generated implementing mixins.
+String buildDiagnosticableSurface() {
+  final buffer = StringBuffer();
+
+  buffer.writeln('  @override');
+  buffer.writeln("  String toStringShort() => '\$runtimeType';");
+  buffer.writeln();
+  buffer.writeln('  @override');
+  buffer.writeln(
+    '  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) =>',
+  );
+  buffer.writeln(
+    '      toDiagnosticsNode(style: DiagnosticsTreeStyle.singleLine)',
+  );
+  buffer.writeln('          .toString(minLevel: minLevel);');
+  buffer.writeln();
+  buffer.writeln('  @override');
+  buffer.writeln(
+    '  DiagnosticsNode toDiagnosticsNode({String? name, DiagnosticsTreeStyle? style}) =>',
+  );
+  buffer.writeln(
+    '      DiagnosticableNode<Diagnosticable>(name: name, value: this, style: style);',
+  );
+
+  return buffer.toString();
+}

--- a/packages/mix_generator/lib/src/core/helpers/widget_call_planner.dart
+++ b/packages/mix_generator/lib/src/core/helpers/widget_call_planner.dart
@@ -3,6 +3,7 @@ library;
 
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
+import 'package:source_gen/source_gen.dart';
 
 import '../checkers.dart';
 import '../errors.dart';
@@ -18,6 +19,79 @@ const reservedParamNames = {
   'toString',
   'noSuchMethod',
 };
+
+/// Builds the widget-facing `call()` method configured by
+/// `@MixableSpec(target:)`.
+///
+/// [hostElement] and [hostLibrary] identify where the generated method is
+/// emitted. Legacy handwritten stylers can live in a different library from
+/// the spec, so [validateTargetVisibility] preserves their stricter visibility
+/// check without changing the generated-spec path.
+String? buildMixableSpecTargetCall({
+  required ConstantReader annotation,
+  required InterfaceElement specElement,
+  required String specName,
+  required String stylerName,
+  required Element hostElement,
+  required LibraryElement hostLibrary,
+  bool validateTargetVisibility = false,
+  String indent = '',
+}) {
+  final target = annotation.peek('target');
+  if (target == null || target.isNull) return null;
+
+  final constructor = target.objectValue.toFunctionValue();
+  if (constructor is! ConstructorElement) {
+    fail(
+      specElement,
+      '@MixableSpec(target:) must be a constructor tear-off '
+      '(e.g., Box.new).',
+    );
+  }
+
+  final widgetName = mixableSpecTargetWidgetName(constructor);
+  if (validateTargetVisibility) {
+    final widgetElement = constructor.enclosingElement;
+    final hiddenWidgetType = firstInvisibleTypeName(
+      widgetElement.thisType,
+      hostLibrary,
+    );
+    if (hiddenWidgetType != null) {
+      fail(
+        hostElement,
+        'Target widget `$hiddenWidgetType` is used by @MixableSpec(target:) '
+        'but is not visible from the @MixableStyler library.',
+        todo:
+            'Import or re-export `$hiddenWidgetType` where the styler is declared.',
+      );
+    }
+  }
+
+  validateMixableSpecTargetConstructor(
+    constructor: constructor,
+    widgetName: widgetName,
+    specElement: specElement,
+    specName: specName,
+    anchor: specElement,
+  );
+
+  final call = extractCallParams(
+    constructor,
+    anchor: hostElement,
+    library: hostLibrary,
+    factoryReference: stylerName,
+    excludeNames: const {'style', 'styleSpec'},
+    annotationLabel: '@MixableSpec(target:)',
+    keyOwner: 'the target constructor',
+  );
+
+  return renderWidgetCall(
+    widgetName: widgetName,
+    params: call.params,
+    forwardsKey: call.forwardsKey,
+    indent: indent,
+  );
+}
 
 /// Returns display names of optional positional parameters in declaration
 /// order, with `<unnamed>` substituted for nameless parameters.

--- a/packages/mix_generator/lib/src/styler_generator.dart
+++ b/packages/mix_generator/lib/src/styler_generator.dart
@@ -82,56 +82,14 @@ class StylerGenerator extends GeneratorForAnnotation<MixableStyler> {
     );
     if (specAnnotation == null) return null;
 
-    final reader = ConstantReader(specAnnotation).peek('target');
-    if (reader == null || reader.isNull) return null;
-
-    final fn = reader.objectValue.toFunctionValue();
-    if (fn is! ConstructorElement) {
-      fail(
-        specElement,
-        '@MixableSpec(target:) must be a constructor tear-off '
-        '(e.g., Box.new).',
-      );
-    }
-
-    final widgetClass = fn.enclosingElement;
-    final widgetName = mixableSpecTargetWidgetName(fn);
-    final hiddenWidgetType = firstInvisibleTypeName(
-      widgetClass.thisType,
-      stylerElement.library,
-    );
-    if (hiddenWidgetType != null) {
-      fail(
-        stylerElement,
-        'Target widget `$hiddenWidgetType` is used by @MixableSpec(target:) '
-        'but is not visible from the @MixableStyler library.',
-        todo:
-            'Import or re-export `$hiddenWidgetType` where the styler is declared.',
-      );
-    }
-
-    validateMixableSpecTargetConstructor(
-      constructor: fn,
-      widgetName: widgetName,
+    return buildMixableSpecTargetCall(
+      annotation: ConstantReader(specAnnotation),
       specElement: specElement,
       specName: specName,
-      anchor: specElement,
-    );
-
-    final result = extractCallParams(
-      fn,
-      anchor: stylerElement,
-      library: stylerElement.library,
-      factoryReference: stylerName,
-      excludeNames: const {'style', 'styleSpec'},
-      annotationLabel: '@MixableSpec(target:)',
-      keyOwner: 'the target constructor',
-    );
-
-    return renderWidgetCall(
-      widgetName: widgetName,
-      params: result.params,
-      forwardsKey: result.forwardsKey,
+      stylerName: stylerName,
+      hostElement: stylerElement,
+      hostLibrary: stylerElement.library,
+      validateTargetVisibility: true,
       indent: '  ',
     );
   }

--- a/packages/mix_generator/test/builder_factory_test.dart
+++ b/packages/mix_generator/test/builder_factory_test.dart
@@ -1,0 +1,48 @@
+import 'package:build/build.dart';
+import 'package:mix_generator/mix_generator.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('builder factories', () {
+    final cases = <({String name, Builder builder, String outputExtension})>[
+      (
+        name: 'mixGenerator',
+        builder: mixGenerator(BuilderOptions.empty),
+        outputExtension: '.mix_generator.g.part',
+      ),
+      (
+        name: 'specStylerGenerator',
+        builder: specStylerGenerator(BuilderOptions.empty),
+        outputExtension: '.spec_styler_generator.g.part',
+      ),
+      (
+        name: 'stylerGenerator',
+        builder: stylerGenerator(BuilderOptions.empty),
+        outputExtension: '.styler_generator.g.part',
+      ),
+      (
+        name: 'mixableGenerator',
+        builder: mixableGenerator(BuilderOptions.empty),
+        outputExtension: '.mixable_generator.g.part',
+      ),
+      (
+        name: 'mixWidgetGenerator',
+        builder: mixWidgetGenerator(BuilderOptions.empty),
+        outputExtension: '.mix_widget_generator.g.part',
+      ),
+      (
+        name: 'modifierGenerator',
+        builder: modifierGenerator(BuilderOptions.empty),
+        outputExtension: '.modifier_generator.g.part',
+      ),
+    ];
+
+    for (final entry in cases) {
+      test('${entry.name} preserves its declared output extension', () {
+        expect(entry.builder.buildExtensions, {
+          '.dart': [entry.outputExtension],
+        });
+      });
+    }
+  });
+}


### PR DESCRIPTION
## Summary

- centralize the six public builder factories while preserving their signatures and output extensions
- deduplicate generated equality, diagnostics, props, and MixableSpec target-call planning
- add builder-factory characterization tests and document the MixableModifier output accurately

## Compatibility

- public annotation and builder APIs are unchanged
- existing validation behavior and diagnostics are preserved
- regeneration produces no generated-file changes

## Validation

- `melos run gen:build`
- `melos run ci --no-select`
- `melos run analyze:dart --no-select`
- `melos run analyze:dcm --no-select`
- `dart format --output=none --set-exit-if-changed packages/mix_generator`
- `git diff --check`
