### PR TITLE
fix(mix): encode multi-source nested stylers

### DIFF
--- a/packages/mix_protocol/lib/src/schema/styler_codec_helpers.dart
+++ b/packages/mix_protocol/lib/src/schema/styler_codec_helpers.dart
@@ -1,8 +1,8 @@
 import 'package:ack/ack.dart';
 import 'package:mix/mix.dart';
 
+import '../errors/mix_protocol_error.dart';
 import 'animation_codec.dart';
-import 'common_codecs.dart';
 import 'modifier_codec.dart';
 import 'schema_field.dart';
 import 'variant_codec.dart';
@@ -67,14 +67,112 @@ Object? encodedNestedStylerField<
   encodeFields,
   required String fieldName,
 }) {
-  final styler = readProp<Styler, StyleSpec<SpecType>>(read(value), fieldName);
+  final styler = mergeNestedStyler<Styler, SpecType>(read(value), fieldName);
   if (styler != null) {
-    failIfPresent(styler.$variants, '$fieldName.variants');
-    failIfPresent(styler.$modifier, '$fieldName.modifiers');
-    failIfPresent(styler.$animation, '$fieldName.animation');
+    _failNestedMetadata(fieldName, 'variants', styler.$variants);
+    _failNestedMetadata(fieldName, 'modifiers', styler.$modifier);
+    _failNestedMetadata(fieldName, 'animation', styler.$animation);
   }
 
   return styler == null
       ? null
       : encodeFields(styler, includeStylerMetadata: false)[wire];
+}
+
+void _failNestedMetadata(String fieldName, String metadata, Object? value) {
+  if (value == null) return;
+
+  throw _unsupportedNestedStyler(
+    '$fieldName/$metadata',
+    value,
+    'Field "$fieldName.$metadata" is not representable by this schema.',
+  );
+}
+
+/// Builds a path-qualified diagnostic for an unrepresentable composite slot.
+///
+/// Composite slots (`box`/`flex`/`stack`) are read from the object-level encode
+/// callback, outside any Ack field codec, so a bare [UnsupportedEncodeValueError]
+/// would surface with an empty path — and, because the root styler schema is a
+/// union, without a specific path the sibling-branch "Expected ..." noise is not
+/// filtered. Emitting a [SchemaPathError] anchored at the slot both satisfies the
+/// path-qualified diagnostics contract and lets the root union collapse to this
+/// single error. The code stays [MixProtocolErrorCode.unsupportedEncodeValue].
+SchemaPathError _unsupportedNestedStyler(
+  String relativePath,
+  Object? value,
+  String reason,
+) {
+  return SchemaPathError(
+    code: MixProtocolErrorCode.unsupportedEncodeValue,
+    relativePath: '/$relativePath',
+    reason: reason,
+    value: value,
+  );
+}
+
+/// Collapses every compatible nested [Styler] source on [prop] into a single
+/// styler using Mix merge semantics, preserving source order.
+///
+/// Fluent chaining (`FlexBoxStyler().color(...).paddingAll(...)`) accumulates
+/// one nested [MixSource] per authoring call, so a normally-composed composite
+/// slot can carry several `BoxStyler`/`FlexStyler`/`StackStyler` sources.
+/// Merging here is what lets the per-field encoders emit the ordinary v1
+/// property grammar (including ordered `$merge` terms when two sources touch the
+/// same field) instead of rejecting representable styles. See issue #980.
+///
+/// Fails atomically — no partial output — for unsupported source kinds
+/// (tokens/raw values) or outer directives, each surfaced as a path-qualified
+/// diagnostic anchored at the composite slot (see [_unsupportedNestedStyler]).
+///
+/// Invoked once per wire field of the composite slot (the [encodedNestedStylerField]
+/// `read` callback fires per key), so the merge is intentionally re-derived each
+/// time rather than memoized — it is pure and bounded by small field/source
+/// counts, and the nested [encodeFields] it feeds was already recomputed per
+/// field before this change.
+Styler? mergeNestedStyler<
+  Styler extends Style<SpecType>,
+  SpecType extends Spec<SpecType>
+>(Prop<StyleSpec<SpecType>>? prop, String fieldName) {
+  if (prop == null) return null;
+  if (prop.$directives?.isNotEmpty == true) {
+    throw _unsupportedNestedStyler(
+      fieldName,
+      prop,
+      'Field "$fieldName" has directives and cannot be represented.',
+    );
+  }
+  if (prop.sources.isEmpty) {
+    throw _unsupportedNestedStyler(
+      fieldName,
+      prop,
+      'Field "$fieldName" has no value sources.',
+    );
+  }
+
+  Styler? merged;
+  for (final source in prop.sources) {
+    final styler = _nestedStylerSource<Styler, SpecType>(source, fieldName);
+    merged = merged == null ? styler : merged.merge(styler) as Styler;
+  }
+
+  return merged;
+}
+
+Styler _nestedStylerSource<
+  Styler extends Style<SpecType>,
+  SpecType extends Spec<SpecType>
+>(PropSource<StyleSpec<SpecType>> source, String fieldName) {
+  if (source is MixSource<StyleSpec<SpecType>> && source.mix is Styler) {
+    return source.mix as Styler;
+  }
+  if (source is ValueSource<StyleSpec<SpecType>> && source.value is Styler) {
+    return source.value as Styler;
+  }
+
+  throw _unsupportedNestedStyler(
+    fieldName,
+    source,
+    'Field "$fieldName" is ${source.runtimeType}; expected $Styler.',
+  );
 }

