### PR TITLE
fix(mix): prevent variant merge-key collisions

### DIFF
--- a/packages/mix/CHANGELOG.md
+++ b/packages/mix/CHANGELOG.md
@@ -10,6 +10,12 @@
 
 ### Fixes
 
+- **Variant merge-key collisions:** Variant styles now merge by an opaque,
+  semantic identity instead of the human-readable `Variant.key`. Equivalent
+  named, enum-backed, and built-in context variants still coalesce, while
+  unrelated variants with the same label retain their own predicates. Dynamic
+  builders keep their existing build-then-merge behavior and use function
+  equality instead of a hash string for merge identity.
 - **Context variant equality:** `ContextVariant.brightness`,
   `ContextVariant.breakpoint`, `ContextVariant.orientation`,
   `ContextVariant.directionality`, `ContextVariant.platform`,

--- a/packages/mix/lib/src/core/style.dart
+++ b/packages/mix/lib/src/core/style.dart
@@ -245,6 +245,18 @@ abstract class ModifierMix<S extends WidgetModifier<S>> extends Mix<S>
   Type get mergeKey => S;
 }
 
+enum _VariantMergeNamespace { named, context, builder }
+
+// Keep diagnostic labels out of semantic identity. Record equality delegates
+// to the value semantics already defined by each supported variant kind.
+Object _variantMergeKey(Variant variant) {
+  return switch (variant) {
+    NamedVariant(:final name) => (_VariantMergeNamespace.named, name),
+    ContextVariantBuilder(:final fn) => (_VariantMergeNamespace.builder, fn),
+    ContextVariant() => (_VariantMergeNamespace.context, variant),
+  };
+}
+
 /// Variant wrapper for conditional styling
 final class VariantStyle<S extends Spec<S>> extends Mixable<StyleSpec<S>>
     with Equatable
@@ -273,10 +285,12 @@ final class VariantStyle<S extends Spec<S>> extends Mixable<StyleSpec<S>>
       return VariantStyle(variant, _style);
     }
 
-    if (variant.key != other.variant.key) {
+    if (mergeKey != other.mergeKey) {
       throw ArgumentError(
         'Cannot merge VariantStyle with different variants. '
-        'Attempted to merge variant "${variant.key}" with "${other.variant.key}".',
+        '${variant.runtimeType}(key: "${variant.key}") and '
+        '${other.variant.runtimeType}(key: "${other.variant.key}") do not '
+        'have the same semantic merge identity.',
       );
     }
 
@@ -286,6 +300,7 @@ final class VariantStyle<S extends Spec<S>> extends Mixable<StyleSpec<S>>
   @override
   List<Object?> get props => [variant, _style];
 
+  /// Opaque semantic identity used when merging variant style fragments.
   @override
-  Object get mergeKey => variant.key;
+  Object get mergeKey => _variantMergeKey(variant);
 }

--- a/packages/mix/lib/src/variants/variant.dart
+++ b/packages/mix/lib/src/variants/variant.dart
@@ -16,6 +16,9 @@ sealed class Variant {
   /// Factory method to create a named variant
   static NamedVariant named(String name) => .new(name);
 
+  /// Human-readable label used for diagnostics.
+  ///
+  /// This label is not guaranteed to be unique across variant kinds.
   String get key;
 }
 

--- a/packages/mix/test/src/variants/context_variant_builder_test.dart
+++ b/packages/mix/test/src/variants/context_variant_builder_test.dart
@@ -426,22 +426,26 @@ void main() {
 
         expect(variantAttr.variant, builder);
         expect(variantAttr.value, style);
-        expect(variantAttr.mergeKey, builder.key);
       });
 
-      test('key works as mergeKey for VariantSpecAttribute', () {
-        final builder1 = ContextVariantBuilder<BoxStyler>(
-          (context) => BoxStyler().width(100.0),
-        );
-        final builder2 = ContextVariantBuilder<BoxStyler>(
-          (context) => BoxStyler().width(200.0),
-        );
+      test('function equality determines merge identity', () {
+        BoxStyler firstFunction(BuildContext _) {
+          return BoxStyler().width(100.0);
+        }
+
+        BoxStyler secondFunction(BuildContext _) {
+          return BoxStyler().width(200.0);
+        }
+
+        final builder1 = ContextVariantBuilder<BoxStyler>(firstFunction);
+        final sameFunction = ContextVariantBuilder<BoxStyler>(firstFunction);
+        final builder2 = ContextVariantBuilder<BoxStyler>(secondFunction);
 
         final style1 = VariantStyle(builder1, BoxStyler().height(100.0));
+        final sameStyle = VariantStyle(sameFunction, BoxStyler().height(150.0));
         final style2 = VariantStyle(builder2, BoxStyler().height(200.0));
 
-        expect(style1.mergeKey, builder1.key);
-        expect(style2.mergeKey, builder2.key);
+        expect(style1.mergeKey, equals(sameStyle.mergeKey));
         expect(style1.mergeKey, isNot(equals(style2.mergeKey)));
       });
     });

