### PR TITLE
docs(mix_generator): fold unreleased 2.1.2 notes into 2.2.0

### DIFF
--- a/packages/mix_generator/CHANGELOG.md
+++ b/packages/mix_generator/CHANGELOG.md
@@ -4,9 +4,6 @@
    when an `@MixWidget` function has a named, non-nullable enum parameter named
    `variant` (for example, `Button.solid(...)`). The existing unnamed
    constructor remains unchanged.
-
-## 2.1.2
-
  - **FEAT**: Derive nested styler types for `StyleSpec<XSpec>` spec fields by
    the `XSpec -> XStyler` naming convention. Generated spec stylers now expose
    styler-typed constructors, setters, and field factories with


### PR DESCRIPTION
## What

`mix_generator-v2.1.2` was never tagged/published (latest published tag is `mix_generator-v2.1.1`), so everything under its `## 2.1.2` heading is still **unreleased**. PR #968 bumped the package to `2.2.0` and added its own entry above the orphaned 2.1.2 section.

This folds the two unreleased 2.1.2 items up into `## 2.2.0` so they ship with this release:

- **FEAT**: derive nested styler types for `StyleSpec<XSpec>` fields by convention (from #961)
- **FIX**: `@MixWidget` generic styler `call<T>()` support (from #958)

## Why this is correct

- The **Breaking** nested-styler change now ships under a minor bump (2.2.0) rather than the earlier patch (2.1.2) — more correct semver, and #968 forced the minor anyway.
- No orphan `## 2.1.2` heading left behind that would never map to a pub.dev release.

## Scope

Docs-only. `pubspec.yaml` is already `2.2.0` (set by #968); no code, no version change. Release still launches by pushing the `mix_generator-v2.2.0` tag.