### PR TITLE
chore: release mix_generator 2.1.2 and mix_annotations 2.1.2

### DIFF
--- a/packages/mix_annotations/CHANGELOG.md
+++ b/packages/mix_annotations/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.1.2
+
+ - **DOCS**: Document that nested `StyleSpec<XSpec>` fields derive `XStyler`
+   automatically by convention, so `@MixableField(setterType:)` is only needed
+   to override the derived name (#961).
+
 ## 2.1.1
 
  - **DOCS**: Document `@MixableField(setterType:)` usage for `@MixableSpec` and `@MixableModifier` fields (#950, #951).

--- a/packages/mix_annotations/pubspec.yaml
+++ b/packages/mix_annotations/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mix_annotations
 description: Annotations for mix and mix_generator
-version: 2.1.1
+version: 2.1.2
 repository: https://github.com/btwld/mix/tree/main/packages/mix_annotations
 
 environment:

--- a/packages/mix_generator/CHANGELOG.md
+++ b/packages/mix_generator/CHANGELOG.md
@@ -1,12 +1,9 @@
-## 2.2.0
+## 2.1.2
 
  - **FEAT**: Generate one named widget constructor per accessible enum value
    when an `@MixWidget` function has a named, non-nullable enum parameter named
    `variant` (for example, `Button.solid(...)`). The existing unnamed
    constructor remains unchanged.
-
-## 2.1.2
-
  - **FEAT**: Derive nested styler types for `StyleSpec<XSpec>` spec fields by
    the `XSpec -> XStyler` naming convention. Generated spec stylers now expose
    styler-typed constructors, setters, and field factories with

--- a/packages/mix_generator/pubspec.yaml
+++ b/packages/mix_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mix_generator
 description: A code generator for Mix, an expressive way to effortlessly build design systems in Flutter.
-version: 2.2.0
+version: 2.1.2
 homepage: https://github.com/btwld/mix
 repository: https://github.com/btwld/mix/tree/main/packages/mix_generator
 


### PR DESCRIPTION
Release both packages as patch **2.1.2**.

## mix_generator 2.2.0 → 2.1.2
Everything unreleased since `2.1.1` ships under a single `## 2.1.2`:
- **FEAT** variant widget constructors (#968)
- **FEAT** nested styler types by convention (#961) — see breaking note below
- **FIX** `@MixWidget` generic `call<T>()` (#958)

(The 2.2.0 that #968 set was never tagged/published, so renumbering down is safe.)

## mix_annotations 2.1.1 → 2.1.2
- **DOCS** nested-styler convention comment (#961)

## Notes
- **Breaking-change flag stays honest**: the nested-styler entry keeps its `**Breaking**` note (nested `StyleSpec` params now take the styler). It's narrow — only external specs with nested `StyleSpec` fields, compile-time — but real. Shipping it under a patch is a deliberate maintainer call; `^2.1.1` consumers pick up 2.1.2 exactly as they would 2.2.0, so the number is a signal, not a gate.
- **Dependency constraint left at** `mix_annotations: ^2.1.1` — the generator has no functional dependency on the annotations doc change, and the caret already admits 2.1.2. Say the word to tighten it to `^2.1.2`.
- Docs/version-only; no code change. Dry-runs pass for both (only the expected uncommitted + monorepo-override notices).

## Launch after merge
```
git tag mix_annotations-v2.1.2 <merge-sha> && git push origin mix_annotations-v2.1.2
git tag mix_generator-v2.1.2  <merge-sha> && git push origin mix_generator-v2.1.2
```