### PR TITLE
chore: release mix_generator 2.1.3 and mix_annotations 2.1.3

### DIFF
--- a/packages/mix_annotations/CHANGELOG.md
+++ b/packages/mix_annotations/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 2.1.3
 
  - **FEAT**: Add `MixWidgetParameterSelection` and the
    `MixWidget.widgetParameters` default. `@MixWidget()` now concretely carries

--- a/packages/mix_annotations/pubspec.yaml
+++ b/packages/mix_annotations/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mix_annotations
 description: Annotations for mix and mix_generator
-version: 2.1.2
+version: 2.1.3
 repository: https://github.com/btwld/mix/tree/main/packages/mix_annotations
 
 environment:

--- a/packages/mix_generator/CHANGELOG.md
+++ b/packages/mix_generator/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 2.1.3
 
  - **FEAT**: Support `@MixWidget(widgetParameters: .only({...}))` for a stable,
    curated generated widget value-parameter API. Factory parameters, valid

--- a/packages/mix_generator/pubspec.yaml
+++ b/packages/mix_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mix_generator
 description: A code generator for Mix, an expressive way to effortlessly build design systems in Flutter.
-version: 2.1.2
+version: 2.1.3
 homepage: https://github.com/btwld/mix
 repository: https://github.com/btwld/mix/tree/main/packages/mix_generator
 


### PR DESCRIPTION
## Summary

- release mix_annotations 2.1.3
- release mix_generator 2.1.3
- publish curated @MixWidget parameter selection support

## Verification

- fvm dart test (mix_annotations): 9 passed
- fvm dart test (mix_generator): 320 passed
- fvm dart pub publish --dry-run (both packages): 0 warnings