### PR TITLE
refactor(mix): reduce style pipeline overhead

### DIFF
--- a/packages/mix/lib/src/animation/style_animation_builder.dart
+++ b/packages/mix/lib/src/animation/style_animation_builder.dart
@@ -32,17 +32,20 @@ class StyleAnimationBuilder<S extends Spec<S>> extends StatefulWidget {
 class _StyleAnimationBuilderState<S extends Spec<S>>
     extends State<StyleAnimationBuilder<S>>
     with TickerProviderStateMixin {
-  late StyleAnimationDriver<S> animationDriver;
+  StyleAnimationDriver<S>? _animationDriver;
 
   @override
   void initState() {
     super.initState();
     final spec = widget.spec;
     final config = spec.animation;
-    animationDriver = _createAnimationDriver(config: config, initialSpec: spec);
+    _animationDriver = _createAnimationDriver(
+      config: config,
+      initialSpec: spec,
+    );
   }
 
-  StyleAnimationDriver<S> _createAnimationDriver({
+  StyleAnimationDriver<S>? _createAnimationDriver({
     required AnimationConfig? config,
     required StyleSpec<S> initialSpec,
   }) {
@@ -73,14 +76,13 @@ class _StyleAnimationBuilderState<S extends Spec<S>>
         initialSpec: initialSpec,
         context: context,
       ),
-      // ignore: avoid-undisposed-instances
-      null => NoAnimationDriver(vsync: this, initialSpec: initialSpec),
+      null => null,
     };
   }
 
   @override
   void dispose() {
-    animationDriver.dispose();
+    _animationDriver?.dispose();
     super.dispose();
   }
 
@@ -92,22 +94,27 @@ class _StyleAnimationBuilderState<S extends Spec<S>>
     final oldConfig = oldWidget.spec.animation;
 
     if ((oldConfig.runtimeType == config.runtimeType) && config != null) {
-      animationDriver.updateDriver(config);
+      _animationDriver!.updateDriver(config);
     } else {
-      animationDriver.dispose();
-      animationDriver = _createAnimationDriver(
+      _animationDriver?.dispose();
+      _animationDriver = _createAnimationDriver(
         config: config ?? oldConfig,
         initialSpec: oldWidget.spec,
       );
     }
 
     if (oldWidget.spec != widget.spec) {
-      animationDriver.didUpdateSpec(oldWidget.spec, widget.spec);
+      _animationDriver?.didUpdateSpec(oldWidget.spec, widget.spec);
     }
   }
 
   @override
   Widget build(BuildContext context) {
+    final animationDriver = _animationDriver;
+    if (animationDriver == null) {
+      return widget.builder(context, widget.spec);
+    }
+
     return AnimatedBuilder(
       animation: animationDriver.animation,
       builder: (context, child) {

--- a/packages/mix/lib/src/core/providers/widget_state_provider.dart
+++ b/packages/mix/lib/src/core/providers/widget_state_provider.dart
@@ -42,6 +42,14 @@ class WidgetStateProvider extends InheritedModel<WidgetState> {
     );
   }
 
+  /// Whether a [WidgetStateProvider] exists above [context].
+  ///
+  /// Unlike [of], this lookup does not register a dependency on any state
+  /// aspect.
+  static bool hasProvider(BuildContext context) {
+    return context.getInheritedWidgetOfExactType<WidgetStateProvider>() != null;
+  }
+
   /// Checks if a specific [WidgetState] is currently active.
   ///
   /// Returns false if no [WidgetStateProvider] is found in the widget tree.

--- a/packages/mix/lib/src/core/style.dart
+++ b/packages/mix/lib/src/core/style.dart
@@ -72,6 +72,24 @@ abstract class Style<S extends Spec<S>> extends Mix<StyleSpec<S>>
         .toSet();
   }
 
+  /// Whether this style reacts to a state produced by automatic pointer
+  /// tracking.
+  @internal
+  bool get needsPointerTracking {
+    final variants = $variants;
+    if (variants == null) return false;
+
+    for (final variantStyle in variants) {
+      final variant = variantStyle.variant;
+      if (variant is WidgetStateVariant &&
+          (variant.state == .hovered || variant.state == .pressed)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   /// Merges all active variants with their nested variants recursively.
   ///
   /// This method evaluates which variants should be active based on the current
@@ -88,8 +106,13 @@ abstract class Style<S extends Spec<S>> extends Mix<StyleSpec<S>>
     BuildContext context, {
     required Set<NamedVariant> namedVariants,
   }) {
+    final variants = $variants;
+    if (variants == null || variants.isEmpty) {
+      return this;
+    }
+
     // Filter variants that should be active in this context
-    final activeVariants = ($variants ?? [])
+    final activeVariants = variants
         .where(
           (variantAttr) => switch (variantAttr.variant) {
             (ContextVariant variant) => variant.when(context),

--- a/packages/mix/lib/src/core/style_builder.dart
+++ b/packages/mix/lib/src/core/style_builder.dart
@@ -46,45 +46,8 @@ class StyleBuilder<S extends Spec<S>> extends StatefulWidget {
   State<StyleBuilder<S>> createState() => _StyleBuilderState<S>();
 }
 
-class _StyleBuilderState<S extends Spec<S>> extends State<StyleBuilder<S>>
-    with TickerProviderStateMixin {
-  late WidgetStatesController _controller;
-
-  /// Tracks whether we created the controller internally (and thus own it)
-  bool _ownsController = false;
-
-  @override
-  void initState() {
-    super.initState();
-    _initController();
-  }
-
-  void _initController() {
-    if (widget.controller != null) {
-      _controller = widget.controller!;
-      _ownsController = false;
-    } else {
-      _controller = WidgetStatesController();
-      _ownsController = true;
-    }
-  }
-
-  void _handleControllerChange(StyleBuilder<S> oldWidget) {
-    // Dispose old internal controller if we owned it
-    if (_ownsController) {
-      _controller.dispose();
-    }
-
-    // Set up new controller
-    if (widget.controller != null) {
-      _controller = widget.controller!;
-      _ownsController = false;
-    } else {
-      // Create internal controller, preserving state from old external controller
-      _controller = WidgetStatesController(oldWidget.controller?.value ?? {});
-      _ownsController = true;
-    }
-  }
+class _StyleBuilderState<S extends Spec<S>> extends State<StyleBuilder<S>> {
+  WidgetStatesController? _preservedController;
 
   Style<S> _buildStyle(BuildContext context) {
     final inheritedStyle = Style.maybeOf<S>(context);
@@ -105,31 +68,28 @@ class _StyleBuilderState<S extends Spec<S>> extends State<StyleBuilder<S>>
   void didUpdateWidget(covariant StyleBuilder<S> oldWidget) {
     super.didUpdateWidget(oldWidget);
 
-    // Handle controller changes
-    if (oldWidget.controller != widget.controller) {
-      _handleControllerChange(oldWidget);
+    if (oldWidget.controller == widget.controller) return;
+
+    if (widget.controller != null) {
+      _preservedController?.dispose();
+      _preservedController = null;
+    } else {
+      _preservedController = WidgetStatesController(
+        oldWidget.controller?.value ?? {},
+      );
     }
   }
 
   @override
   void dispose() {
-    // Only dispose controllers we created internally
-    if (_ownsController) {
-      _controller.dispose();
-    }
-
+    _preservedController?.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
     final style = _buildStyle(context);
-
-    // Calculate interactivity need early
-    final needsToTrackWidgetState =
-        widget.controller == null && style.widgetStates.isNotEmpty;
-
-    final alreadyHasWidgetStateScope = WidgetStateProvider.of(context) != null;
+    final externalController = widget.controller;
 
     Widget current = Builder(
       builder: (context) {
@@ -142,14 +102,15 @@ class _StyleBuilderState<S extends Spec<S>> extends State<StyleBuilder<S>>
       },
     );
 
-    if (needsToTrackWidgetState && !alreadyHasWidgetStateScope) {
-      // If we need interactivity and no MixWidgetStateModel is present,
-      // wrap in MixInteractionDetector
-      current = MixInteractionDetector(controller: _controller, child: current);
-    } else if (widget.controller != null) {
-      // If we have an external controller, wrap with _ExternalControllerProvider
+    if (externalController != null) {
       current = _ExternalControllerProvider(
-        controller: _controller,
+        controller: externalController,
+        child: current,
+      );
+    } else if (style.needsPointerTracking &&
+        !WidgetStateProvider.hasProvider(context)) {
+      current = MixInteractionDetector(
+        controller: _preservedController,
         child: current,
       );
     }

--- a/packages/mix/test/src/core/style_builder_test.dart
+++ b/packages/mix/test/src/core/style_builder_test.dart
@@ -72,35 +72,49 @@ void main() {
         );
 
         // Verify that the animation wrapper is created
-        expect(find.byType(StyleAnimationBuilder<BoxSpec>), findsOneWidget);
+        final animationBuilder = find.byType(StyleAnimationBuilder<BoxSpec>);
+        expect(animationBuilder, findsOneWidget);
+        expect(
+          find.descendant(
+            of: animationBuilder,
+            matching: find.byType(AnimatedBuilder),
+          ),
+          findsOneWidget,
+        );
       });
 
-      testWidgets(
-        'Animation driver is still present when animation config is null',
-        (tester) async {
-          final boxAttribute = BoxStyler()
-              .width(100)
-              .height(200)
-              .color(Colors.blue);
+      testWidgets('Null animation bypasses the animated rebuild path', (
+        tester,
+      ) async {
+        final boxAttribute = BoxStyler()
+            .width(100)
+            .height(200)
+            .color(Colors.blue);
 
-          await tester.pumpWidget(
-            MaterialApp(
-              home: StyleBuilder<BoxSpec>(
-                style: boxAttribute,
-                builder: (context, spec) {
-                  return Container(
-                    decoration: spec.decoration,
-                    constraints: spec.constraints,
-                  );
-                },
-              ),
+        await tester.pumpWidget(
+          MaterialApp(
+            home: StyleBuilder<BoxSpec>(
+              style: boxAttribute,
+              builder: (context, spec) {
+                return Container(
+                  decoration: spec.decoration,
+                  constraints: spec.constraints,
+                );
+              },
             ),
-          );
+          ),
+        );
 
-          // StyleSpecBuilder always wraps with StyleAnimationBuilder.
-          expect(find.byType(StyleAnimationBuilder<BoxSpec>), findsOneWidget);
-        },
-      );
+        final animationBuilder = find.byType(StyleAnimationBuilder<BoxSpec>);
+        expect(animationBuilder, findsOneWidget);
+        expect(
+          find.descendant(
+            of: animationBuilder,
+            matching: find.byType(AnimatedBuilder),
+          ),
+          findsNothing,
+        );
+      });
 
       testWidgets(
         'Animation creates new animated build rather than interpolating between style changes',
@@ -839,6 +853,56 @@ void main() {
           );
         },
       );
+
+      testWidgets(
+        'preserves state from inherited pointer style when controller is removed',
+        (tester) async {
+          final externalController = WidgetStatesController({
+            WidgetState.hovered,
+          });
+          addTearDown(externalController.dispose);
+
+          WidgetStatesController? controller = externalController;
+          late void Function(VoidCallback) setState;
+
+          await tester.pumpWidget(
+            MaterialApp(
+              home: StyleProvider<BoxSpec>(
+                style: BoxStyler()
+                    .color(Colors.red)
+                    .onHovered(BoxStyler().color(Colors.blue)),
+                child: StatefulBuilder(
+                  builder: (context, stateSetter) {
+                    setState = stateSetter;
+                    return StyleBuilder<BoxSpec>(
+                      controller: controller,
+                      style: BoxStyler(),
+                      builder: (context, spec) {
+                        return Container(decoration: spec.decoration);
+                      },
+                    );
+                  },
+                ),
+              ),
+            ),
+          );
+
+          expect(
+            tester.widget<Container>(find.byType(Container)).decoration,
+            const BoxDecoration(color: Colors.blue),
+          );
+
+          setState(() {
+            controller = null;
+          });
+          await tester.pump();
+
+          expect(
+            tester.widget<Container>(find.byType(Container)).decoration,
+            const BoxDecoration(color: Colors.blue),
+          );
+        },
+      );
     });
 
     testWidgets(
@@ -864,6 +928,59 @@ void main() {
         expect(find.byType(MixInteractionDetector), findsNothing);
       },
     );
+
+    testWidgets(
+      'does not install pointer tracking for non-pointer widget states',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(
+          StyleBuilder<BoxSpec>(
+            style: BoxStyler().variant(
+              ContextVariant.widgetState(WidgetState.selected),
+              BoxStyler().color(Colors.blue),
+            ),
+            builder: (context, spec) => const SizedBox(),
+          ),
+        );
+
+        expect(find.byType(MixInteractionDetector), findsNothing);
+      },
+    );
+
+    testWidgets('only rebuilds for widget states declared by the style', (
+      WidgetTester tester,
+    ) async {
+      final controller = WidgetStatesController();
+      addTearDown(controller.dispose);
+      var styleBuilds = 0;
+
+      final styledChild = StyleBuilder<BoxSpec>(
+        style: BoxStyler().onPressed(BoxStyler().color(Colors.blue)),
+        builder: (context, spec) {
+          styleBuilds++;
+          return const SizedBox();
+        },
+      );
+
+      await tester.pumpWidget(
+        ListenableBuilder(
+          listenable: controller,
+          child: styledChild,
+          builder: (context, child) {
+            return WidgetStateProvider(states: controller.value, child: child!);
+          },
+        ),
+      );
+
+      expect(styleBuilds, 1);
+
+      controller.update(WidgetState.hovered, true);
+      await tester.pump();
+      expect(styleBuilds, 1);
+
+      controller.update(WidgetState.pressed, true);
+      await tester.pump();
+      expect(styleBuilds, 2);
+    });
 
     testWidgets('should update the Style when the controller is updated', (
       WidgetTester tester,


### PR DESCRIPTION
## Summary

- avoid subscribing a `StyleBuilder` to every widget-state aspect when it only needs to know whether a `WidgetStateProvider` exists
- bypass the no-op animation driver and `AnimatedBuilder` subtree when a style has no animation
- return immediately when a style declares no variants
- allocate pointer tracking and controller state lazily, and only for automatically produced hover/pressed states
- preserve controller state across external-to-internal transitions and cover the optimized paths with package-level regression tests

## Why

The rendering-pipeline investigation found several common paths doing work that could not affect output:

- the provider-presence check used a listening inherited-model lookup, so unrelated state changes could rebuild styles
- every `StyleBuilder` allocated a controller even when no interaction tracking was needed
- non-pointer widget-state variants installed a pointer detector/provider subtree that could never produce those states
- null-animation styles still created a no-animation driver and an `AnimatedBuilder`
- styles with no variants still entered filtering/list setup

The accepted changes remove that work without changing Mix's public styling API or legitimate animation and controller behavior. A package regression confirms that a hover update does not rebuild a pressed-only style, while a pressed update still rebuilds once.

The earlier combined workload measurement moved static Mix iterations by roughly 20–22 µs (about 4%, directional). That timing predates the final fresh-process protocol, so this PR treats it as characterization rather than a regression threshold; the stronger claim is the test-backed elimination of unnecessary dependencies, wrappers, controllers, and list work.

## What we discovered next

The investigation also identified larger headroom in variant processing:

- active-variant evaluation/merge is roughly 63–64% of realistic `Style.build` CPU
- generated property/spec resolution is roughly 30–33%
- two synchronous S2 state updates produce two controller notifications but coalesce into one Mix resolution/build; there is no duplicate pipeline computation

A fused variant-merge experiment made S0 21.5% faster and S0I 15.6% faster, but regressed S2 state transitions by 7.9% in 10/10 release pairs and also moved real-cadence profile results backward. A narrower fast path still regressed S2. Those experiments were reverted and are intentionally not part of this PR.

This leaves a clear follow-up target: optimize static variant evaluation or generated resolution without changing the already-efficient state-transition path.

## Validation

- `fvm dart run melos run gen:build`
- `fvm dart run melos run test:flutter --no-select` — 2,740 tests
- `fvm dart run melos run test:dart --no-select` — 320 generator tests and 37 linter tests
- `fvm dart run melos run analyze` — Dart and DCM analysis clean after bootstrapping the fresh worktree
- focused `StyleBuilder` and `StyleAnimationBuilder` suite — 33 tests
- `git diff --check`

## Scope

This is intentionally a code-only PR based directly on `main`: four Mix production files and one package test file. The separate benchmark harness and investigation documents are not included.