### PR TITLE
feat(mix_generator): curate @MixWidget parameters

### DIFF
--- a/packages/mix_annotations/CHANGELOG.md
+++ b/packages/mix_annotations/CHANGELOG.md
@@ -3,7 +3,8 @@
  - **FEAT**: Add `MixWidgetParameterSelection` and the
    `MixWidget.widgetParameters` default. `@MixWidget()` now concretely carries
    `.all()`, while `.only({...})` supports opt-in curation of generated widget
-   parameters.
+   value parameters. Factory parameters, valid `Key? key`, and method-level
+   type parameters remain automatic.
 
 ## 2.1.2
 

--- a/packages/mix_annotations/CHANGELOG.md
+++ b/packages/mix_annotations/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+ - **FEAT**: Add `MixWidgetParameterSelection` and the
+   `MixWidget.widgetParameters` default. `@MixWidget()` now concretely carries
+   `.all()`, while `.only({...})` supports opt-in curation of generated widget
+   parameters.
+
 ## 2.1.2
 
  - **DOCS**: Document that nested `StyleSpec<XSpec>` fields derive `XStyler`

--- a/packages/mix_annotations/README.md
+++ b/packages/mix_annotations/README.md
@@ -106,6 +106,32 @@ final Prop<Matrix4>? $transform;
 final Prop<List<Shadow>>? $shadows;
 ```
 
+### `@MixWidget`
+
+Generates a `StatelessWidget` wrapper around a top-level styler variable or
+styler-returning function. By default, the wrapper exposes every non-`key`
+parameter from the styler's `call()` method:
+
+```dart
+@MixWidget() // Equivalent to widgetParameters: .all()
+final cardStyle = BoxStyler();
+```
+
+Use `widgetParameters: .only(...)` to keep the generated widget API limited to
+a deliberate subset. This prevents newly added styler parameters from becoming
+public widget parameters automatically:
+
+```dart
+@MixWidget(
+  widgetParameters: .only({'controller', 'focusNode'}),
+)
+final editorStyle = EditorStyler();
+```
+
+An empty `.only({})` exposes no selectable styler parameters. Factory
+parameters and a valid `Key? key` parameter remain automatic in every mode;
+required styler parameters must be selected.
+
 ## Generator Flags
 
 Each annotation accepts bitwise flags to control which methods or components are generated:

--- a/packages/mix_annotations/README.md
+++ b/packages/mix_annotations/README.md
@@ -110,16 +110,16 @@ final Prop<List<Shadow>>? $shadows;
 
 Generates a `StatelessWidget` wrapper around a top-level styler variable or
 styler-returning function. By default, the wrapper exposes every non-`key`
-parameter from the styler's `call()` method:
+value parameter from the styler's `call()` method:
 
 ```dart
 @MixWidget() // Equivalent to widgetParameters: .all()
 final cardStyle = BoxStyler();
 ```
 
-Use `widgetParameters: .only(...)` to keep the generated widget API limited to
-a deliberate subset. This prevents newly added styler parameters from becoming
-public widget parameters automatically:
+Use `widgetParameters: .only(...)` to keep the generated widget's value-
+parameter API limited to a deliberate subset. This prevents newly added styler
+value parameters from becoming public widget parameters automatically:
 
 ```dart
 @MixWidget(
@@ -128,9 +128,15 @@ public widget parameters automatically:
 final editorStyle = EditorStyler();
 ```
 
-An empty `.only({})` exposes no selectable styler parameters. Factory
-parameters and a valid `Key? key` parameter remain automatic in every mode;
-required styler parameters must be selected.
+An empty `.only({})` exposes no selectable styler value parameters. Factory
+parameters, a valid `Key? key`, and method-level `call<T>()` type parameters
+remain automatic in every mode; required styler value parameters must be
+selected. Excluded optional parameters are not forwarded, so the styler
+method's defaults apply.
+
+Generators that also support older `mix_annotations` releases interpret an
+annotation without `widgetParameters` as `.all()`. Using `.only(...)` requires
+an annotations release that defines `MixWidgetParameterSelection`.
 
 ## Generator Flags
 

--- a/packages/mix_annotations/lib/src/annotations.dart
+++ b/packages/mix_annotations/lib/src/annotations.dart
@@ -122,27 +122,28 @@ class MixableField {
   });
 }
 
-/// Selects styler `call()` parameters exposed by a generated [MixWidget].
+/// Selects styler `call()` value parameters exposed by a generated [MixWidget].
 ///
 /// [MixWidget] defaults to [MixWidgetParameterSelection.all], which includes
-/// every non-`key` parameter. Use [MixWidgetParameterSelection.only] to expose
-/// a stable, explicit subset instead. Factory parameters and a valid
-/// `Key? key` parameter remain automatic in both modes.
+/// every non-`key` value parameter. Use [MixWidgetParameterSelection.only] to
+/// expose a stable, explicit value-parameter subset instead. Factory
+/// parameters, a valid `Key? key`, and method-level `call<T>()` type parameters
+/// remain automatic in both modes.
 final class MixWidgetParameterSelection {
-  /// Whether every selectable styler `call()` parameter is included.
+  /// Whether every selectable styler `call()` value parameter is included.
   final bool includesAll;
 
-  /// The selected non-`key` styler `call()` parameter names.
+  /// The selected non-`key` styler `call()` value parameter names.
   ///
   /// This is empty for [MixWidgetParameterSelection.all].
   final Set<String> names;
 
-  /// Includes every non-`key` styler `call()` parameter.
+  /// Includes every non-`key` styler `call()` value parameter.
   const MixWidgetParameterSelection.all()
     : includesAll = true,
       names = const {};
 
-  /// Includes exactly the non-`key` styler `call()` parameters in [names].
+  /// Includes exactly the non-`key` styler `call()` value parameters in [names].
   const MixWidgetParameterSelection.only(this.names) : includesAll = false;
 }
 
@@ -171,12 +172,14 @@ final class MixWidgetParameterSelection {
 /// // `color` (factory param) plus `child` (from `BoxStyler.call`).
 /// ```
 ///
-/// [widgetParameters] controls which non-`key` styler `call()` parameters are
-/// exposed by the generated widget. It defaults to
+/// [widgetParameters] controls which non-`key` styler `call()` value parameters
+/// are exposed by the generated widget. It defaults to
 /// [MixWidgetParameterSelection.all]. Use
 /// `widgetParameters: .only({'controller', 'focusNode'})` when the widget
-/// should expose only a curated subset. Factory parameters and a valid
-/// `Key? key` styler parameter remain automatic.
+/// should expose only a curated subset. Factory parameters, a valid `Key? key`,
+/// and method-level `call<T>()` type parameters remain automatic. Optional
+/// value parameters omitted by `.only(...)` are not forwarded, so the styler
+/// method's defaults apply.
 ///
 /// Requires the annotated element's name to be `lowerCamelCase` ending in
 /// `Style` (for example, `cardStyle`, `primaryButtonStyle`, or
@@ -188,7 +191,7 @@ class MixWidget {
   /// the name is derived from the annotated element's name.
   final String? name;
 
-  /// Selection of non-`key` styler `call()` parameters exposed by the
+  /// Selection of non-`key` styler `call()` value parameters exposed by the
   /// generated widget.
   final MixWidgetParameterSelection widgetParameters;
 

--- a/packages/mix_annotations/lib/src/annotations.dart
+++ b/packages/mix_annotations/lib/src/annotations.dart
@@ -122,6 +122,30 @@ class MixableField {
   });
 }
 