--- a/packages/mix/test/src/variants/enum_variant_test.dart
+++ b/packages/mix/test/src/variants/enum_variant_test.dart
@@ -69,7 +69,6 @@ void main() {
         final variantStyle = VariantStyle(ButtonVariant.primary, style);
 
         expect(variantStyle.variant, ButtonVariant.primary);
-        expect(variantStyle.mergeKey, 'primary');
       });
 
       test('different enum values create different mergeKeys', () {

--- a/packages/mix/test/src/variants/named_variant_test.dart
+++ b/packages/mix/test/src/variants/named_variant_test.dart
@@ -214,7 +214,6 @@ void main() {
 
         expect(variantAttr.variant, primaryVariant);
         expect(variantAttr.value, style);
-        expect(variantAttr.mergeKey, 'primary');
       });
 
       test('different NamedVariants create different mergeKeys', () {
@@ -231,8 +230,6 @@ void main() {
           BoxStyler().width(150.0),
         );
 
-        expect(primaryStyle.mergeKey, 'primary');
-        expect(secondaryStyle.mergeKey, 'secondary');
         expect(primaryStyle.mergeKey, isNot(equals(secondaryStyle.mergeKey)));
       });
 

--- a/packages/mix/test/src/variants/variant_merge_identity_test.dart
+++ b/packages/mix/test/src/variants/variant_merge_identity_test.dart
@@ -1,0 +1,302 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mix/mix.dart';
+
+import '../../helpers/testing_utils.dart';
+
+enum _TestVariant with EnumVariant { primary }
+
+void main() {
+  group('VariantStyle merge identity', () {
+    test(
+      'keeps different variant kinds with the same display key separate',
+      () {
+        final cases = <(Variant, Variant)>[
+          (const NamedVariant('web'), ContextVariant.web()),
+          (const NamedVariant('custom'), ContextVariant('custom', (_) => true)),
+          (
+            const NamedVariant('widget_state_hovered'),
+            WidgetStateVariant(WidgetState.hovered),
+          ),
+        ];
+
+        for (final (named, contextual) in cases) {
+          for (final (first, second) in [
+            (named, contextual),
+            (contextual, named),
+          ]) {
+            final firstFragment = BoxStyler().width(100.0);
+            final secondFragment = BoxStyler().height(50.0);
+            final merged = _withVariant(
+              first,
+              firstFragment,
+            ).merge(_withVariant(second, secondFragment));
+
+            expect(
+              merged.$variants,
+              hasLength(2),
+              reason:
+                  '${first.runtimeType} and ${second.runtimeType} both use '
+                  'the display key "${first.key}"',
+            );
+            expect(merged.$variants![0].variant, same(first));
+            expect(merged.$variants![0].value, same(firstFragment));
+            expect(merged.$variants![1].variant, same(second));
+            expect(merged.$variants![1].value, same(secondFragment));
+          }
+        }
+      },
+    );
+
+    test('keeps same-label context predicates independently active', () {
+      var firstActive = true;
+      var secondActive = false;
+      final first = ContextVariant('shared', (_) => firstActive);
+      final second = ContextVariant('shared', (_) => secondActive);
+      final merged = _withVariant(
+        first,
+        BoxStyler().width(100.0),
+      ).merge(_withVariant(second, BoxStyler().height(50.0)));
+      final context = MockBuildContext();
+
+      expect(merged.$variants!.map((entry) => entry.variant), [first, second]);
+      final reused = _withVariant(
+        first,
+        BoxStyler().width(100.0),
+      ).merge(_withVariant(first, BoxStyler().height(50.0)));
+      expect(reused.$variants, hasLength(1));
+
+      final firstResult = merged
+          .mergeActiveVariants(context, namedVariants: const {})
+          .resolve(context)
+          .constraints;
+      expect(firstResult?.minWidth, 100.0);
+      expect(firstResult?.maxWidth, 100.0);
+      expect(firstResult?.maxHeight, double.infinity);
+
+      firstActive = false;
+      secondActive = true;
+      final secondResult = merged
+          .mergeActiveVariants(context, namedVariants: const {})
+          .resolve(context)
+          .constraints;
+      expect(secondResult?.maxWidth, double.infinity);
+      expect(secondResult?.minHeight, 50.0);
+      expect(secondResult?.maxHeight, 50.0);
+    });
+
+    test('uses builder function equality in a separate namespace', () {
+      BoxStyler firstBuilder(BuildContext _) => BoxStyler().width(100.0);
+      BoxStyler secondBuilder(BuildContext _) => BoxStyler().height(50.0);
+
+      final first = ContextVariantBuilder<BoxStyler>(firstBuilder);
+      final second = ContextVariantBuilder<BoxStyler>(secondBuilder);
+      final sameFunction = ContextVariantBuilder<BoxStyler>(firstBuilder);
+
+      expect(_mergeKey(first), equals(_mergeKey(sameFunction)));
+      expect(_mergeKey(first), isNot(equals(_mergeKey(second))));
+
+      final distinctBuilders = _withVariant(
+        first,
+        BoxStyler().width(100.0),
+      ).merge(_withVariant(second, BoxStyler().height(50.0)));
+      expect(distinctBuilders.$variants, hasLength(2));
+
+      final sameBuilders = _withVariant(
+        first,
+        BoxStyler().width(100.0),
+      ).merge(_withVariant(sameFunction, BoxStyler().height(50.0)));
+      expect(sameBuilders.$variants, hasLength(1));
+
+      final namedWithBuilderKey = NamedVariant(first.key);
+
+      for (final (left, right) in <(Variant, Variant)>[
+        (first, namedWithBuilderKey),
+        (namedWithBuilderKey, first),
+      ]) {
+        final merged = _withVariant(
+          left,
+          BoxStyler().width(100.0),
+        ).merge(_withVariant(right, BoxStyler().height(50.0)));
+        expect(merged.$variants, hasLength(2));
+      }
+    });
+
+    test('distinct builders execute and their returned styles merge', () {
+      var firstCalls = 0;
+      var secondCalls = 0;
+      final first = BoxStyler().onBuilder((_) {
+        firstCalls++;
+
+        return BoxStyler().width(100.0);
+      });
+      final second = BoxStyler().onBuilder((_) {
+        secondCalls++;
+
+        return BoxStyler().height(50.0);
+      });
+      final context = MockBuildContext();
+
+      final constraints = first
+          .merge(second)
+          .mergeActiveVariants(context, namedVariants: const {})
+          .resolve(context)
+          .constraints;
+
+      expect(firstCalls, 1);
+      expect(secondCalls, 1);
+      expect(constraints?.minWidth, 100.0);
+      expect(constraints?.maxWidth, 100.0);
+      expect(constraints?.minHeight, 50.0);
+      expect(constraints?.maxHeight, 50.0);
+    });
+
+    test('reused builder function keeps execute-once behavior', () {
+      var calls = 0;
+      BoxStyler builder(BuildContext _) {
+        calls++;
+
+        return BoxStyler().width(100.0);
+      }
+
+      final first = BoxStyler().onBuilder(builder);
+      final second = BoxStyler().onBuilder(builder);
+      final merged = first.merge(second);
+      final context = MockBuildContext();
+
+      expect(merged.$variants, hasLength(1));
+      final constraints = merged
+          .mergeActiveVariants(context, namedVariants: const {})
+          .resolve(context)
+          .constraints;
+
+      expect(calls, 1);
+      expect(constraints?.minWidth, 100.0);
+      expect(constraints?.maxWidth, 100.0);
+    });
+
+    test('normalizes named and enum variants while preserving precedence', () {
+      const named = NamedVariant('primary');
+      const cases = <(Variant, Variant)>[
+        (NamedVariant('primary'), NamedVariant('primary')),
+        (named, _TestVariant.primary),
+        (_TestVariant.primary, named),
+      ];
+      final context = MockBuildContext();
+
+      for (final (first, second) in cases) {
+        final merged = _withVariant(
+          first,
+          BoxStyler().width(100.0).height(40.0),
+        ).merge(_withVariant(second, BoxStyler().width(200.0)));
+
+        expect(merged.$variants, hasLength(1));
+        expect(merged.$variants!.single.variant, same(first));
+        final constraints = merged.$variants!.single.value
+            .resolve(context)
+            .constraints;
+        expect(constraints?.minWidth, 200.0);
+        expect(constraints?.maxWidth, 200.0);
+        expect(constraints?.minHeight, 40.0);
+        expect(constraints?.maxHeight, 40.0);
+      }
+    });
+
+    test('coalesces equivalent built-in context variants', () {
+      const breakpoint = Breakpoint(minWidth: 400.0, maxWidth: 800.0);
+      final cases = <(ContextVariant, ContextVariant)>[
+        (
+          ContextVariant.widgetState(WidgetState.hovered),
+          ContextVariant.widgetState(WidgetState.hovered),
+        ),
+        (
+          ContextVariant.brightness(Brightness.dark),
+          ContextVariant.brightness(Brightness.dark),
+        ),
+        (
+          ContextVariant.breakpoint(breakpoint),
+          ContextVariant.breakpoint(breakpoint),
+        ),
+        (
+          ContextVariant.orientation(Orientation.portrait),
+          ContextVariant.orientation(Orientation.portrait),
+        ),
+        (
+          ContextVariant.directionality(TextDirection.ltr),
+          ContextVariant.directionality(TextDirection.ltr),
+        ),
+        (
+          ContextVariant.platform(TargetPlatform.macOS),
+          ContextVariant.platform(TargetPlatform.macOS),
+        ),
+        (ContextVariant.web(), ContextVariant.web()),
+        (
+          ContextVariant.not(ContextVariant.web()),
+          ContextVariant.not(ContextVariant.web()),
+        ),
+      ];
+      final context = MockBuildContext();
+
+      for (final (first, second) in cases) {
+        final merged = _withVariant(
+          first,
+          BoxStyler().width(100.0),
+        ).merge(_withVariant(second, BoxStyler().height(50.0)));
+
+        expect(
+          merged.$variants,
+          hasLength(1),
+          reason: '${first.runtimeType} should have value equality',
+        );
+        expect(merged.$variants!.single.variant, same(first));
+        final constraints = merged.$variants!.single.value
+            .resolve(context)
+            .constraints;
+        expect(constraints?.minWidth, 100.0);
+        expect(constraints?.maxWidth, 100.0);
+        expect(constraints?.minHeight, 50.0);
+        expect(constraints?.maxHeight, 50.0);
+      }
+    });
+
+    test('direct incompatible merge reports both variants', () {
+      final named = VariantStyle<BoxSpec>(
+        const NamedVariant('web'),
+        BoxStyler().width(100.0),
+      );
+      final contextual = VariantStyle<BoxSpec>(
+        ContextVariant.web(),
+        BoxStyler().height(50.0),
+      );
+
+      for (final (first, second)
+          in <(VariantStyle<BoxSpec>, VariantStyle<BoxSpec>)>[
+            (named, contextual),
+            (contextual, named),
+          ]) {
+        expect(
+          () => first.merge(second),
+          throwsA(
+            isA<ArgumentError>().having(
+              (error) => error.message,
+              'message',
+              allOf(
+                contains('NamedVariant'),
+                contains('WebVariant'),
+                contains('"web"'),
+              ),
+            ),
+          ),
+        );
+      }
+    });
+  });
+}
+
+BoxStyler _withVariant(Variant variant, BoxStyler fragment) {
+  return BoxStyler(variants: [VariantStyle<BoxSpec>(variant, fragment)]);
+}
+
+Object _mergeKey(Variant variant) {
+  return VariantStyle<BoxSpec>(variant, BoxStyler()).mergeKey;
+}

--- a/packages/mix/test/src/variants/variant_spec_style_test.dart
+++ b/packages/mix/test/src/variants/variant_spec_style_test.dart
@@ -14,7 +14,6 @@ void main() {
 
         expect(variantAttr.variant, variant);
         expect(variantAttr.value, style);
-        expect(variantAttr.mergeKey, 'primary');
       });
 
       test('creates VariantSpecAttribute with ContextVariant', () {
@@ -24,7 +23,6 @@ void main() {
 
         expect(variantAttr.variant, variant);
         expect(variantAttr.value, style);
-        expect(variantAttr.mergeKey, 'widget_state_hovered');
       });
 
       test('creates VariantSpecAttribute with ContextVariant', () {
@@ -34,7 +32,6 @@ void main() {
 
         expect(variantAttr.variant, variant);
         expect(variantAttr.value, style);
-        expect(variantAttr.mergeKey, 'widget_state_hovered');
       });
     });
 
