### PR TITLE
refactor(mix): optimize single-value prop resolution

### DIFF
--- a/packages/mix/lib/src/core/prop.dart
+++ b/packages/mix/lib/src/core/prop.dart
@@ -214,6 +214,13 @@ class Prop<V> {
       throw FlutterError('Prop<$V> has no sources');
     }
 
+    if (sources.length == 1) {
+      final source = sources.first;
+      if (source is ValueSource<V> && source.value is! Mix<V>) {
+        return PropOps.applyDirectives(source.value, $directives);
+      }
+    }
+
     // Resolve all sources to values
     final values = [];
     for (final source in sources) {

--- a/packages/mix/test/src/core/prop_test.dart
+++ b/packages/mix/test/src/core/prop_test.dart
@@ -42,6 +42,29 @@ void main() {
       expect(resolved, equals(42));
     });
 
+    test('applies directives after resolving a single direct source', () {
+      final prop = Prop.value(
+        21,
+      ).directives([MockDirective<int>('double', (value) => value * 2)]);
+
+      expect(prop.resolveProp(MockBuildContext()), 42);
+    });
+
+    test('resolves a Mix stored as a single direct source', () {
+      final mix = MockMix<Object>(42);
+      final prop = Prop.value<Object>(mix);
+
+      expect(prop.resolveProp(MockBuildContext()), 42);
+    });
+
+    test('resolves a Mix returned by a single token source', () {
+      final token = TestToken<Object>('mixed');
+      final prop = Prop.token(token);
+      final context = MockBuildContext(tokens: {token: MockMix<Object>(42)});
+
+      expect(prop.resolveProp(context), 42);
+    });
+
     test('merges value and token sources (universal accumulation)', () {
       final token = TestToken<int>('n');
       final p1 = Prop.value(1);


### PR DESCRIPTION
> [!IMPORTANT]
> **Depends on #976. Merge #976 first, then retarget this PR to `main`.**

## Summary

- return directly when a Prop contains one ordinary ValueSource
- preserve the existing path for tokens, MixSource, direct Mix values, nested styles, and multiple sources
- add regression coverage for directives and direct/token values that implement Mix

## Why

Generated styles commonly resolve properties with one direct value. The previous path still allocated a temporary values list, scanned it for Mix values, and selected the last element. The narrow fast path removes that accumulation work without changing the cases that require conversion, merging, token lookup, or nested style building.

## Performance evidence

Ten fresh-process, alternating-order release pairs with Flutter controls:

| Scenario | Adjusted change | Faster pairs |
| --- | ---: | ---: |
| S0 | -9.88% | 9/10 |
| S0I | -9.23% | 9/10 |
| S1 | -0.05% | 6/10 |
| S1I | +0.16% | 5/10 |
| S2 | -8.60% | 10/10 |

The directly affected static property-resolution stage improved 28.2%, and full static Style.build improved 12.4%. Two balanced profile pairs improved adjusted build time by 0.374 ms and total span by 710 us with zero budget misses. A separate 40-process release/AOT cadence campaign was frame-level neutral and recorded zero changed-Mix misses.

More general single-source implementations were rejected because they regressed profile cadence. This PR intentionally keeps the fast path limited to ordinary direct values.

## Verification

- repository generation completed with no unexpected generated diff
- full Flutter and Dart test suites passed
- Dart analyzer and fatal DCM analysis passed for all configured packages
- rendering-pipeline benchmark: 26 tests passed and analysis found no issues
- isolated branch: 88 focused Prop/token/nested-style tests passed and targeted analysis found no issues

## Stack

Draft follow-up to #976. The base is its code-only branch so this PR contains only the two-file Prop optimization diff. Retarget to main after #976 lands.