+/// Selects styler `call()` parameters exposed by a generated [MixWidget].
+///
+/// [MixWidget] defaults to [MixWidgetParameterSelection.all], which includes
+/// every non-`key` parameter. Use [MixWidgetParameterSelection.only] to expose
+/// a stable, explicit subset instead. Factory parameters and a valid
+/// `Key? key` parameter remain automatic in both modes.
+final class MixWidgetParameterSelection {
+  /// Whether every selectable styler `call()` parameter is included.
+  final bool includesAll;
+
+  /// The selected non-`key` styler `call()` parameter names.
+  ///
+  /// This is empty for [MixWidgetParameterSelection.all].
+  final Set<String> names;
+
+  /// Includes every non-`key` styler `call()` parameter.
+  const MixWidgetParameterSelection.all()
+    : includesAll = true,
+      names = const {};
+
+  /// Includes exactly the non-`key` styler `call()` parameters in [names].
+  const MixWidgetParameterSelection.only(this.names) : includesAll = false;
+}
+
 /// Annotation that drives generation of a `StatelessWidget` wrapper for a
 /// `Style<S>` factory.
 ///
@@ -147,6 +171,13 @@ class MixableField {
 /// // `color` (factory param) plus `child` (from `BoxStyler.call`).
 /// ```
 ///
+/// [widgetParameters] controls which non-`key` styler `call()` parameters are
+/// exposed by the generated widget. It defaults to
+/// [MixWidgetParameterSelection.all]. Use
+/// `widgetParameters: .only({'controller', 'focusNode'})` when the widget
+/// should expose only a curated subset. Factory parameters and a valid
+/// `Key? key` styler parameter remain automatic.
+///
 /// Requires the annotated element's name to be `lowerCamelCase` ending in
 /// `Style` (for example, `cardStyle`, `primaryButtonStyle`, or
 /// `_internalCardStyle`). The generator strips a trailing `Style` and
@@ -157,7 +188,14 @@ class MixWidget {
   /// the name is derived from the annotated element's name.
   final String? name;
 
-  const MixWidget({this.name});
+  /// Selection of non-`key` styler `call()` parameters exposed by the
+  /// generated widget.
+  final MixWidgetParameterSelection widgetParameters;
+
+  const MixWidget({
+    this.name,
+    this.widgetParameters = const MixWidgetParameterSelection.all(),
+  });
 }
 
 const mixWidget = MixWidget();

--- a/packages/mix_annotations/test/annotations_test.dart
+++ b/packages/mix_annotations/test/annotations_test.dart
@@ -31,4 +31,36 @@ void main() {
       expect(annotation.factoryName, 'foo');
     });
   });
+
+  group('MixWidget', () {
+    test('defaults widgetParameters to all', () {
+      const annotation = MixWidget();
+
+      expect(annotation.widgetParameters.includesAll, isTrue);
+      expect(annotation.widgetParameters.names, isEmpty);
+    });
+
+    test('preserves an explicit all selection', () {
+      const annotation = MixWidget(widgetParameters: .all());
+
+      expect(annotation.widgetParameters.includesAll, isTrue);
+      expect(annotation.widgetParameters.names, isEmpty);
+    });
+
+    test('preserves selected widget parameters', () {
+      const annotation = MixWidget(
+        widgetParameters: .only({'controller', 'focusNode'}),
+      );
+
+      expect(annotation.widgetParameters.includesAll, isFalse);
+      expect(annotation.widgetParameters.names, {'controller', 'focusNode'});
+    });
+
+    test('allows an empty widget parameter selection', () {
+      const annotation = MixWidget(widgetParameters: .only({}));
+
+      expect(annotation.widgetParameters.includesAll, isFalse);
+      expect(annotation.widgetParameters.names, isEmpty);
+    });
+  });
 }

--- a/packages/mix_generator/CHANGELOG.md
+++ b/packages/mix_generator/CHANGELOG.md
@@ -1,9 +1,11 @@
 ## Unreleased
 
  - **FEAT**: Support `@MixWidget(widgetParameters: .only({...}))` for a stable,
-   curated generated widget API. Factory parameters and valid `Key? key`
-   forwarding remain automatic; excluded styler parameters are not validated
-   for generated-widget visibility or name collisions.
+   curated generated widget value-parameter API. Factory parameters, valid
+   `Key? key` forwarding, and method-level type parameters remain automatic;
+   excluded optional parameters use the styler method's defaults and are not
+   validated for generated-widget visibility or name collisions. Annotations
+   from older `mix_annotations` releases retain `.all()` behavior.
 
 ## 2.1.2
 

--- a/packages/mix_generator/CHANGELOG.md
+++ b/packages/mix_generator/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+ - **FEAT**: Support `@MixWidget(widgetParameters: .only({...}))` for a stable,
+   curated generated widget API. Factory parameters and valid `Key? key`
+   forwarding remain automatic; excluded styler parameters are not validated
+   for generated-widget visibility or name collisions.
+
 ## 2.1.2
 
  - **FEAT**: Generate one named widget constructor per accessible enum value

--- a/packages/mix_generator/README.md
+++ b/packages/mix_generator/README.md
@@ -163,6 +163,21 @@ be a Mix type; the setter type must resolve to the field's runtime value type.
 
 Generates a `StatelessWidget` wrapper around a top-level `Style<S>` variable or function. The wrapper's constructor mirrors the factory's parameters (for function-backed styles) plus the styler's `call()` parameters; `build()` invokes the factory and forwards the parameters through to the resulting widget.
 