@@ -275,28 +272,35 @@ void main() {
     });
 
     group('mergeKey property', () {
-      test('uses variant key as merge key', () {
-        const variant = NamedVariant('primary');
+      test('matches semantically equivalent named variants', () {
+        const first = NamedVariant('primary');
+        const second = NamedVariant('primary');
         final style = BoxStyler().width(100.0);
-        final variantAttr = VariantStyle(variant, style);
+        final firstStyle = VariantStyle(first, style);
+        final secondStyle = VariantStyle(second, style);
 
-        expect(variantAttr.mergeKey, 'primary');
+        expect(firstStyle.mergeKey, equals(secondStyle.mergeKey));
       });
 
-      test('uses ContextVariant key as merge key', () {
-        final variant = ContextVariant.widgetState(WidgetState.hovered);
+      test('matches semantically equivalent context variants', () {
+        final first = ContextVariant.widgetState(WidgetState.hovered);
+        final second = ContextVariant.widgetState(WidgetState.hovered);
         final style = BoxStyler().width(100.0);
-        final variantAttr = VariantStyle(variant, style);
+        final firstStyle = VariantStyle(first, style);
+        final secondStyle = VariantStyle(second, style);
 
-        expect(variantAttr.mergeKey, 'widget_state_hovered');
+        expect(firstStyle.mergeKey, equals(secondStyle.mergeKey));
       });
 
-      test('uses variant key as merge key', () {
-        const variant = NamedVariant('primary');
+      test('does not use the display key as semantic identity', () {
+        const named = NamedVariant('web');
+        final contextual = ContextVariant.web();
         final style = BoxStyler().width(100.0);
-        final variantAttr = VariantStyle(variant, style);
+        final namedStyle = VariantStyle(named, style);
+        final contextualStyle = VariantStyle(contextual, style);
 
-        expect(variantAttr.mergeKey, 'primary');
+        expect(named.key, contextual.key);
+        expect(namedStyle.mergeKey, isNot(equals(contextualStyle.mergeKey)));
       });
     });
 

--- a/packages/mix/test/src/variants/widget_state_variant_test.dart
+++ b/packages/mix/test/src/variants/widget_state_variant_test.dart
@@ -352,7 +352,6 @@ void main() {
 
         expect(variantAttr.variant, hoverVariant);
         expect(variantAttr.value, style);
-        expect(variantAttr.mergeKey, hoverVariant.key);
       });
 
       test(
@@ -369,8 +368,6 @@ void main() {
           );
 
           expect(hoverStyle.mergeKey, isNot(equals(pressStyle.mergeKey)));
-          expect(hoverStyle.mergeKey, 'widget_state_hovered');
-          expect(pressStyle.mergeKey, 'widget_state_pressed');
         },
       );
 


### PR DESCRIPTION
#### Related issue

Closes #969

### Description

Variant styles previously merged by the human-readable `Variant.key`. That allowed unrelated variants sharing a label—for example, `NamedVariant('web')` and the built-in `ContextVariant.web()`—to collapse into one entry. The variant merged first retained its predicate while both style fragments were combined under it, making the result order-dependent: an explicitly selected named style could become automatically active on web, or an automatic web style could require the named variant to be selected.

Dynamic builders had a related problem because their merge identity was the string form of `fn.hashCode`; a hash collision could silently drop a builder before resolution.

This PR switches variant merging to an opaque, namespaced semantic identity. Equivalent variants still coalesce, while unrelated variants retain their own predicates and activation behavior.

### Changes

- Added a namespaced `_variantMergeKey` in `style.dart` that derives merge identity from each variant kind's value semantics instead of `Variant.key`.
- Dynamic `ContextVariantBuilder`s now merge by function equality rather than a hash string. Build-then-merge behavior is unchanged: distinct closures each build and merge, while the same function reference still coalesces.
- Documented `Variant.key` as diagnostic-only and made incompatible-merge errors include both runtime types and keys.
- Added `variant_merge_identity_test.dart` with collision, activation, ordering, precedence, and compatibility coverage. Updated existing variant tests to treat `mergeKey` as opaque.
- Added a CHANGELOG entry.

**Review Checklist**

- [x] **Testing**: Full Mix Flutter suite, variant suite, generator, and linter suites passed on this diff; new regression tests added.
- [ ] **Breaking Changes**: No public API change; behavior differs only in previously buggy collision cases.
- [x] **Documentation Updates**: CHANGELOG entry and `Variant.key` dartdoc updated.
- [ ] **Website Updates**: N/A — no website-facing changes.

### Additional Information (optional)

`mergeKey` is an internal identity token. `Variant.key` remains the human-readable diagnostic label and is no longer used as semantic merge identity. `melos run gen:build` produced no generated changes.