--- a/packages/mix_protocol/test/composite_multi_source_codec_test.dart
+++ b/packages/mix_protocol/test/composite_multi_source_codec_test.dart
@@ -1,0 +1,274 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mix/mix.dart';
+import 'package:mix_protocol/mix_protocol.dart';
+
+/// Regression coverage for issue #980: fluent chaining accumulates more than one
+/// nested [BoxStyler]/[FlexStyler]/[StackStyler] source on a composite slot
+/// (`$box`, `$flex`, `$stack`). Those styles must encode with the ordinary v1
+/// grammar — merging the sources and emitting `$merge` per-field where needed —
+/// instead of being rejected as "N sources; expected one".
+void main() {
+  final contract = mixProtocol;
+
+  JsonMap encode(Object styler) {
+    final result = contract.encodeStyle(styler);
+
+    return switch (result) {
+      MixProtocolSuccess<JsonMap>(:final value) => value,
+      MixProtocolFailure<JsonMap>(:final errors) => fail('$errors'),
+    };
+  }
+
+  List<MixProtocolError> encodeErrors(Object styler) {
+    final result = contract.encodeStyle(styler);
+
+    return switch (result) {
+      MixProtocolSuccess<JsonMap>() => fail('expected encode failure'),
+      MixProtocolFailure<JsonMap>(:final errors) => errors,
+    };
+  }
+
+  T decode<T extends Object>(JsonMap payload) {
+    final result = contract.decodeStyle<T>(payload);
+
+    return switch (result) {
+      MixProtocolSuccess<T>(:final value) => value,
+      MixProtocolFailure<T>(:final errors) => fail('$errors'),
+    };
+  }
+
+  group('fluent composites with multiple nested sources', () {
+    test('FlexBoxStyler multi-box-source chain encodes like its constructor', () {
+      // Two distinct box authoring calls (`color`, `paddingAll`) accumulate two
+      // BoxStyler sources on `$box`; `spacing` adds a FlexStyler source.
+      final fluent = FlexBoxStyler()
+          .color(const Color(0xFF112233))
+          .paddingAll(8)
+          .spacing(4);
+
+      final wire = encode(fluent);
+      expect(wire, {
+        'v': 1,
+        'type': 'flex_box',
+        'padding': 8.0,
+        'decoration': {'color': '#112233'},
+        'spacing': 4.0,
+      });
+
+      // The equivalent single-constructor style is a single source per slot and
+      // must produce byte-identical canonical wire.
+      final constructor = FlexBoxStyler(
+        decoration: BoxDecorationMix(color: const Color(0xFF112233)),
+        padding: EdgeInsetsGeometryMix.all(8),
+        spacing: 4,
+      );
+      expect(encode(constructor), wire);
+
+      // Strict decode then encode returns identical canonical JSON.
+      expect(encode(decode<FlexBoxStyler>(wire)), wire);
+    });
+
+    test('StackBoxStyler multi-source chain across box and stack encodes', () {
+      final fluent = StackBoxStyler()
+          .color(const Color(0xFF445566))
+          .paddingAll(6)
+          .stackAlignment(Alignment.center)
+          .fit(StackFit.expand);
+
+      final wire = encode(fluent);
+      expect(wire, {
+        'v': 1,
+        'type': 'stack_box',
+        'padding': 6.0,
+        'decoration': {'color': '#445566'},
+        'stackAlignment': 'center',
+        'fit': 'expand',
+      });
+
+      final constructor = StackBoxStyler(
+        decoration: BoxDecorationMix(color: const Color(0xFF445566)),
+        padding: EdgeInsetsGeometryMix.all(6),
+        stackAlignment: Alignment.center,
+        fit: StackFit.expand,
+      );
+      expect(encode(constructor), wire);
+      expect(encode(decode<StackBoxStyler>(wire)), wire);
+    });
+  });
+
+  group('merge order', () {
+    test('accumulating Mix sources on one field emit ordered \$merge', () {
+      // `paddingTop` then `paddingLeft` both target `$padding`, so the merged
+      // BoxStyler carries two ordered EdgeInsets sources.
+      final fluent = FlexBoxStyler().paddingTop(4).paddingLeft(8);
+
+      final wire = encode(fluent);
+      expect(wire, {
+        'v': 1,
+        'type': 'flex_box',
+        'padding': {
+          r'$merge': [
+            {'top': 4.0},
+            {'left': 8.0},
+          ],
+        },
+      });
+
+      // Order is preserved through a strict decode/re-encode cycle.
+      expect(encode(decode<FlexBoxStyler>(wire)), wire);
+    });
+
+    test('last-wins value sources on one field keep ordered \$merge', () {
+      final fluent = FlexBoxStyler()
+          .clipBehavior(Clip.hardEdge)
+          .clipBehavior(Clip.antiAlias);
+
+      final wire = encode(fluent);
+      expect(wire, {
+        'v': 1,
+        'type': 'flex_box',
+        'clipBehavior': {
+          r'$merge': ['hardEdge', 'antiAlias'],
+        },
+      });
+      expect(encode(decode<FlexBoxStyler>(wire)), wire);
+    });
+  });
+
+  group('token references across sources', () {
+    test('tokens spread over sources stay discoverable and encodable', () {
+      final fluent = FlexBoxStyler()
+          .color(const ColorToken('color.accent')())
+          .paddingAll(const SpaceToken('space.pad')())
+          .spacing(const SpaceToken('space.gap')());
+
+      final wire = encode(fluent);
+      expect(wire, {
+        'v': 1,
+        'type': 'flex_box',
+        'padding': {r'$token': 'space.pad', 'kind': 'space'},
+        'decoration': {
+          'color': {r'$token': 'color.accent'},
+        },
+        'spacing': {r'$token': 'space.gap', 'kind': 'space'},
+      });
+
+      final expectedRefs = {
+        const MixProtocolTokenReference('colors', 'color.accent'),
+        const MixProtocolTokenReference('spaces', 'space.pad'),
+        const MixProtocolTokenReference('spaces', 'space.gap'),
+      };
+      // Discoverable on the original multi-source style...
+      expect(tokenReferencesOf(fluent), expectedRefs);
+      // ...and on the decoded single-source style.
+      expect(tokenReferencesOf(decode<FlexBoxStyler>(wire)), expectedRefs);
+    });
+  });
+
+  group('resolution equivalence', () {
+    testWidgets('decoded style resolves to the same spec as the original', (
+      tester,
+    ) async {
+      final fluent = FlexBoxStyler()
+          .color(const Color(0xFF112233))
+          .paddingAll(8)
+          .paddingTop(2)
+          .spacing(4)
+          .mainAxisAlignment(MainAxisAlignment.spaceBetween);
+
+      final decoded = decode<FlexBoxStyler>(encode(fluent));
+
+      late final BuildContext context;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (ctx) {
+              context = ctx;
+
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+
+      expect(fluent.build(context).spec, decoded.build(context).spec);
+    });
+  });
+
+  group('atomic failure diagnostics', () {
+    test('nested metadata on any merged source fails with a slot path', () {
+      // Two box sources; the second carries a nested variant that the built-in
+      // schema cannot represent. Encoding must fail atomically with a single
+      // path-qualified diagnostic (no partial output, no sibling-branch noise).
+      final styler = FlexBoxStyler.create(
+        box: Prop.mix(BoxStyler(padding: EdgeInsetsMix.all(8))).mergeProp(
+          Prop.mix(
+            BoxStyler(
+              variants: [
+                VariantStyle(const NamedVariant('nested'), BoxStyler()),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      final error = encodeErrors(styler).single;
+      expect(error.code, MixProtocolErrorCode.unsupportedEncodeValue);
+      expect(error.path, '/box/variants');
+    });
+
+    test('flex slot metadata fails with the flex slot path', () {
+      final styler = FlexBoxStyler.create(
+        flex: Prop.mix(FlexStyler(spacing: 2)).mergeProp(
+          Prop.mix(
+            FlexStyler(
+              modifier: WidgetModifierConfig.modifiers([
+                OpacityModifierMix(opacity: 0.5),
+              ]),
+            ),
+          ),
+        ),
+      );
+
+      final error = encodeErrors(styler).single;
+      expect(error.code, MixProtocolErrorCode.unsupportedEncodeValue);
+      expect(error.path, '/flex/modifiers');
+    });
+
+    test('unsupported nested source kind fails with the slot path', () {
+      // A raw StyleSpec value source (not a Styler) is not representable.
+      final styler = FlexBoxStyler.create(
+        box: Prop.value<StyleSpec<BoxSpec>>(const StyleSpec(spec: BoxSpec())),
+      );
+
+      final error = encodeErrors(styler).single;
+      expect(error.code, MixProtocolErrorCode.unsupportedEncodeValue);
+      expect(error.path, '/box');
+    });
+  });
+
+  group('single-source compatibility', () {
+    test('single-source constructor composites are unchanged', () {
+      final styler = FlexBoxStyler(
+        padding: EdgeInsetsMix.all(8),
+        decoration: BoxDecorationMix(color: const Color(0xFF112233)),
+        direction: Axis.vertical,
+        spacing: 4,
+        flexClipBehavior: Clip.hardEdge,
+      );
+
+      final wire = encode(styler);
+      expect(wire, {
+        'v': 1,
+        'type': 'flex_box',
+        'padding': 8.0,
+        'decoration': {'color': '#112233'},
+        'direction': 'vertical',
+        'flexClipBehavior': 'hardEdge',
+        'spacing': 4.0,
+      });
+      expect(encode(decode<FlexBoxStyler>(wire)), wire);
+    });
+  });
+}


### PR DESCRIPTION
#### Related issue

Closes #980.

### Description

Allows mix_protocol to encode fluent composite styles with multiple nested styler sources while preserving source order, merge semantics, token references, and v1 wire compatibility.

### Changes

- Merge compatible BoxStyler, FlexStyler, and StackStyler sources before field encoding.
- Return path-qualified diagnostics for unsupported nested sources and metadata.
- Add regression coverage for round trips, merge ordering, token discovery, resolution equivalence, and compatibility.

**Review Checklist**

- [x] **Testing**: `melos run gen:build`, `melos run ci`, and `melos run analyze`.
- [x] **Breaking Changes**: No breaking changes.
- [x] **Documentation Updates**: No documentation changes required.
- [x] **Website Updates**: No website changes required.

### Additional Information (optional)

The change uses the existing v1 property grammar and does not require a protocol version bump.