+`@MixWidget()` is equivalent to `widgetParameters: .all()`: every non-`key`
+styler `call()` parameter is exposed. To keep a generated widget API stable as
+a styler evolves, select the supported parameters explicitly:
+
+```dart
+@MixWidget(
+  widgetParameters: .only({'controller', 'focusNode'}),
+)
+final editorStyle = EditorStyler();
+```
+
+`.only({})` exposes none of the selectable styler parameters. Factory
+parameters and a valid `Key? key` parameter are always automatic, and required
+styler parameters must be included in an `.only(...)` selection.
+
 ```dart
 part 'card.g.dart';
 

--- a/packages/mix_generator/README.md
+++ b/packages/mix_generator/README.md
@@ -164,8 +164,8 @@ be a Mix type; the setter type must resolve to the field's runtime value type.
 Generates a `StatelessWidget` wrapper around a top-level `Style<S>` variable or function. The wrapper's constructor mirrors the factory's parameters (for function-backed styles) plus the styler's `call()` parameters; `build()` invokes the factory and forwards the parameters through to the resulting widget.
 
 `@MixWidget()` is equivalent to `widgetParameters: .all()`: every non-`key`
-styler `call()` parameter is exposed. To keep a generated widget API stable as
-a styler evolves, select the supported parameters explicitly:
+styler `call()` value parameter is exposed. To keep that value-parameter API
+stable as a styler evolves, select the supported parameters explicitly:
 
 ```dart
 @MixWidget(
@@ -174,9 +174,16 @@ a styler evolves, select the supported parameters explicitly:
 final editorStyle = EditorStyler();
 ```
 
-`.only({})` exposes none of the selectable styler parameters. Factory
-parameters and a valid `Key? key` parameter are always automatic, and required
-styler parameters must be included in an `.only(...)` selection.
+`.only({})` exposes none of the selectable styler value parameters. Factory
+parameters, a valid `Key? key`, and method-level `call<T>()` type parameters are
+always automatic, and required styler value parameters must be included in an
+`.only(...)` selection. Excluded optional parameters are not forwarded, so the
+styler method's defaults apply.
+
+For compatibility, an annotation from an older `mix_annotations` release that
+does not define `widgetParameters` is interpreted as `.all()`. Using
+`.only(...)` requires an annotations release that defines
+`MixWidgetParameterSelection`.
 
 ```dart
 part 'card.g.dart';

--- a/packages/mix_generator/lib/src/mix_widget_generator.dart
+++ b/packages/mix_generator/lib/src/mix_widget_generator.dart
@@ -360,12 +360,15 @@ class MixWidgetGenerator extends GeneratorForAnnotation<MixWidget> {
 
   /// Reads the concrete annotation value into the two generator modes.
   ///
-  /// The public annotation always supplies [MixWidget.widgetParameters], so
-  /// generation never treats a missing or null value as an implicit default.
+  /// `mix_annotations` versions before parameter curation do not expose
+  /// [MixWidget.widgetParameters]. Treat that legacy shape as `.all()` so a
+  /// generator upgrade does not break existing `@MixWidget()` consumers.
   _WidgetParameterSelection _widgetParameterSelectionFor(
     ConstantReader annotation,
   ) {
-    final selection = annotation.read('widgetParameters');
+    final selection = annotation.peek('widgetParameters');
+    if (selection == null) return (includesAll: true, names: <String>{});
+
     final names = {
       for (final name in selection.read('names').setValue)
         ConstantReader(name).stringValue,
@@ -452,8 +455,8 @@ class MixWidgetGenerator extends GeneratorForAnnotation<MixWidget> {
     if (optionalPositional.isNotEmpty) {
       fail(
         anchor,
-        '$_annotationLabel does not support optional positional `call()` '
-        'parameters on '
+        '$_annotationLabel does not support selected optional positional '
+        '`call()` parameters on '
         '${callMethod.enclosingElement?.displayName ?? 'the styler'}: '
         '[${optionalPositional.join(', ')}].',
         todo: 'Convert these parameters to required positional or named.',

--- a/packages/mix_generator/lib/src/mix_widget_generator.dart
+++ b/packages/mix_generator/lib/src/mix_widget_generator.dart
@@ -27,6 +27,8 @@ import 'core/models/mix_widget_model.dart';
 
 const _annotationLabel = '@MixWidget';
 
+typedef _WidgetParameterSelection = ({bool includesAll, Set<String> names});
+
 class MixWidgetGenerator extends GeneratorForAnnotation<MixWidget> {
   static final _identifierPattern = RegExp(r'^_*[A-Za-z][A-Za-z0-9_]*$');
   static final _derivedNamePattern = RegExp(r'^_*[a-z][A-Za-z0-9]*Style$');
@@ -108,6 +110,7 @@ class MixWidgetGenerator extends GeneratorForAnnotation<MixWidget> {
   MixWidgetModel _modelForVariable(
     TopLevelVariableElement variable,
     ConstantReader annotation,
+    _WidgetParameterSelection widgetParameters,
   ) {
     final variableName = requireName(
       variable,
@@ -122,11 +125,12 @@ class MixWidgetGenerator extends GeneratorForAnnotation<MixWidget> {
       library: library,
     );
     _requireUnprefixedFlutterSymbols(variable, callMethod, library);
-    final call = extractCallParams(
+    final call = _extractWidgetCallParams(
       callMethod,
       anchor: variable,
       library: library,
       factoryReference: variableName,
+      widgetParameters: widgetParameters,
     );
 
     return MixWidgetModel(
@@ -149,6 +153,7 @@ class MixWidgetGenerator extends GeneratorForAnnotation<MixWidget> {
   MixWidgetModel _modelForFunction(
     TopLevelFunctionElement function,
     ConstantReader annotation,
+    _WidgetParameterSelection widgetParameters,
   ) {
     final functionName = requireName(
       function,
@@ -178,11 +183,12 @@ class MixWidgetGenerator extends GeneratorForAnnotation<MixWidget> {
       library: library,
       factoryReference: functionName,
     );
-    final call = extractCallParams(
+    final call = _extractWidgetCallParams(
       callMethod,
       anchor: function,
       library: library,
       factoryReference: functionName,
+      widgetParameters: widgetParameters,
     );
 
     _rejectCollisions(function, factoryParams, call.params);
@@ -319,8 +325,7 @@ class MixWidgetGenerator extends GeneratorForAnnotation<MixWidget> {
   }
 
   /// Looks up the styler's `call()` method (including inherited members) and
-  /// validates the contract: returns a `Widget`-assignable type, no optional
-  /// positional parameters.
+  /// validates that it returns a `Widget`-assignable type.
   MethodElement _requireCallMethod(
     Element anchor,
     InterfaceType stylerType, {
@@ -350,17 +355,118 @@ class MixWidgetGenerator extends GeneratorForAnnotation<MixWidget> {
       );
     }
 
-    final optionalPositional = optionalPositionalNames(call.formalParameters);
+    return call;
+  }
+
+  /// Reads the concrete annotation value into the two generator modes.
+  ///
+  /// The public annotation always supplies [MixWidget.widgetParameters], so
+  /// generation never treats a missing or null value as an implicit default.
+  _WidgetParameterSelection _widgetParameterSelectionFor(
+    ConstantReader annotation,
+  ) {
+    final selection = annotation.read('widgetParameters');
+    final names = {
+      for (final name in selection.read('names').setValue)
+        ConstantReader(name).stringValue,
+    };
+
+    return (includesAll: selection.read('includesAll').boolValue, names: names);
+  }
+
+  /// Selects and validates the non-key styler `call()` parameters exposed by
+  /// a generated widget.
+  ///
+  /// Excluded parameters are removed before optional-positional, reserved-name,
+  /// visibility, and collision validation. `key` remains automatic and is
+  /// therefore always validated, even in an empty `only` selection.
+  ({List<WidgetCallParam> params, bool forwardsKey}) _extractWidgetCallParams(
+    MethodElement callMethod, {
+    required Element anchor,
+    required LibraryElement library,
+    required String factoryReference,
+    required _WidgetParameterSelection widgetParameters,
+  }) {
+    final excludedNames = <String>{};
+
+    if (!widgetParameters.includesAll) {
+      final availableNames = {
+        for (final parameter in callMethod.formalParameters)
+          if (parameter.name case final String name) name,
+      };
+
+      for (final name in widgetParameters.names) {
+        if (name == 'key') {
+          fail(
+            anchor,
+            '$_annotationLabel widgetParameters must not select `key`; '
+            '`Key? key` is forwarded automatically.',
+            todo: 'Remove `key` from the selection.',
+          );
+        }
+
+        if (!availableNames.contains(name)) {
+          fail(
+            anchor,
+            '$_annotationLabel widgetParameters selects unknown styler '
+            '`call()` parameter `$name`.',
+            todo: 'Select a parameter declared by the styler `call()` method.',
+          );
+        }
+      }
+
+      for (final parameter in callMethod.formalParameters) {
+        final name = parameter.name;
+        if (name == 'key' ||
+            name == null ||
+            widgetParameters.names.contains(name)) {
+          continue;
+        }
+
+        if (parameter.isRequired) {
+          fail(
+            anchor,
+            '$_annotationLabel widgetParameters must include required styler '
+            '`call()` parameter `$name`.',
+            todo:
+                'Add `$name` to `widgetParameters: .only({...})` or use '
+                '`widgetParameters: .all()`.',
+          );
+        }
+
+        excludedNames.add(name);
+      }
+    }
+
+    final selectedParameters = [
+      for (final parameter in callMethod.formalParameters)
+        if (parameter.name == 'key' ||
+            parameter.name == null ||
+            !excludedNames.contains(parameter.name))
+          parameter,
+    ];
+
+    final optionalPositional = optionalPositionalNames(
+      selectedParameters.where((parameter) => parameter.name != 'key'),
+    );
     if (optionalPositional.isNotEmpty) {
       fail(
         anchor,
         '$_annotationLabel does not support optional positional `call()` '
-        'parameters on $stylerName: [${optionalPositional.join(', ')}].',
+        'parameters on '
+        '${callMethod.enclosingElement?.displayName ?? 'the styler'}: '
+        '[${optionalPositional.join(', ')}].',
         todo: 'Convert these parameters to required positional or named.',
       );
     }
 
-    return call;
+    return extractCallParams(
+      callMethod,
+      anchor: anchor,
+      library: library,
+      factoryReference: factoryReference,
+      excludeNames: excludedNames,
+    );
   }
 
   /// A generic `call<T extends Widget>()` reports its return as `T`; validate
@@ -634,9 +740,18 @@ class MixWidgetGenerator extends GeneratorForAnnotation<MixWidget> {
     ConstantReader annotation,
     BuildStep buildStep,
   ) {
+    final widgetParameters = _widgetParameterSelectionFor(annotation);
     final model = switch (element) {
-      TopLevelVariableElement v => _modelForVariable(v, annotation),
-      TopLevelFunctionElement f => _modelForFunction(f, annotation),
+      TopLevelVariableElement v => _modelForVariable(
+        v,
+        annotation,
+        widgetParameters,
+      ),
+      TopLevelFunctionElement f => _modelForFunction(
+        f,
+        annotation,
+        widgetParameters,
+      ),
       _ => fail(
         element,
         '$_annotationLabel can only be applied to top-level variables or '

--- a/packages/mix_generator/test/core/test_helpers.dart
+++ b/packages/mix_generator/test/core/test_helpers.dart
@@ -235,10 +235,25 @@ class MixableField {
   });
 }
 
+class MixWidgetParameterSelection {
+  final bool includesAll;
+  final Set<String> names;
+
+  const MixWidgetParameterSelection.all()
+    : includesAll = true,
+      names = const {};
+
+  const MixWidgetParameterSelection.only(this.names) : includesAll = false;
+}
+
 class MixWidget {
   final String? name;
+  final MixWidgetParameterSelection widgetParameters;
 
-  const MixWidget({this.name});
+  const MixWidget({
+    this.name,
+    this.widgetParameters = const MixWidgetParameterSelection.all(),
+  });
 }
 
 class MixableModifier {

--- a/packages/mix_generator/test/core/test_helpers.dart
+++ b/packages/mix_generator/test/core/test_helpers.dart
@@ -181,6 +181,22 @@ class Color {
 ''',
 };
 
+/// Stub matching `mix_annotations` 2.1.2, before `MixWidget` exposed
+/// `widgetParameters`. New generators must preserve the legacy `.all()`
+/// behavior when they encounter this annotation shape.
+const legacyMixWidgetAnnotationSources = {
+  'mix_annotations|lib/mix_annotations.dart': "export 'src/annotations.dart';",
+  'mix_annotations|lib/src/annotations.dart': r'''
+library annotations;
+
+class MixWidget {
+  final String? name;
+
+  const MixWidget({this.name});
+}
+''',
+};
+
 /// Stub `mix_annotations` library with the annotation classes and flag
 /// constants the generators read.
 const mixAnnotationsSources = {

--- a/packages/mix_generator/test/integration/generator_smoke_test.dart
+++ b/packages/mix_generator/test/integration/generator_smoke_test.dart
@@ -761,10 +761,56 @@ final cardStyle = const BoxStyler();
       },
     );
 
-    test(
-      'function-backed style: routes factory params back into the factory',
-      () async {
-        const source = r'''
+    test('explicit all selection preserves every call parameter', () async {
+      const source = r'''
+library widget_case;
+
+import 'package:flutter/widgets.dart';
+import 'package:mix_annotations/mix_annotations.dart';
+import 'package:mix/src/core/style.dart';
+
+part 'widget_case.g.dart';
+
+class BoxSpec { const BoxSpec(); }
+
+class BoxStyler extends Style<BoxSpec> {
+  const BoxStyler();
+  Widget call({Key? key, String? label, Widget? child}) => const _Stub();
+}
+
+class _Stub extends StatelessWidget {
+  const _Stub();
+  @override
+  Widget build(BuildContext context) => const _Stub();
+}
+
+@MixWidget(widgetParameters: .all())
+final allStyle = const BoxStyler();
+''';
+
+      await expectGeneratorOutputResolves(
+        builder: partBuilder(const MixWidgetGenerator()),
+        sources: {
+          ...mixAnnotationsSources,
+          ...widgetStub,
+          'mix|lib/src/core/style.dart': styleStub,
+          'mix_generator|lib/widget_case.dart': source,
+        },
+        inputAsset: 'mix_generator|lib/widget_case.dart',
+        outputAsset: 'mix_generator|lib/widget_case.g.dart',
+        outputMatcher: allOf([
+          contains('class All extends StatelessWidget'),
+          contains('final String? label;'),
+          contains('final Widget? child;'),
+          contains('key: this.key'),
+          contains('label: this.label'),
+          contains('child: this.child'),
+        ]),
+      );
+    });
+
+    test('empty only selection keeps automatic key forwarding', () async {
+      const source = r'''
 library widget_case;
 
 import 'package:flutter/widgets.dart';
@@ -786,8 +832,119 @@ class _Stub extends StatelessWidget {
   Widget build(BuildContext context) => const _Stub();
 }
 
-@MixWidget()
-BoxStyler badgeStyle({Color? color, BoxStyler? style}) => const BoxStyler();
+@MixWidget(widgetParameters: .only({}))
+final emptyStyle = const BoxStyler();
+''';
+
+      await expectGeneratorOutputResolves(
+        builder: partBuilder(const MixWidgetGenerator()),
+        sources: {
+          ...mixAnnotationsSources,
+          ...widgetStub,
+          'mix|lib/src/core/style.dart': styleStub,
+          'mix_generator|lib/widget_case.dart': source,
+        },
+        inputAsset: 'mix_generator|lib/widget_case.dart',
+        outputAsset: 'mix_generator|lib/widget_case.g.dart',
+        outputMatcher: allOf([
+          contains('class Empty extends StatelessWidget'),
+          contains('const Empty({super.key});'),
+          contains('return emptyStyle.call(key: this.key);'),
+          isNot(contains('final Widget? child;')),
+          isNot(contains('child: this.child')),
+        ]),
+      );
+    });
+
+    test(
+      'only selection filters optional, reserved, and invisible call parameters',
+      () async {
+        const host = r'''
+library widget_case;
+
+import 'package:flutter/widgets.dart';
+import 'package:mix_annotations/mix_annotations.dart';
+import 'external_styler.dart';
+
+part 'widget_case.g.dart';
+
+@MixWidget(widgetParameters: .only({'child'}))
+final externalStyle = const ExternalStyler();
+''';
+        const externalStyler = r'''
+import 'package:flutter/widgets.dart';
+import 'package:mix/src/core/style.dart';
+
+class ExternalSpec { const ExternalSpec(); }
+class _Hidden {}
+
+class ExternalStyler extends Style<ExternalSpec> {
+  const ExternalStyler();
+
+  Widget call(
+    Widget child,
+    [String? optional, _Hidden? hidden, String? build],
+  ) => const _Stub();
+}
+
+class _Stub extends StatelessWidget {
+  const _Stub();
+  @override
+  Widget build(BuildContext context) => const _Stub();
+}
+''';
+
+        await expectGeneratorOutputResolves(
+          builder: partBuilder(const MixWidgetGenerator()),
+          sources: {
+            ...mixAnnotationsSources,
+            ...widgetStub,
+            'mix|lib/src/core/style.dart': styleStub,
+            'mix_generator|lib/external_styler.dart': externalStyler,
+            'mix_generator|lib/widget_case.dart': host,
+          },
+          inputAsset: 'mix_generator|lib/widget_case.dart',
+          outputAsset: 'mix_generator|lib/widget_case.g.dart',
+          outputMatcher: allOf([
+            contains('class External extends StatelessWidget'),
+            contains('final Widget child;'),
+            contains('return externalStyle.call(this.child);'),
+            isNot(contains('optional')),
+            isNot(contains('hidden')),
+            isNot(contains('final String? build;')),
+          ]),
+        );
+      },
+    );
+
+    test(
+      'function-backed style: routes factory params back into the factory',
+      () async {
+        const source = r'''
+library widget_case;
+
+import 'package:flutter/widgets.dart';
+import 'package:mix_annotations/mix_annotations.dart';
+import 'package:mix/src/core/style.dart';
+
+part 'widget_case.g.dart';
+
+class BoxSpec { const BoxSpec(); }
+
+class BoxStyler extends Style<BoxSpec> {
+  const BoxStyler();
+  Widget call({Key? key, String? label, Widget? child}) => const _Stub();
+}
+
+class _Stub extends StatelessWidget {
+  const _Stub();
+  @override
+  Widget build(BuildContext context) => const _Stub();
+}
+
+@MixWidget(widgetParameters: .only({'label'}))
+BoxStyler badgeStyle({String? child, Color? color, BoxStyler? style}) =>
+    const BoxStyler();
 ''';
 
         await expectGeneratorOutputResolves(
@@ -802,12 +959,16 @@ BoxStyler badgeStyle({Color? color, BoxStyler? style}) => const BoxStyler();
           outputAsset: 'mix_generator|lib/widget_case.g.dart',
           outputMatcher: allOf([
             contains('class Badge extends StatelessWidget'),
+            contains('final String? child;'),
             contains('final Color? color;'),
             contains('final BoxStyler? style;'),
-            contains('final Widget? child;'),
+            contains('final String? label;'),
+            isNot(contains('final Widget? child;')),
             contains('return badgeStyle('),
+            contains('child: this.child'),
             contains('color: this.color'),
             contains('style: this.style'),
+            contains('label: this.label'),
           ]),
         );
       },
@@ -883,7 +1044,7 @@ class BaseStyler<T> extends Style<BoxSpec> {
   Widget call({
     Key? key,
     required T value,
-    required List<T> values,
+    T? fallback,
   }) => const _Stub();
 }
 
@@ -897,7 +1058,7 @@ class _Stub extends StatelessWidget {
   Widget build(BuildContext context) => const _Stub();
 }
 
-@MixWidget()
+@MixWidget(widgetParameters: .only({'value'}))
 final inheritedStyle = const StringStyler();
 ''';
 
@@ -914,9 +1075,8 @@ final inheritedStyle = const StringStyler();
         outputMatcher: allOf([
           contains('class Inherited extends StatelessWidget'),
           contains('final String value;'),
-          contains('final List<String> values;'),
+          isNot(contains('fallback')),
           isNot(contains('final T value;')),
-          isNot(contains('final List<T> values;')),
         ]),
       );
     });

--- a/packages/mix_generator/test/integration/generator_smoke_test.dart
+++ b/packages/mix_generator/test/integration/generator_smoke_test.dart
@@ -761,6 +761,54 @@ final cardStyle = const BoxStyler();
       },
     );
 
+    test('legacy MixWidget annotation defaults to all parameters', () async {
+      const source = r'''
+library widget_case;
+
+import 'package:flutter/widgets.dart';
+import 'package:mix_annotations/mix_annotations.dart';
+import 'package:mix/src/core/style.dart';
+
+part 'widget_case.g.dart';
+
+class BoxSpec { const BoxSpec(); }
+
+class BoxStyler extends Style<BoxSpec> {
+  const BoxStyler();
+  Widget call({Key? key, String? label, Widget? child}) => const _Stub();
+}
+
+class _Stub extends StatelessWidget {
+  const _Stub();
+  @override
+  Widget build(BuildContext context) => const _Stub();
+}
+
+@MixWidget()
+final legacyStyle = const BoxStyler();
+''';
+
+      await expectGeneratorOutputResolves(
+        builder: partBuilder(const MixWidgetGenerator()),
+        sources: {
+          ...legacyMixWidgetAnnotationSources,
+          ...widgetStub,
+          'mix|lib/src/core/style.dart': styleStub,
+          'mix_generator|lib/widget_case.dart': source,
+        },
+        inputAsset: 'mix_generator|lib/widget_case.dart',
+        outputAsset: 'mix_generator|lib/widget_case.g.dart',
+        outputMatcher: allOf([
+          contains('class Legacy extends StatelessWidget'),
+          contains('final String? label;'),
+          contains('final Widget? child;'),
+          contains('key: this.key'),
+          contains('label: this.label'),
+          contains('child: this.child'),
+        ]),
+      );
+    });
+
     test('explicit all selection preserves every call parameter', () async {
       const source = r'''
 library widget_case;
@@ -1026,7 +1074,66 @@ final genericStyle = const GenericStyler<String>();
       );
     });
 
-    test('inherited generic call params use concrete type arguments', () async {
+    test(
+      'inherited generic call params preserve nested concrete types',
+      () async {
+        const source = r'''
+library widget_case;
+
+import 'package:flutter/widgets.dart';
+import 'package:mix_annotations/mix_annotations.dart';
+import 'package:mix/src/core/style.dart';
+
+part 'widget_case.g.dart';
+
+class BoxSpec { const BoxSpec(); }
+
+class BaseStyler<T> extends Style<BoxSpec> {
+  const BaseStyler();
+
+  Widget call({
+    Key? key,
+    required T value,
+    required List<T> values,
+  }) => const _Stub();
+}
+
+class StringStyler extends BaseStyler<String> {
+  const StringStyler();
+}
+
+class _Stub extends StatelessWidget {
+  const _Stub();
+  @override
+  Widget build(BuildContext context) => const _Stub();
+}
+
+@MixWidget()
+final inheritedStyle = const StringStyler();
+''';
+
+        await expectGeneratorOutputResolves(
+          builder: partBuilder(const MixWidgetGenerator()),
+          sources: {
+            ...mixAnnotationsSources,
+            ...widgetStub,
+            'mix|lib/src/core/style.dart': styleStub,
+            'mix_generator|lib/widget_case.dart': source,
+          },
+          inputAsset: 'mix_generator|lib/widget_case.dart',
+          outputAsset: 'mix_generator|lib/widget_case.g.dart',
+          outputMatcher: allOf([
+            contains('class Inherited extends StatelessWidget'),
+            contains('final String value;'),
+            contains('final List<String> values;'),
+            isNot(contains('final T value;')),
+            isNot(contains('final List<T> values;')),
+          ]),
+        );
+      },
+    );
+
+    test('only selection curates inherited generic call params', () async {
       const source = r'''
 library widget_case;
 
@@ -1077,6 +1184,56 @@ final inheritedStyle = const StringStyler();
           contains('final String value;'),
           isNot(contains('fallback')),
           isNot(contains('final T value;')),
+        ]),
+      );
+    });
+
+    test('only selection keeps method type parameters automatic', () async {
+      const source = r'''
+library widget_case;
+
+import 'package:flutter/widgets.dart';
+import 'package:mix_annotations/mix_annotations.dart';
+import 'package:mix/src/core/style.dart';
+
+part 'widget_case.g.dart';
+
+class BoxSpec { const BoxSpec(); }
+
+class GenericCallStyler extends Style<BoxSpec> {
+  const GenericCallStyler();
+
+  Widget call<T>({Key? key, T? value, Widget? child}) => const _Stub();
+}
+
+class _Stub extends StatelessWidget {
+  const _Stub();
+  @override
+  Widget build(BuildContext context) => const _Stub();
+}
+
+@MixWidget(widgetParameters: .only({'child'}))
+final genericCallStyle = const GenericCallStyler();
+''';
+
+      await expectGeneratorOutputResolves(
+        builder: partBuilder(const MixWidgetGenerator()),
+        sources: {
+          ...mixAnnotationsSources,
+          ...widgetStub,
+          'mix|lib/src/core/style.dart': styleStub,
+          'mix_generator|lib/widget_case.dart': source,
+        },
+        inputAsset: 'mix_generator|lib/widget_case.dart',
+        outputAsset: 'mix_generator|lib/widget_case.g.dart',
+        outputMatcher: allOf([
+          contains('class GenericCall<T> extends StatelessWidget'),
+          contains('final Widget? child;'),
+          isNot(contains('final T? value;')),
+          contains('return genericCallStyle.call<T>('),
+          contains('key: this.key'),
+          contains('child: this.child'),
+          isNot(contains('value: this.value')),
         ]),
       );
     });

--- a/packages/mix_generator/test/integration/generator_validation_test.dart
+++ b/packages/mix_generator/test/integration/generator_validation_test.dart
@@ -222,6 +222,167 @@ final brokenStyle = const BadStyler();
       },
     );
 
+    test('MixWidgetGenerator rejects unknown selected call params', () async {
+      const libSource = r'''
+library widget_validation;
+
+import 'package:flutter/widgets.dart';
+import 'package:mix_annotations/mix_annotations.dart';
+import 'package:mix/src/core/style.dart';
+
+class BoxSpec { const BoxSpec(); }
+
+class BoxStyler extends Style<BoxSpec> {
+  const BoxStyler();
+  Widget call({Key? key, Widget? child}) => const _S();
+}
+
+class _S extends StatelessWidget {
+  const _S();
+  @override
+  Widget build(BuildContext context) => const _S();
+}
+
+@MixWidget(widgetParameters: .only({'missing'}))
+final brokenStyle = const BoxStyler();
+''';
+
+      final errors = await _expectMixWidgetValidationError(libSource);
+
+      expect(errors, contains('selects unknown'));
+      expect(errors, contains('`missing`'));
+    });
+
+    test('MixWidgetGenerator rejects selecting automatic key', () async {
+      const libSource = r'''
+library widget_validation;
+
+import 'package:flutter/widgets.dart';
+import 'package:mix_annotations/mix_annotations.dart';
+import 'package:mix/src/core/style.dart';
+
+class BoxSpec { const BoxSpec(); }
+
+class BoxStyler extends Style<BoxSpec> {
+  const BoxStyler();
+  Widget call({Key? key, Widget? child}) => const _S();
+}
+
+class _S extends StatelessWidget {
+  const _S();
+  @override
+  Widget build(BuildContext context) => const _S();
+}
+
+@MixWidget(widgetParameters: .only({'key'}))
+final brokenStyle = const BoxStyler();
+''';
+
+      final errors = await _expectMixWidgetValidationError(libSource);
+
+      expect(errors, contains('must not select `key`'));
+      expect(errors, contains('automatically'));
+    });
+
+    test(
+      'MixWidgetGenerator rejects omitting required named call params',
+      () async {
+        const libSource = r'''
+library widget_validation;
+
+import 'package:flutter/widgets.dart';
+import 'package:mix_annotations/mix_annotations.dart';
+import 'package:mix/src/core/style.dart';
+
+class BoxSpec { const BoxSpec(); }
+
+class BoxStyler extends Style<BoxSpec> {
+  const BoxStyler();
+  Widget call({Key? key, required Widget child, String? label}) => const _S();
+}
+
+class _S extends StatelessWidget {
+  const _S();
+  @override
+  Widget build(BuildContext context) => const _S();
+}
+
+@MixWidget(widgetParameters: .only({'label'}))
+final brokenStyle = const BoxStyler();
+''';
+
+        final errors = await _expectMixWidgetValidationError(libSource);
+
+        expect(errors, contains('must include required'));
+        expect(errors, contains('`child`'));
+      },
+    );
+
+    test(
+      'MixWidgetGenerator rejects omitting required positional call params',
+      () async {
+        const libSource = r'''
+library widget_validation;
+
+import 'package:flutter/widgets.dart';
+import 'package:mix_annotations/mix_annotations.dart';
+import 'package:mix/src/core/style.dart';
+
+class BoxSpec { const BoxSpec(); }
+
+class BoxStyler extends Style<BoxSpec> {
+  const BoxStyler();
+  Widget call(Widget child, {Key? key, String? label}) => const _S();
+}
+
+class _S extends StatelessWidget {
+  const _S();
+  @override
+  Widget build(BuildContext context) => const _S();
+}
+
+@MixWidget(widgetParameters: .only({'label'}))
+final brokenStyle = const BoxStyler();
+''';
+
+        final errors = await _expectMixWidgetValidationError(libSource);
+
+        expect(errors, contains('must include required'));
+        expect(errors, contains('`child`'));
+      },
+    );
+
+    test('MixWidgetGenerator validates key in only mode', () async {
+      const libSource = r'''
+library widget_validation;
+
+import 'package:flutter/widgets.dart';
+import 'package:mix_annotations/mix_annotations.dart';
+import 'package:mix/src/core/style.dart';
+
+class BoxSpec { const BoxSpec(); }
+
+class BoxStyler extends Style<BoxSpec> {
+  const BoxStyler();
+  Widget call({String? key, Widget? child}) => const _S();
+}
+
+class _S extends StatelessWidget {
+  const _S();
+  @override
+  Widget build(BuildContext context) => const _S();
+}
+
+@MixWidget(widgetParameters: .only({'child'}))
+final brokenStyle = const BoxStyler();
+''';
+
+      final errors = await _expectMixWidgetValidationError(libSource);
+
+      expect(errors, contains('only forwards a `key` parameter'));
+      expect(errors, contains('must use the exact `Key` type'));
+    });
+
     test(
       'MixWidgetGenerator rejects generic call returns with non-widget bounds',
       () async {

--- a/packages/mix_generator/test/integration/generator_validation_test.dart
+++ b/packages/mix_generator/test/integration/generator_validation_test.dart
@@ -217,7 +217,47 @@ final brokenStyle = const BadStyler();
 
         expect(
           errors,
-          contains('does not support optional positional `call()` parameters'),
+          contains(
+            'does not support selected optional positional `call()` parameters',
+          ),
+        );
+      },
+    );
+
+    test(
+      'MixWidgetGenerator rejects selected optional positional call params',
+      () async {
+        const libSource = r'''
+library widget_validation;
+
+import 'package:flutter/widgets.dart';
+import 'package:mix_annotations/mix_annotations.dart';
+import 'package:mix/src/core/style.dart';
+
+class BoxSpec { const BoxSpec(); }
+
+class BadStyler extends Style<BoxSpec> {
+  const BadStyler();
+  Widget call([Widget? child]) => const _S();
+}
+
+class _S extends StatelessWidget {
+  const _S();
+  @override
+  Widget build(BuildContext context) => const _S();
+}
+
+@MixWidget(widgetParameters: .only({'child'}))
+final brokenStyle = const BadStyler();
+''';
+
+        final errors = await _expectMixWidgetValidationError(libSource);
+
+        expect(
+          errors,
+          contains(
+            'does not support selected optional positional `call()` parameters',
+          ),
         );
       },
     );
@@ -382,6 +422,112 @@ final brokenStyle = const BoxStyler();
       expect(errors, contains('only forwards a `key` parameter'));
       expect(errors, contains('must use the exact `Key` type'));
     });
+
+    test('MixWidgetGenerator rejects selected reserved call params', () async {
+      const libSource = r'''
+library widget_validation;
+
+import 'package:flutter/widgets.dart';
+import 'package:mix_annotations/mix_annotations.dart';
+import 'package:mix/src/core/style.dart';
+
+class BoxSpec { const BoxSpec(); }
+
+class BoxStyler extends Style<BoxSpec> {
+  const BoxStyler();
+  Widget call({Widget? build}) => const _S();
+}
+
+class _S extends StatelessWidget {
+  const _S();
+  @override
+  Widget build(BuildContext context) => const _S();
+}
+
+@MixWidget(widgetParameters: .only({'build'}))
+final brokenStyle = const BoxStyler();
+''';
+
+      final errors = await _expectMixWidgetValidationError(libSource);
+
+      expect(errors, contains('reserves the parameter name `build`'));
+    });
+
+    test(
+      'MixWidgetGenerator rejects selected invisible call param types',
+      () async {
+        const libSource = r'''
+library widget_validation;
+
+import 'package:flutter/widgets.dart';
+import 'package:mix_annotations/mix_annotations.dart';
+import 'external_styler.dart';
+
+@MixWidget(widgetParameters: .only({'hidden'}))
+final brokenStyle = const ExternalStyler();
+''';
+
+        final errors = await _expectMixWidgetValidationError(
+          libSource,
+          extraSources: {
+            'mix_generator|lib/external_styler.dart': r'''
+import 'package:flutter/widgets.dart';
+import 'package:mix/src/core/style.dart';
+
+class ExternalSpec { const ExternalSpec(); }
+class _Hidden {}
+
+class ExternalStyler extends Style<ExternalSpec> {
+  const ExternalStyler();
+  Widget call({_Hidden? hidden}) => const _S();
+}
+
+class _S extends StatelessWidget {
+  const _S();
+  @override
+  Widget build(BuildContext context) => const _S();
+}
+''',
+          },
+        );
+
+        expect(errors, contains('Parameter `hidden` uses type `_Hidden`'));
+        expect(errors, contains('not visible from the annotated library'));
+      },
+    );
+
+    test(
+      'MixWidgetGenerator rejects selected factory/call name collisions',
+      () async {
+        const libSource = r'''
+library widget_validation;
+
+import 'package:flutter/widgets.dart';
+import 'package:mix_annotations/mix_annotations.dart';
+import 'package:mix/src/core/style.dart';
+
+class BoxSpec { const BoxSpec(); }
+
+class BoxStyler extends Style<BoxSpec> {
+  const BoxStyler();
+  Widget call({Widget? child}) => const _S();
+}
+
+class _S extends StatelessWidget {
+  const _S();
+  @override
+  Widget build(BuildContext context) => const _S();
+}
+
+@MixWidget(widgetParameters: .only({'child'}))
+BoxStyler brokenStyle({String? child}) => const BoxStyler();
+''';
+
+        final errors = await _expectMixWidgetValidationError(libSource);
+
+        expect(errors, contains('parameter name collision: `child`'));
+      },
+    );
 
     test(
       'MixWidgetGenerator rejects generic call returns with non-widget bounds',

--- a/packages/mix_generator/test/integration/mix_widget_variant_constructor_test.dart
+++ b/packages/mix_generator/test/integration/mix_widget_variant_constructor_test.dart
@@ -142,6 +142,38 @@ ButtonStyler buttonStyle({
       },
     );
 
+    test(
+      'curates call parameters in unnamed and variant constructors',
+      () async {
+        const factory = r'''
+enum ButtonVariant { solid, ghost }
+
+@MixWidget(widgetParameters: .only({'label'}))
+ButtonStyler buttonStyle({
+  ButtonVariant variant = ButtonVariant.solid,
+  int size = 2,
+}) => const ButtonStyler();
+''';
+
+        await expectGeneratorOutputResolves(
+          builder: partBuilder(const MixWidgetGenerator()),
+          sources: _sources(factory),
+          inputAsset: 'mix_generator|lib/widget_case.dart',
+          outputAsset: 'mix_generator|lib/widget_case.g.dart',
+          outputMatcher: allOf([
+            contains('this.variant = ButtonVariant.solid'),
+            contains('this.size = 2'),
+            contains('required this.label'),
+            contains('const Button.solid('),
+            contains('const Button.ghost('),
+            isNot(contains('final Widget? child;')),
+            isNot(contains('child: this.child')),
+            contains('label: this.label'),
+          ]),
+        );
+      },
+    );
+
     test('required named enum variants also trigger', () async {
       const factory = r'''
 enum ButtonVariant { solid }


### PR DESCRIPTION
## Summary

Adds an opt-in curated widget API for `@MixWidget`, allowing design systems to expose only the supported parameters from a styler `call()` method.

## What changed

- Adds `MixWidgetParameterSelection`, with `.all()` as the default and `.only({...})` for an explicit allowlist.
- Keeps factory parameters and a valid `Key? key` automatic.
- Fails generation for unknown names, explicitly selected `key`, and omitted required call parameters.
- Preserves generic calls and enum-derived variant constructors with the curated surface.

## Examples

Default behavior remains unchanged:

```dart
@MixWidget() // Equivalent to widgetParameters: .all()
final cardStyle = BoxStyler();
```

Expose a stable subset:

```dart
@MixWidget(
  widgetParameters: .only({'controller', 'focusNode', 'onChanged'}),
)
final editorStyle = EditorStyler();
```

## Validation

- `fvm dart test` in `packages/mix_annotations`
- `fvm dart test` in `packages/mix_generator`
- `fvm dart run build_runner build --delete-conflicting-outputs` in `packages/mix_generator`

## Issues

- Closes #973