### PR TITLE
feat(mix_generator): forward nested Styler factories

### DIFF
--- a/packages/mix_annotations/CHANGELOG.md
+++ b/packages/mix_annotations/CHANGELOG.md
@@ -8,6 +8,8 @@
  - **FEAT**: Add `MixableField.forwardStyler` and `stylerSurface` for opt-in
    projection of a nested generated Styler's canonical named-factory surface
    onto its parent Styler (#983).
+ - **DOCS**: Document the construction and fluent-method contract for a custom
+   `setterType` combined with `forwardStyler`.
 
 ## 2.1.2
 

--- a/packages/mix_annotations/CHANGELOG.md
+++ b/packages/mix_annotations/CHANGELOG.md
@@ -5,6 +5,9 @@
    `.all()`, while `.only({...})` supports opt-in curation of generated widget
    value parameters. Factory parameters, valid `Key? key`, and method-level
    type parameters remain automatic.
+ - **FEAT**: Add `MixableField.forwardStyler` and `stylerSurface` for opt-in
+   projection of a nested generated Styler's canonical named-factory surface
+   onto its parent Styler (#983).
 
 ## 2.1.2
 

--- a/packages/mix_annotations/README.md
+++ b/packages/mix_annotations/README.md
@@ -104,7 +104,20 @@ final Prop<Matrix4>? $transform;
 // Override the setter parameter type
 @MixableField(setterType: List<Shadow>)
 final Prop<List<Shadow>>? $shadows;
+
+// Forward canonical factories from a nested generated Styler.
+@MixableField(forwardStyler: true)
+final StyleSpec<BoxSpec>? container;
+
+// Restrict a FlexBox-backed field to the Box-generated Styler surface.
+@MixableField(forwardStyler: true, stylerSurface: BoxSpec)
+final StyleSpec<FlexBoxSpec>? restrictedContainer;
 ```
+
+`stylerSurface` references the source `@MixableSpec` type, not its generated
+Styler, so same-package clean builds do not depend on resolving generated code.
+Forwarding preserves the canonical named-factory allowlist and does not promote
+fluent-only helpers such as `paddingAll`.
 
 ### `@MixWidget`
 

--- a/packages/mix_annotations/README.md
+++ b/packages/mix_annotations/README.md
@@ -119,6 +119,11 @@ Styler, so same-package clean builds do not depend on resolving generated code.
 Forwarding preserves the canonical named-factory allowlist and does not promote
 fluent-only helpers such as `paddingAll`.
 
+When `setterType` and `forwardStyler` are combined, the custom setter type must
+be a concrete class with an accessible unnamed constructor callable without
+arguments. It must implement every forwarded fluent method with the canonical
+generated signature and return a type assignable to itself.
+
 ### `@MixWidget`
 
 Generates a `StatelessWidget` wrapper around a top-level styler variable or

--- a/packages/mix_annotations/lib/src/annotations.dart
+++ b/packages/mix_annotations/lib/src/annotations.dart
@@ -85,7 +85,11 @@ const mixableStyler = MixableStyler();
 ///
 /// When used on a `@MixableSpec` field, `setterType` must be a Mix/Styler type
 /// (i.e. assignable to `Mix<...>`), because generated constructors wrap the
-/// argument with `Prop.maybeMix(...)`.
+/// argument with `Prop.maybeMix(...)`. When combined with [forwardStyler], the
+/// override must also be a concrete class with an accessible unnamed
+/// constructor callable without arguments. It must implement every forwarded
+/// fluent method with the generated signature and a return type assignable to
+/// itself.
 /// Example usage:
 /// ```dart
 /// @MixableField(ignoreSetter: true)

--- a/packages/mix_annotations/lib/src/annotations.dart
+++ b/packages/mix_annotations/lib/src/annotations.dart
@@ -65,6 +65,11 @@ const mixableStyler = MixableStyler();
 /// [skipMixin] prevents spec-driven stylers from inferring an owner mixin.
 /// [factoryName] optionally overrides the generated field factory name.
 /// [skipFactory] prevents spec-driven stylers from generating a field factory.
+/// [forwardStyler] projects the canonical named-factory surface of a nested
+/// `StyleSpec<XSpec>` field onto its generated parent Styler.
+/// [stylerSurface] optionally restricts forwarding to the generated Styler
+/// surface of another `@MixableSpec` type, such as `BoxSpec` for a
+/// `StyleSpec<FlexBoxSpec>` field.
 ///
 /// For spec-driven stylers ([MixableSpec]), [setterType] also drives the
 /// generated field factory and `Prop` wrapping: a nested `StyleSpec<S>` field
@@ -112,6 +117,15 @@ class MixableField {
   /// Whether to skip field factory generation for spec-driven stylers.
   final bool skipFactory;
 
+  /// Whether to forward a nested Styler's canonical factory surface.
+  final bool forwardStyler;
+
+  /// Optional `@MixableSpec` type whose generated Styler surface is forwarded.
+  ///
+  /// The source Spec type is used instead of its generated Styler type so the
+  /// annotation also works during clean same-package builds.
+  final Type? stylerSurface;
+
   const MixableField({
     this.ignoreSetter = false,
     this.setterType,
@@ -119,6 +133,8 @@ class MixableField {
     this.skipMixin = false,
     this.factoryName,
     this.skipFactory = false,
+    this.forwardStyler = false,
+    this.stylerSurface,
   });
 }
 

--- a/packages/mix_annotations/test/annotations_test.dart
+++ b/packages/mix_annotations/test/annotations_test.dart
@@ -25,10 +25,26 @@ void main() {
       expect(annotation.skipFactory, isFalse);
     });
 
+    test('defaults nested styler forwarding to disabled', () {
+      const annotation = MixableField();
+      expect(annotation.forwardStyler, isFalse);
+      expect(annotation.stylerSurface, isNull);
+    });
+
     test('preserves mixin and factoryName overrides', () {
       const annotation = MixableField(mixin: String, factoryName: 'foo');
       expect(annotation.mixin, String);
       expect(annotation.factoryName, 'foo');
+    });
+
+    test('preserves nested styler forwarding configuration', () {
+      const annotation = MixableField(
+        forwardStyler: true,
+        stylerSurface: String,
+      );
+
+      expect(annotation.forwardStyler, isTrue);
+      expect(annotation.stylerSurface, String);
     });
   });
 

--- a/packages/mix_generator/CHANGELOG.md
+++ b/packages/mix_generator/CHANGELOG.md
@@ -12,6 +12,10 @@
    supports compatible restricted surfaces without resolving same-package
    generated Stylers, with field-located diagnostics for invalid or ambiguous
    configurations (#983).
+ - **FIX**: Render forwarded nested Styler APIs in the host library scope,
+   delegate restricted aliases through the actual nested implementation,
+   validate custom forwarding `setterType` construction and method
+   compatibility, and reject collisions with inherited `MixStyler` members.
 
 ## 2.1.2
 

--- a/packages/mix_generator/CHANGELOG.md
+++ b/packages/mix_generator/CHANGELOG.md
@@ -6,6 +6,12 @@
    excluded optional parameters use the styler method's defaults and are not
    validated for generated-widget visibility or name collisions. Annotations
    from older `mix_annotations` releases retain `.all()` behavior.
+ - **FEAT**: Forward canonical named factories and matching fluent anchors from
+   nested `StyleSpec<XSpec>` fields with
+   `@MixableField(forwardStyler: true)`. A source-Spec `stylerSurface` override
+   supports compatible restricted surfaces without resolving same-package
+   generated Stylers, with field-located diagnostics for invalid or ambiguous
+   configurations (#983).
 
 ## 2.1.2
 

--- a/packages/mix_generator/README.md
+++ b/packages/mix_generator/README.md
@@ -255,6 +255,10 @@ are projected: a Box-backed field forwards `padding`, `color`, and `scale`, but
 not fluent-only helpers such as `paddingAll`. Parent-lifecycle factories such as
 `animate` are not forwarded. Unsupported fields, incompatible restricted
 surfaces, and member collisions produce diagnostics on the annotated field.
+When forwarding also specifies `setterType`, that custom type must be a concrete
+class with an accessible unnamed constructor callable without arguments. It
+must implement each forwarded fluent method with the canonical signature and a
+return type assignable to itself.
 
 ## Running the Generator
 

--- a/packages/mix_generator/README.md
+++ b/packages/mix_generator/README.md
@@ -237,7 +237,24 @@ final Prop<Matrix4>? $transform;
 // Override the setter parameter type.
 @MixableField(setterType: List<Shadow>)
 final Prop<List<Shadow>>? $shadows;
+
+// Forward a nested generated Styler's canonical named factories and matching
+// fluent anchors onto the parent Styler.
+@MixableField(forwardStyler: true)
+final StyleSpec<BoxSpec>? container;
+
+// Keep the actual FlexBoxStyler setter type, but expose only the BoxSpec
+// generated Styler surface.
+@MixableField(forwardStyler: true, stylerSurface: BoxSpec)
+final StyleSpec<FlexBoxSpec>? restrictedContainer;
 ```
+
+Forwarding uses the nested source Spec rather than resolving its generated
+Styler, so it works in clean same-package builds. Only canonical named factories
+are projected: a Box-backed field forwards `padding`, `color`, and `scale`, but
+not fluent-only helpers such as `paddingAll`. Parent-lifecycle factories such as
+`animate` are not forwarded. Unsupported fields, incompatible restricted
+surfaces, and member collisions produce diagnostics on the annotated field.
 
 ## Running the Generator
 

--- a/packages/mix_generator/lib/src/core/builders/spec_styler_class_builder.dart
+++ b/packages/mix_generator/lib/src/core/builders/spec_styler_class_builder.dart
@@ -8,6 +8,7 @@ import '../checkers.dart';
 import '../curated/styler_surface_metadata.dart';
 import '../curated/type_metadata.dart';
 import '../errors.dart';
+import '../helpers/library_scope.dart';
 import '../helpers/widget_call_planner.dart';
 import '../models/annotation_config.dart';
 import '../models/field_model.dart';
@@ -18,24 +19,19 @@ import 'styler_api_planner.dart';
 import 'styler_forwarder_factory.dart';
 import 'styler_mixin_builder.dart';
 
-const _reservedForwardingMethodNames = {
-  'animate',
-  'variants',
-  'wrap',
-  'modifier',
-};
-
 class SpecStylerClassBuilder {
   final ClassElement specElement;
   final String specName;
   final ConstantReader annotation;
   final KnownMixSymbolResolver symbolResolver;
+  final LibraryElement? emissionLibrary;
 
   const SpecStylerClassBuilder({
     required this.specElement,
     required this.specName,
     required this.annotation,
     required this.symbolResolver,
+    this.emissionLibrary,
   });
 
   String _fieldValueType(FieldModel field) =>
@@ -106,9 +102,31 @@ class SpecStylerClassBuilder {
   /// compile; `@MixableField(setterType:)` overrides the convention for
   /// types that resolve during generation.
   String? _nestedStylerType(FieldModel field) {
-    final specArgument = field.styleSpecArgument;
+    final nestedSpec = field.styleSpecElement;
+    final specArgument = nestedSpec?.name ?? field.styleSpecArgument;
+    if (specArgument == null) return null;
 
-    return specArgument == null ? null : deriveStylerName(specArgument);
+    final nestedStylerName = deriveStylerName(specArgument);
+    if (nestedSpec == null) return nestedStylerName;
+
+    final reference = referenceFor(nestedSpec, _emissionLibrary);
+    if (reference == null) {
+      final fieldElement = specElement.getField(field.name) ?? specElement;
+      fail(
+        fieldElement,
+        'Nested spec `$specArgument` is not visible from the library where '
+        'its Styler API is emitted.',
+        todo:
+            'Import or re-export `$specArgument` from the host library, or '
+            'disable `forwardStyler`.',
+      );
+    }
+
+    final separator = reference.lastIndexOf('.');
+
+    return separator < 0
+        ? nestedStylerName
+        : '${reference.substring(0, separator + 1)}$nestedStylerName';
   }
 
   /// Whether [field] declares a `@MixableField(setterType:)` override.
@@ -133,7 +151,7 @@ class SpecStylerClassBuilder {
 
     final typeCode = type_helpers.visibleTypeCodeForField(
       element,
-      visibleFrom: element.library,
+      visibleFrom: _emissionLibrary,
       type: type,
       usage: 'setter type',
     );
@@ -155,7 +173,7 @@ class SpecStylerClassBuilder {
     );
     final expectedType = type_helpers.visibleTypeCodeForField(
       element,
-      visibleFrom: element.library,
+      visibleFrom: _emissionLibrary,
       type: fieldValueType,
       usage: 'field value type',
     );
@@ -182,7 +200,7 @@ class SpecStylerClassBuilder {
 
     final actualType = type_helpers.visibleTypeCodeForField(
       element,
-      visibleFrom: element.library,
+      visibleFrom: _emissionLibrary,
       type: mixValueType,
       usage: 'setter type Mix value',
     );
@@ -513,8 +531,13 @@ class SpecStylerClassBuilder {
     final factoryNames = existingFactories
         .map((factory) => factory.name)
         .toSet();
+    final inheritedStylerMemberNames = symbolResolver.instanceMemberNames(
+      'MixStyler',
+      specElement,
+    );
     final methodNames = <String>{
-      ..._reservedForwardingMethodNames,
+      ...stylerGeneratedBaseMethodNames,
+      ...inheritedStylerMemberNames,
       ..._generatedSetterNames(fields, mixins),
       ...existingMethods.map((method) => method.name),
       ...mixins.expand(
@@ -581,7 +604,15 @@ class SpecStylerClassBuilder {
         for (final descriptor in actualFactories) descriptor.name: descriptor,
       };
       final nestedStylerType = _publicParamType(field);
+      final customSetterType = _setterTypeValue(field);
       final setterName = _setterNameFor(field)!;
+      if (customSetterType is InterfaceType) {
+        _validateCustomForwardingConstructor(
+          fieldElement,
+          customSetterType,
+          nestedStylerType,
+        );
+      }
 
       for (final descriptor in selectedFactories) {
         // `animate` configures the parent Styler's own lifecycle and already
@@ -603,6 +634,15 @@ class SpecStylerClassBuilder {
           );
         }
 
+        if (customSetterType is InterfaceType) {
+          _validateCustomForwardingMethod(
+            fieldElement,
+            customSetterType,
+            nestedStylerType,
+            actualDescriptor,
+          );
+        }
+
         if (!factoryNames.add(descriptor.name)) {
           fail(
             fieldElement,
@@ -614,11 +654,14 @@ class SpecStylerClassBuilder {
           );
         }
         if (!methodNames.add(descriptor.name)) {
+          final conflict = inheritedStylerMemberNames.contains(descriptor.name)
+              ? 'an inherited `MixStyler` member'
+              : 'a generated setter, generated base member, owner mixin, or '
+                    'another forwarded method';
           fail(
             fieldElement,
             'Forwarded method `$stylerName.${descriptor.name}` conflicts with '
-            'a generated setter, base member, owner mixin, or another '
-            'forwarded method.',
+            '$conflict.',
             todo:
                 'Forward a smaller surface or rename/remove the conflicting '
                 'parent member.',
@@ -637,7 +680,7 @@ class SpecStylerClassBuilder {
             name: descriptor.name,
             signature: descriptor.signature,
             bodyLines: [
-              'return $setterName($nestedStylerType().${descriptor.invocation});',
+              'return $setterName($nestedStylerType().${actualDescriptor.invocation});',
             ],
           ),
         );
@@ -645,6 +688,103 @@ class SpecStylerClassBuilder {
     }
 
     return (factories: factories, methods: methods);
+  }
+
+  void _validateCustomForwardingConstructor(
+    FieldElement fieldElement,
+    InterfaceType setterType,
+    String setterTypeCode,
+  ) {
+    final element = setterType.element;
+    final constructor = element is ClassElement
+        ? element.unnamedConstructor
+        : null;
+    final canConstruct =
+        element is ClassElement &&
+        !element.isAbstract &&
+        constructor != null &&
+        constructor.formalParameters.every((parameter) => parameter.isOptional);
+    if (canConstruct) return;
+
+    fail(
+      fieldElement,
+      'Custom `setterType` `$setterTypeCode` must be constructible with no '
+      'arguments for nested Styler forwarding.',
+      todo:
+          'Add an accessible unnamed constructor with no required parameters, '
+          'choose a constructible `setterType`, or disable `forwardStyler`.',
+    );
+  }
+
+  void _validateCustomForwardingMethod(
+    FieldElement fieldElement,
+    InterfaceType setterType,
+    String setterTypeCode,
+    StylerFactoryDescriptor descriptor,
+  ) {
+    final methodName = descriptor.invocationName;
+    final method =
+        setterType.getMethod(methodName) ??
+        setterType.lookUpMethod(
+          methodName,
+          fieldElement.library,
+          inherited: true,
+        );
+    if (method == null) {
+      fail(
+        fieldElement,
+        'Custom `setterType` `$setterTypeCode` does not implement forwarded '
+        'method `$methodName`.',
+        todo:
+            'Implement `$methodName` with the nested Styler signature, choose a '
+            'compatible `setterType`, or disable `forwardStyler`.',
+      );
+    }
+
+    final customDescriptor = stylerFactoryDescriptorForMethod(
+      factoryName: methodName,
+      invocationName: methodName,
+      method: method,
+      requiredFieldNames: const {},
+      libraryScope: fieldElement.library,
+    );
+    final argumentsOffset = descriptor.signature.indexOf('(');
+    final expectedSignature =
+        '$methodName${descriptor.signature.substring(argumentsOffset)}';
+    if (customDescriptor.signature != expectedSignature) {
+      fail(
+        fieldElement,
+        'Custom `setterType` `$setterTypeCode` forwarded method `$methodName` '
+        'has incompatible signature `${customDescriptor.signature}`; expected '
+        '`$expectedSignature`.',
+        todo:
+            'Match the generated nested Styler method signature or choose a '
+            'compatible `setterType`.',
+      );
+    }
+
+    final returnsSetterType = fieldElement.library.typeSystem.isAssignableTo(
+      method.returnType,
+      setterType,
+      strictCasts: false,
+    );
+    if (returnsSetterType) return;
+
+    final returnTypeCode = type_helpers.visibleTypeCodeForField(
+      fieldElement,
+      visibleFrom: fieldElement.library,
+      type: method.returnType,
+      usage: 'custom forwarded method return type',
+    );
+    fail(
+      fieldElement,
+      'Custom `setterType` `$setterTypeCode` forwarded method `$methodName` '
+      'must return a type assignable to `$setterTypeCode`, but returns '
+      '`$returnTypeCode`.',
+      todo:
+          'Return `$setterTypeCode` from `$methodName` or choose a compatible '
+          '`setterType`.',
+    );
   }
 
   ClassElement _requireSurfaceSpec(
@@ -688,8 +828,13 @@ class SpecStylerClassBuilder {
       specName: name,
       annotation: ConstantReader(surfaceAnnotation),
       symbolResolver: symbolResolver,
+      emissionLibrary: _emissionLibrary,
     );
-    final fields = extractSpecFields(surfaceSpec, name);
+    final fields = extractSpecFields(
+      surfaceSpec,
+      name,
+      visibleFrom: _emissionLibrary,
+    );
     final mixins = builder._collectOwnerMixins(fields);
 
     return builder._canonicalFactoryDescriptors(fields, mixins);
@@ -761,7 +906,7 @@ class SpecStylerClassBuilder {
             mixinElement: mixin.element,
             orderedMethodNames: entry.methodNames,
             requiredFieldNames: entry.requiredFieldNames,
-            libraryScope: mixin.element.library,
+            libraryScope: _emissionLibrary,
             anchor: specElement,
           ),
         );
@@ -989,10 +1134,16 @@ class SpecStylerClassBuilder {
     buffer.writeln();
   }
 
+  LibraryElement get _emissionLibrary => emissionLibrary ?? specElement.library;
+
   String get stylerName => deriveStylerName(specName);
 
   String build() {
-    final fields = extractSpecFields(specElement, specName);
+    final fields = extractSpecFields(
+      specElement,
+      specName,
+      visibleFrom: _emissionLibrary,
+    );
     final mixins = _collectOwnerMixins(fields);
     final mixinNames = mixins.map((m) => '${m.name}<$stylerName>').toList();
     final mixinClause = mixinNames.isEmpty

--- a/packages/mix_generator/lib/src/core/builders/spec_styler_class_builder.dart
+++ b/packages/mix_generator/lib/src/core/builders/spec_styler_class_builder.dart
@@ -18,6 +18,13 @@ import 'styler_api_planner.dart';
 import 'styler_forwarder_factory.dart';
 import 'styler_mixin_builder.dart';
 
+const _reservedForwardingMethodNames = {
+  'animate',
+  'variants',
+  'wrap',
+  'modifier',
+};
+
 class SpecStylerClassBuilder {
   final ClassElement specElement;
   final String specName;
@@ -459,12 +466,259 @@ class SpecStylerClassBuilder {
         (usesCompoundSurface
             ? compound != null
             : surface.isAvailableFor(fieldNames));
-    final fieldFactories = _fieldFactoryMembers(
+    final factoryDescriptors = _canonicalFactoryDescriptors(fields, mixins);
+    final curatedMethods = <StylerMethodDescriptor>[
+      if (useSurface)
+        ..._surfaceMethods(
+          surface,
+          fieldNames,
+          ignoreRequiredFields: compound != null,
+        ),
+      if (_needsTransformAnchor(fields, mixins) && compound == null)
+        transformAnchorMethodDescriptor(),
+      if (_hasFieldNamed(fields, 'textDirectives'))
+        ...textDirectiveMethodDescriptors(),
+      if (surface?.generatesSingleShadowConvenience == true &&
+          _hasFieldNamed(fields, 'shadows'))
+        iconShadowMethodDescriptor(),
+      ...?compound?.surface.methodDescriptors,
+    ];
+    final forwardedApi = _forwardedApi(
       fields,
       mixins,
-      surface?.suppressedFieldFactoryNames ?? const {},
+      existingFactories: factoryDescriptors,
+      existingMethods: curatedMethods,
     );
-    final curatedFactories = <StylerFactoryDescriptor>[
+
+    return planStylerApi(
+      stylerName: stylerName,
+      curatedFactories: [...factoryDescriptors, ...forwardedApi.factories],
+      curatedMethods: [...curatedMethods, ...forwardedApi.methods],
+      generatedSetterNames: _generatedSetterNames(fields, mixins),
+    );
+  }
+
+  ({
+    List<StylerFactoryDescriptor> factories,
+    List<StylerMethodDescriptor> methods,
+  })
+  _forwardedApi(
+    List<FieldModel> fields,
+    List<_OwnerMixinReference> mixins, {
+    required List<StylerFactoryDescriptor> existingFactories,
+    required List<StylerMethodDescriptor> existingMethods,
+  }) {
+    final factories = <StylerFactoryDescriptor>[];
+    final methods = <StylerMethodDescriptor>[];
+    final factoryNames = existingFactories
+        .map((factory) => factory.name)
+        .toSet();
+    final methodNames = <String>{
+      ..._reservedForwardingMethodNames,
+      ..._generatedSetterNames(fields, mixins),
+      ...existingMethods.map((method) => method.name),
+      ...mixins.expand(
+        (mixin) => mixin.element.methods.map((method) => method.name).nonNulls,
+      ),
+    };
+
+    for (final field in fields) {
+      final fieldElement = specElement.getField(field.name);
+      if (fieldElement == null) continue;
+      final reader = _mixableFieldReader(field.name);
+      final forwardStyler = reader?.peek('forwardStyler')?.boolValue ?? false;
+      final selectedSurfaceType = reader?.peek('stylerSurface')?.typeValue;
+
+      if (!forwardStyler) {
+        if (selectedSurfaceType != null) {
+          fail(
+            fieldElement,
+            '@MixableField(stylerSurface: ...) on `${field.name}` requires '
+            '`forwardStyler: true`.',
+            todo: 'Enable `forwardStyler` or remove `stylerSurface`.',
+          );
+        }
+        continue;
+      }
+
+      if (!_shouldGenerateSetter(field, fields, mixins)) {
+        fail(
+          fieldElement,
+          '@MixableField(forwardStyler: true) on `${field.name}` requires a '
+          'generated setter to delegate the nested Styler.',
+          todo:
+              'Remove `ignoreSetter`, resolve the setter collision, or disable '
+              '`forwardStyler`.',
+        );
+      }
+
+      final actualSpec = field.styleSpecElement;
+      if (actualSpec is! ClassElement) {
+        fail(
+          fieldElement,
+          '@MixableField(forwardStyler: true) on `${field.name}` requires an '
+          'exact `StyleSpec<XSpec>` field.',
+          todo:
+              'Use `StyleSpec<XSpec>` for the field or disable '
+              '`forwardStyler`.',
+        );
+      }
+
+      final selectedSpec = selectedSurfaceType == null
+          ? actualSpec
+          : _requireSurfaceSpec(fieldElement, selectedSurfaceType.element);
+      final actualFactories = _factoryDescriptorsForSpec(
+        actualSpec,
+        errorElement: fieldElement,
+      );
+      final selectedFactories = selectedSpec == actualSpec
+          ? actualFactories
+          : _factoryDescriptorsForSpec(
+              selectedSpec,
+              errorElement: fieldElement,
+            );
+      final actualByName = {
+        for (final descriptor in actualFactories) descriptor.name: descriptor,
+      };
+      final nestedStylerType = _publicParamType(field);
+      final setterName = _setterNameFor(field)!;
+
+      for (final descriptor in selectedFactories) {
+        // `animate` configures the parent Styler's own lifecycle and already
+        // exists as a base method. It is deliberately not projected as nested
+        // field API.
+        if (descriptor.name == 'animate') continue;
+
+        final actualDescriptor = actualByName[descriptor.name];
+        if (actualDescriptor == null ||
+            actualDescriptor.signature != descriptor.signature) {
+          fail(
+            fieldElement,
+            'Styler surface `${deriveStylerName(selectedSpec.name!)}` is not a '
+            'compatible subset of `${deriveStylerName(actualSpec.name!)}`: '
+            'factory `${descriptor.signature}` is unavailable.',
+            todo:
+                'Choose a compatible `stylerSurface` or use the nested '
+                "Styler's inferred surface.",
+          );
+        }
+
+        if (!factoryNames.add(descriptor.name)) {
+          fail(
+            fieldElement,
+            'Forwarded factory `$stylerName.${descriptor.name}` conflicts with '
+            'another generated factory.',
+            todo:
+                'Forward a smaller surface, rename the conflicting field '
+                'factory, or disable one forwarding field.',
+          );
+        }
+        if (!methodNames.add(descriptor.name)) {
+          fail(
+            fieldElement,
+            'Forwarded method `$stylerName.${descriptor.name}` conflicts with '
+            'a generated setter, base member, owner mixin, or another '
+            'forwarded method.',
+            todo:
+                'Forward a smaller surface or rename/remove the conflicting '
+                'parent member.',
+          );
+        }
+
+        factories.add(
+          StylerFactoryDescriptor(
+            name: descriptor.name,
+            signature: descriptor.signature,
+            invocation: descriptor.forwardingInvocation,
+          ),
+        );
+        methods.add(
+          StylerMethodDescriptor(
+            name: descriptor.name,
+            signature: descriptor.signature,
+            bodyLines: [
+              'return $setterName($nestedStylerType().${descriptor.invocation});',
+            ],
+          ),
+        );
+      }
+    }
+
+    return (factories: factories, methods: methods);
+  }
+
+  ClassElement _requireSurfaceSpec(
+    FieldElement fieldElement,
+    Element? selectedElement,
+  ) {
+    if (selectedElement is! ClassElement) {
+      fail(
+        fieldElement,
+        '`stylerSurface` must reference an @MixableSpec class.',
+        todo: 'Pass a source Spec class such as `BoxSpec`.',
+      );
+    }
+
+    return selectedElement;
+  }
+
+  List<StylerFactoryDescriptor> _factoryDescriptorsForSpec(
+    ClassElement surfaceSpec, {
+    required FieldElement errorElement,
+  }) {
+    final surfaceAnnotation = mixableSpecAnnotationChecker.firstAnnotationOf(
+      surfaceSpec,
+    );
+    if (surfaceAnnotation == null) {
+      final name = surfaceSpec.name ?? '<unnamed>';
+      fail(
+        errorElement,
+        'Cannot forward `$name` because it is not annotated with '
+        '`@MixableSpec`.',
+        todo: 'Select an @MixableSpec source type for `stylerSurface`.',
+      );
+    }
+    final name = surfaceSpec.name;
+    if (name == null) {
+      fail(errorElement, 'Cannot forward an unnamed Styler surface.');
+    }
+
+    final builder = SpecStylerClassBuilder(
+      specElement: surfaceSpec,
+      specName: name,
+      annotation: ConstantReader(surfaceAnnotation),
+      symbolResolver: symbolResolver,
+    );
+    final fields = extractSpecFields(surfaceSpec, name);
+    final mixins = builder._collectOwnerMixins(fields);
+
+    return builder._canonicalFactoryDescriptors(fields, mixins);
+  }
+
+  /// The complete ordered named-factory contract emitted for this spec's
+  /// generated Styler. Keeping direct and curated factories in one descriptor
+  /// form lets nested fields project exactly this surface without inspecting a
+  /// generated Styler element.
+  List<StylerFactoryDescriptor> _canonicalFactoryDescriptors(
+    List<FieldModel> fields,
+    List<_OwnerMixinReference> mixins,
+  ) {
+    final compound = _compoundConfig(fields);
+    final fieldNames = _fieldNames(fields);
+    final surface = stylerSurfaceFor(stylerName);
+    final usesCompoundSurface = compoundStylerSurfaceFor(stylerName) != null;
+    final useSurface =
+        surface != null &&
+        (usesCompoundSurface
+            ? compound != null
+            : surface.isAvailableFor(fieldNames));
+
+    return [
+      ..._fieldFactoryDescriptors(
+        fields,
+        mixins,
+        surface?.suppressedFieldFactoryNames ?? const {},
+      ),
       if (useSurface)
         ..._surfaceFactories(
           surface,
@@ -483,30 +737,6 @@ class SpecStylerClassBuilder {
       if (useSurface && surface.generatesAnimateFactory)
         animateFactoryDescriptor(),
     ];
-    final curatedMethods = <StylerMethodDescriptor>[
-      if (useSurface)
-        ..._surfaceMethods(
-          surface,
-          fieldNames,
-          ignoreRequiredFields: compound != null,
-        ),
-      if (_needsTransformAnchor(fields, mixins) && compound == null)
-        transformAnchorMethodDescriptor(),
-      if (_hasFieldNamed(fields, 'textDirectives'))
-        ...textDirectiveMethodDescriptors(),
-      if (surface?.generatesSingleShadowConvenience == true &&
-          _hasFieldNamed(fields, 'shadows'))
-        iconShadowMethodDescriptor(),
-      ...?compound?.surface.methodDescriptors,
-    ];
-
-    return planStylerApi(
-      stylerName: stylerName,
-      fieldFactories: fieldFactories,
-      curatedFactories: curatedFactories,
-      curatedMethods: curatedMethods,
-      generatedSetterNames: _generatedSetterNames(fields, mixins),
-    );
   }
 
   List<StylerFactoryDescriptor> _surfaceFactories(
@@ -575,12 +805,12 @@ class SpecStylerClassBuilder {
         .toList();
   }
 
-  List<ApiMember> _fieldFactoryMembers(
+  List<StylerFactoryDescriptor> _fieldFactoryDescriptors(
     List<FieldModel> fields,
     List<_OwnerMixinReference> mixins,
     Set<String> suppressedFieldFactoryNames,
   ) {
-    final members = <ApiMember>[];
+    final descriptors = <StylerFactoryDescriptor>[];
     for (final field in fields) {
       final factoryName = _fieldFactoryName(field, fields, mixins);
       if (factoryName == null) continue;
@@ -590,14 +820,16 @@ class SpecStylerClassBuilder {
       if (setterName == null) continue;
 
       final paramType = _publicParamType(field);
-      members.add((
-        name: factoryName,
-        code:
-            'factory $stylerName.$factoryName($paramType value) => $stylerName().$setterName(value);',
-      ));
+      descriptors.add(
+        StylerFactoryDescriptor(
+          name: factoryName,
+          signature: '$factoryName($paramType value)',
+          invocation: '$setterName(value)',
+        ),
+      );
     }
 
-    return members;
+    return descriptors;
   }
 
   Set<String> _generatedSetterNames(

--- a/packages/mix_generator/lib/src/core/builders/styler_api_planner.dart
+++ b/packages/mix_generator/lib/src/core/builders/styler_api_planner.dart
@@ -6,7 +6,13 @@ import '../curated/styler_surface_metadata.dart';
 /// Concrete generated API member code keyed by public member name.
 typedef ApiMember = ({String name, String code});
 
-const _reservedBaseMethodNames = {'animate', 'variants', 'wrap', 'modifier'};
+/// Methods emitted by every generated Styler outside the curated API plan.
+const stylerGeneratedBaseMethodNames = {
+  'animate',
+  'variants',
+  'wrap',
+  'modifier',
+};
 
 void _validateUniqueFactories(String stylerName, List<ApiMember> factories) {
   final seen = <String>{};
@@ -25,12 +31,15 @@ void _validateUniqueMethods(
   List<ApiMember> methods,
 ) {
   for (final setterName in generatedSetterNames) {
-    if (!_reservedBaseMethodNames.contains(setterName)) continue;
+    if (!stylerGeneratedBaseMethodNames.contains(setterName)) continue;
 
     throw StateError('Duplicate generated method `$stylerName.$setterName`.');
   }
 
-  final seen = <String>{..._reservedBaseMethodNames, ...generatedSetterNames};
+  final seen = <String>{
+    ...stylerGeneratedBaseMethodNames,
+    ...generatedSetterNames,
+  };
   for (final method in methods) {
     if (seen.add(method.name)) continue;
 

--- a/packages/mix_generator/lib/src/core/builders/styler_forwarder_factory.dart
+++ b/packages/mix_generator/lib/src/core/builders/styler_forwarder_factory.dart
@@ -57,15 +57,32 @@ StylerFactoryDescriptor _descriptorFor(
     );
   }
 
+  return stylerFactoryDescriptorForMethod(
+    factoryName: methodName,
+    invocationName: methodName,
+    method: method,
+    requiredFieldNames: requiredFieldNames,
+    libraryScope: libraryScope,
+  );
+}
+
+/// Describes a named Styler factory backed by an existing fluent [method].
+StylerFactoryDescriptor stylerFactoryDescriptorForMethod({
+  required String factoryName,
+  required String invocationName,
+  required MethodElement method,
+  required Set<String> requiredFieldNames,
+  required LibraryElement libraryScope,
+}) {
   final params = [
     for (final parameter in method.formalParameters)
       _forwarderParamFor(parameter, libraryScope),
   ];
 
   return StylerFactoryDescriptor(
-    name: methodName,
-    signature: '$methodName(${_signatureParameters(params)})',
-    invocation: '$methodName(${_invocationArguments(params)})',
+    name: factoryName,
+    signature: '$factoryName(${_signatureParameters(params)})',
+    invocation: '$invocationName(${_invocationArguments(params)})',
     requiredFieldNames: requiredFieldNames,
   );
 }

--- a/packages/mix_generator/lib/src/core/curated/styler_surface_metadata.dart
+++ b/packages/mix_generator/lib/src/core/curated/styler_surface_metadata.dart
@@ -29,6 +29,21 @@ class StylerFactoryDescriptor extends StylerFactorySurfaceEntry {
     this.requiredFieldNames = const {},
   });
 
+  /// Returns this invocation with its method name replaced by the factory name.
+  ///
+  /// Factory aliases can invoke a differently named fluent setter. Forwarded
+  /// parent factories instead invoke their generated same-name anchor method,
+  /// while the anchor keeps using the original invocation against the nested
+  /// Styler.
+  String get forwardingInvocation {
+    final argumentsOffset = invocation.indexOf('(');
+    if (argumentsOffset < 0) {
+      throw StateError('Invalid Styler factory invocation `$invocation`.');
+    }
+
+    return '$name${invocation.substring(argumentsOffset)}';
+  }
+
   /// Whether all required fields are available.
   bool isAvailableFor(Set<String> fieldNames) {
     return fieldNames.containsAll(requiredFieldNames);

--- a/packages/mix_generator/lib/src/core/curated/styler_surface_metadata.dart
+++ b/packages/mix_generator/lib/src/core/curated/styler_surface_metadata.dart
@@ -29,20 +29,27 @@ class StylerFactoryDescriptor extends StylerFactorySurfaceEntry {
     this.requiredFieldNames = const {},
   });
 
+  int get _invocationArgumentsOffset {
+    final offset = invocation.indexOf('(');
+    if (offset < 0) {
+      throw StateError('Invalid Styler factory invocation `$invocation`.');
+    }
+
+    return offset;
+  }
+
+  /// The fluent method invoked by this factory.
+  String get invocationName =>
+      invocation.substring(0, _invocationArgumentsOffset);
+
   /// Returns this invocation with its method name replaced by the factory name.
   ///
   /// Factory aliases can invoke a differently named fluent setter. Forwarded
   /// parent factories instead invoke their generated same-name anchor method,
   /// while the anchor keeps using the original invocation against the nested
   /// Styler.
-  String get forwardingInvocation {
-    final argumentsOffset = invocation.indexOf('(');
-    if (argumentsOffset < 0) {
-      throw StateError('Invalid Styler factory invocation `$invocation`.');
-    }
-
-    return '$name${invocation.substring(argumentsOffset)}';
-  }
+  String get forwardingInvocation =>
+      '$name${invocation.substring(_invocationArgumentsOffset)}';
 
   /// Whether all required fields are available.
   bool isAvailableFor(Set<String> fieldNames) {

--- a/packages/mix_generator/lib/src/core/models/field_model.dart
+++ b/packages/mix_generator/lib/src/core/models/field_model.dart
@@ -27,7 +27,11 @@ String deriveStylerName(String specName) {
 ///
 /// Returns an empty list when the class has no unnamed constructor. Fails via
 /// [fail] when a named parameter is missing a matching field declaration.
-List<FieldModel> extractSpecFields(ClassElement classElement, String specName) {
+List<FieldModel> extractSpecFields(
+  ClassElement classElement,
+  String specName, {
+  LibraryElement? visibleFrom,
+}) {
   final constructor = classElement.unnamedConstructor;
   if (constructor == null) return [];
 
@@ -43,7 +47,11 @@ List<FieldModel> extractSpecFields(ClassElement classElement, String specName) {
       fail(classElement, 'Field $paramName not found in $specName');
     }
 
-    return FieldModel.fromElement(field, stylerName: stylerName);
+    return FieldModel.fromElement(
+      field,
+      stylerName: stylerName,
+      visibleFrom: visibleFrom ?? classElement.library,
+    );
   }).toList();
 }
 
@@ -108,6 +116,7 @@ class FieldModel {
   factory FieldModel.fromElement(
     FieldElement element, {
     required String stylerName,
+    LibraryElement? visibleFrom,
   }) {
     final field = extractField(element);
     final type = field.type;
@@ -117,7 +126,10 @@ class FieldModel {
     final isList = _isList(type);
     final listElementType = isList ? _getListElementType(type) : null;
 
-    final effectiveSpecType = _getEffectiveSpecType(element);
+    final effectiveSpecType = _getEffectiveSpecType(
+      element,
+      visibleFrom ?? element.library,
+    );
     final isLerpable = _isLerpable(typeName, isList, listElementType);
     final diagnosticKind = diagnosticKindFor(typeName, isList: isList);
 
@@ -184,8 +196,8 @@ String? _getListElementType(DartType type) {
   return getBaseTypeName(type.typeArguments.first);
 }
 
-String _getEffectiveSpecType(FieldElement element) {
-  return visibleTypeCodeForField(element, visibleFrom: element.library);
+String _getEffectiveSpecType(FieldElement element, LibraryElement visibleFrom) {
+  return visibleTypeCodeForField(element, visibleFrom: visibleFrom);
 }
 
 bool _isLerpable(String typeName, bool isList, String? listElementType) {

--- a/packages/mix_generator/lib/src/core/models/field_model.dart
+++ b/packages/mix_generator/lib/src/core/models/field_model.dart
@@ -68,6 +68,13 @@ class FieldModel {
   /// classes never match); synthesized models must set it explicitly.
   final String? styleSpecArgument;
 
+  /// The resolved spec element inside Mix's `StyleSpec<X>`, when available.
+  ///
+  /// The source spec remains resolvable even when its generated Styler does
+  /// not, which lets later generator stages derive the Styler's public surface
+  /// during clean same-package builds.
+  final InterfaceElement? styleSpecElement;
+
   /// The type emitted in generated `copyWith` and `lerp` methods.
   final String effectiveSpecType;
 
@@ -89,6 +96,7 @@ class FieldModel {
     required this.isList,
     this.listElementType,
     this.styleSpecArgument,
+    this.styleSpecElement,
     required this.effectiveSpecType,
     required this.isLerpable,
     required this.diagnosticKind,
@@ -120,12 +128,15 @@ class FieldModel {
         ? flagDescriptionFor(name)
         : null;
 
+    final styleSpec = _styleSpecOf(type);
+
     return FieldModel(
       name: name,
       typeName: typeName,
       isList: isList,
       listElementType: listElementType,
-      styleSpecArgument: _styleSpecArgumentOf(type),
+      styleSpecArgument: styleSpec?.name,
+      styleSpecElement: styleSpec?.element,
       effectiveSpecType: effectiveSpecType,
       isLerpable: isLerpable,
       diagnosticKind: diagnosticKind,
@@ -152,14 +163,17 @@ bool _isList(DartType type) {
 
 /// The spec type argument name `X` of Mix's `StyleSpec<X>`, or `null` when
 /// [type] is not that `StyleSpec` or its argument is not an interface type.
-String? _styleSpecArgumentOf(DartType type) {
+({String name, InterfaceElement element})? _styleSpecOf(DartType type) {
   if (type is! InterfaceType) return null;
   if (!styleSpecChecker.isExactlyType(type)) return null;
   if (type.typeArguments.length != 1) return null;
 
   final argument = type.typeArguments.single;
 
-  return argument is InterfaceType ? argument.element.name : null;
+  if (argument is! InterfaceType) return null;
+  final name = argument.element.name;
+
+  return name == null ? null : (name: name, element: argument.element);
 }
 
 String? _getListElementType(DartType type) {

--- a/packages/mix_generator/lib/src/core/resolvers/known_mix_symbol_resolver.dart
+++ b/packages/mix_generator/lib/src/core/resolvers/known_mix_symbol_resolver.dart
@@ -51,4 +51,31 @@ final class KnownMixSymbolResolver {
           'curated ownerMixins registry.',
     );
   }
+
+  /// All non-static instance member names declared or inherited by [symbolName].
+  Set<String> instanceMemberNames(String symbolName, Element errorElement) {
+    final interface = requireInterface(symbolName, errorElement);
+    final hierarchy = {
+      interface,
+      ...interface.allSupertypes.map((type) => type.element),
+    };
+
+    return {
+      for (final element in hierarchy)
+        ...element.methods
+            .where((method) => !method.isStatic)
+            .map((method) => method.name)
+            .nonNulls,
+      for (final element in hierarchy)
+        ...element.getters
+            .where((getter) => !getter.isStatic)
+            .map((getter) => getter.name)
+            .nonNulls,
+      for (final element in hierarchy)
+        ...element.setters
+            .where((setter) => !setter.isStatic)
+            .map((setter) => setter.name)
+            .nonNulls,
+    };
+  }
 }

--- a/packages/mix_generator/test/core/curated/styler_surface_metadata_test.dart
+++ b/packages/mix_generator/test/core/curated/styler_surface_metadata_test.dart
@@ -3,6 +3,16 @@ import 'package:test/test.dart';
 
 void main() {
   group('styler surface metadata', () {
+    test('retargets aliased factory invocations for forwarding anchors', () {
+      const descriptor = StylerFactoryDescriptor(
+        name: 'visibility',
+        signature: 'visibility(bool value)',
+        invocation: 'visible(value)',
+      );
+
+      expect(descriptor.forwardingInvocation, 'visibility(value)');
+    });
+
     test(
       'contains the complete handwritten TextStyler convenience surface',
       () {

--- a/packages/mix_generator/test/core/curated/styler_surface_metadata_test.dart
+++ b/packages/mix_generator/test/core/curated/styler_surface_metadata_test.dart
@@ -10,6 +10,7 @@ void main() {
         invocation: 'visible(value)',
       );
 
+      expect(descriptor.invocationName, 'visible');
       expect(descriptor.forwardingInvocation, 'visibility(value)');
     });
 

--- a/packages/mix_generator/test/core/test_helpers.dart
+++ b/packages/mix_generator/test/core/test_helpers.dart
@@ -240,6 +240,8 @@ class MixableField {
   final bool skipMixin;
   final String? factoryName;
   final bool skipFactory;
+  final bool forwardStyler;
+  final Type? stylerSurface;
 
   const MixableField({
     this.ignoreSetter = false,
@@ -248,6 +250,8 @@ class MixableField {
     this.skipMixin = false,
     this.factoryName,
     this.skipFactory = false,
+    this.forwardStyler = false,
+    this.stylerSurface,
   });
 }
 

--- a/packages/mix_generator/test/integration/spec_styler_generator_smoke_test.dart
+++ b/packages/mix_generator/test/integration/spec_styler_generator_smoke_test.dart
@@ -1369,6 +1369,76 @@ void main() {
     );
 
     test(
+      'renders forwarded sibling surface types in the host library scope',
+      () async {
+        const visible = '''
+        class VisibleType {}
+      ''';
+        const inner = '''
+        import 'package:mix/mix.dart';
+        import 'package:mix_annotations/mix_annotations.dart';
+        import 'visible.dart' as inner_types;
+        part 'inner_support.dart';
+
+        @MixableSpec()
+        final class InnerSpec extends Spec<InnerSpec> {
+          final inner_types.VisibleType? value;
+
+          const InnerSpec({this.value});
+        }
+      ''';
+        const innerSupport = '''
+        part of 'inner_spec.dart';
+
+        final class InnerStyler extends Mix<StyleSpec<InnerSpec>> {
+          const InnerStyler();
+
+          InnerStyler value(inner_types.VisibleType value) => this;
+        }
+      ''';
+        const input = '''
+        library spike;
+        import 'package:flutter/foundation.dart';
+        import 'package:flutter/widgets.dart';
+        import 'package:mix/mix.dart';
+        import 'package:mix_annotations/mix_annotations.dart';
+        import 'inner_spec.dart' as nested;
+        import 'visible.dart' as host_types;
+        part 'spike.g.dart';
+
+        @MixableSpec()
+        final class HostSpec extends Spec<HostSpec> {
+          @MixableField(forwardStyler: true)
+          final StyleSpec<nested.InnerSpec>? inner;
+
+          const HostSpec({this.inner});
+        }
+      ''';
+
+        await expectGeneratorOutputResolves(
+          builder: _specStylerPartBuilder(),
+          sources: {
+            ...mixAnnotationsSources,
+            ..._flutterResolveStubs,
+            ..._mixSources,
+            'mix|lib/visible.dart': visible,
+            'mix|lib/inner_spec.dart': inner,
+            'mix|lib/inner_support.dart': innerSupport,
+            'mix|lib/spike.dart': input,
+          },
+          inputAsset: 'mix|lib/spike.dart',
+          outputAsset: 'mix|lib/spike.g.dart',
+          outputMatcher: allOf([
+            contains('factory HostStyler.inner(nested.InnerStyler value)'),
+            contains('factory HostStyler.value(host_types.VisibleType value)'),
+            contains('return inner(nested.InnerStyler().value(value));'),
+            isNot(contains('inner_types.VisibleType')),
+          ]),
+        );
+      },
+    );
+
+    test(
       'forwards the canonical factory surface of a nested generated styler',
       () async {
         const input = '''
@@ -1519,50 +1589,297 @@ void main() {
       () async {
         const input = '''
         library spike;
+        import 'package:flutter/foundation.dart';
+        import 'package:flutter/widgets.dart';
         import 'package:mix/mix.dart';
         import 'package:mix_annotations/mix_annotations.dart';
         part 'spike.g.dart';
 
-        class Decoration {}
-
         @MixableSpec()
-        final class BoxSpec extends Spec<BoxSpec> {
-          final Decoration? decoration;
-          const BoxSpec({this.decoration});
+        final class InnerSpec extends Spec<InnerSpec> {
+          final bool? visible;
+          const InnerSpec({this.visible});
         }
 
-        final class CustomBoxStyler extends Mix<StyleSpec<BoxSpec>> {
-          const CustomBoxStyler();
+        mixin VisibleStylerMixin<T> {
+          T visible(bool value) => this as T;
+        }
+
+        final class CustomInnerStyler extends Mix<StyleSpec<InnerSpec>>
+            with VisibleStylerMixin<CustomInnerStyler> {
+          const CustomInnerStyler();
         }
 
         @MixableSpec()
         final class CardSpec extends Spec<CardSpec> {
           @MixableField(
-            setterType: CustomBoxStyler,
+            setterType: CustomInnerStyler,
             forwardStyler: true,
           )
-          final StyleSpec<BoxSpec>? container;
+          final StyleSpec<InnerSpec>? container;
           const CardSpec({this.container});
         }
       ''';
 
-        await testBuilder(
-          _specStylerPartBuilder(),
-          {
+        await expectGeneratorOutputResolves(
+          builder: _specStylerPartBuilder(),
+          sources: {
             ...mixAnnotationsSources,
             ..._flutterResolveStubs,
             ..._mixSources,
             'mix|lib/spike.dart': input,
           },
-          outputs: {
-            'mix|lib/spike.g.dart': decodedMatches(
-              allOf([
-                contains('factory CardStyler.container(CustomBoxStyler value)'),
-                contains('factory CardStyler.color(Color value)'),
-                contains('return container(CustomBoxStyler().color(value));'),
-              ]),
-            ),
-          },
+          inputAsset: 'mix|lib/spike.dart',
+          outputAsset: 'mix|lib/spike.g.dart',
+          outputMatcher: allOf([
+            contains('factory CardStyler.container(CustomInnerStyler value)'),
+            contains('factory CardStyler.visible(bool value)'),
+            contains('return container(CustomInnerStyler().visible(value));'),
+          ]),
+        );
+      },
+    );
+
+    test(
+      'rejects a custom forwarding setterType with a missing method',
+      () async {
+        const input = '''
+        library spike;
+        import 'package:mix/mix.dart';
+        import 'package:mix_annotations/mix_annotations.dart';
+        part 'spike.g.dart';
+
+        @MixableSpec()
+        final class InnerSpec extends Spec<InnerSpec> {
+          final bool? visible;
+          const InnerSpec({this.visible});
+        }
+
+        final class CustomInnerStyler extends Mix<StyleSpec<InnerSpec>> {
+          const CustomInnerStyler();
+        }
+
+        @MixableSpec()
+        final class HostSpec extends Spec<HostSpec> {
+          @MixableField(
+            setterType: CustomInnerStyler,
+            forwardStyler: true,
+          )
+          final StyleSpec<InnerSpec>? nested;
+
+          const HostSpec({this.nested});
+        }
+      ''';
+
+        final message = await _expectSpecStylerValidationError({
+          ...mixAnnotationsSources,
+          ..._mixSources,
+          'mix|lib/spike.dart': input,
+        });
+
+        expect(
+          message,
+          allOf([
+            contains('Custom `setterType` `CustomInnerStyler`'),
+            contains('does not implement forwarded method `visible`'),
+          ]),
+        );
+      },
+    );
+
+    test(
+      'rejects a custom forwarding setterType without zero-argument construction',
+      () async {
+        const input = '''
+        library spike;
+        import 'package:mix/mix.dart';
+        import 'package:mix_annotations/mix_annotations.dart';
+        part 'spike.g.dart';
+
+        @MixableSpec()
+        final class InnerSpec extends Spec<InnerSpec> {
+          final bool? visible;
+          const InnerSpec({this.visible});
+        }
+
+        final class CustomInnerStyler extends Mix<StyleSpec<InnerSpec>> {
+          final int seed;
+
+          const CustomInnerStyler(this.seed);
+
+          CustomInnerStyler visible(bool value) => this;
+        }
+
+        @MixableSpec()
+        final class HostSpec extends Spec<HostSpec> {
+          @MixableField(
+            setterType: CustomInnerStyler,
+            forwardStyler: true,
+          )
+          final StyleSpec<InnerSpec>? nested;
+
+          const HostSpec({this.nested});
+        }
+      ''';
+
+        final message = await _expectSpecStylerValidationError({
+          ...mixAnnotationsSources,
+          ..._mixSources,
+          'mix|lib/spike.dart': input,
+        });
+
+        expect(
+          message,
+          allOf([
+            contains('Custom `setterType` `CustomInnerStyler`'),
+            contains('must be constructible with no arguments'),
+          ]),
+        );
+      },
+    );
+
+    test('rejects an abstract custom forwarding setterType', () async {
+      const input = '''
+        library spike;
+        import 'package:mix/mix.dart';
+        import 'package:mix_annotations/mix_annotations.dart';
+        part 'spike.g.dart';
+
+        @MixableSpec()
+        final class InnerSpec extends Spec<InnerSpec> {
+          final bool? visible;
+          const InnerSpec({this.visible});
+        }
+
+        abstract class CustomInnerStyler extends Mix<StyleSpec<InnerSpec>> {
+          const CustomInnerStyler();
+
+          CustomInnerStyler visible(bool value);
+        }
+
+        @MixableSpec()
+        final class HostSpec extends Spec<HostSpec> {
+          @MixableField(
+            setterType: CustomInnerStyler,
+            forwardStyler: true,
+          )
+          final StyleSpec<InnerSpec>? nested;
+
+          const HostSpec({this.nested});
+        }
+      ''';
+
+      final message = await _expectSpecStylerValidationError({
+        ...mixAnnotationsSources,
+        ..._mixSources,
+        'mix|lib/spike.dart': input,
+      });
+
+      expect(
+        message,
+        allOf([
+          contains('Custom `setterType` `CustomInnerStyler`'),
+          contains('must be constructible with no arguments'),
+        ]),
+      );
+    });
+
+    test(
+      'rejects a custom forwarding setterType with an incompatible method',
+      () async {
+        const input = '''
+        library spike;
+        import 'package:mix/mix.dart';
+        import 'package:mix_annotations/mix_annotations.dart';
+        part 'spike.g.dart';
+
+        @MixableSpec()
+        final class InnerSpec extends Spec<InnerSpec> {
+          final bool? visible;
+          const InnerSpec({this.visible});
+        }
+
+        final class CustomInnerStyler extends Mix<StyleSpec<InnerSpec>> {
+          const CustomInnerStyler();
+
+          CustomInnerStyler visible(String value) => this;
+        }
+
+        @MixableSpec()
+        final class HostSpec extends Spec<HostSpec> {
+          @MixableField(
+            setterType: CustomInnerStyler,
+            forwardStyler: true,
+          )
+          final StyleSpec<InnerSpec>? nested;
+
+          const HostSpec({this.nested});
+        }
+      ''';
+
+        final message = await _expectSpecStylerValidationError({
+          ...mixAnnotationsSources,
+          ..._mixSources,
+          'mix|lib/spike.dart': input,
+        });
+
+        expect(
+          message,
+          allOf([
+            contains('Custom `setterType` `CustomInnerStyler`'),
+            contains('forwarded method `visible` has incompatible signature'),
+            contains('expected `visible(bool value)`'),
+          ]),
+        );
+      },
+    );
+
+    test(
+      'rejects a custom forwarding setterType with an incompatible return type',
+      () async {
+        const input = '''
+        library spike;
+        import 'package:mix/mix.dart';
+        import 'package:mix_annotations/mix_annotations.dart';
+        part 'spike.g.dart';
+
+        @MixableSpec()
+        final class InnerSpec extends Spec<InnerSpec> {
+          final bool? visible;
+          const InnerSpec({this.visible});
+        }
+
+        final class CustomInnerStyler extends Mix<StyleSpec<InnerSpec>> {
+          const CustomInnerStyler();
+
+          Object visible(bool value) => Object();
+        }
+
+        @MixableSpec()
+        final class HostSpec extends Spec<HostSpec> {
+          @MixableField(
+            setterType: CustomInnerStyler,
+            forwardStyler: true,
+          )
+          final StyleSpec<InnerSpec>? nested;
+
+          const HostSpec({this.nested});
+        }
+      ''';
+
+        final message = await _expectSpecStylerValidationError({
+          ...mixAnnotationsSources,
+          ..._mixSources,
+          'mix|lib/spike.dart': input,
+        });
+
+        expect(
+          message,
+          allOf([
+            contains('Custom `setterType` `CustomInnerStyler`'),
+            contains('forwarded method `visible` must return'),
+            contains('assignable to `CustomInnerStyler`'),
+          ]),
         );
       },
     );
@@ -1612,6 +1929,63 @@ void main() {
         },
       );
     });
+
+    test(
+      'restricted surfaces delegate through the actual factory implementation',
+      () async {
+        const input = '''
+        library spike;
+        import 'package:flutter/foundation.dart';
+        import 'package:flutter/widgets.dart';
+        import 'package:mix/mix.dart';
+        import 'package:mix_annotations/mix_annotations.dart';
+        part 'spike.g.dart';
+
+        @MixableSpec()
+        final class SelectedSpec extends Spec<SelectedSpec> {
+          @MixableField(factoryName: 'state')
+          final bool? visible;
+
+          const SelectedSpec({this.visible});
+        }
+
+        @MixableSpec()
+        final class ActualSpec extends Spec<ActualSpec> {
+          @MixableField(factoryName: 'state')
+          final bool? enabled;
+
+          const ActualSpec({this.enabled});
+        }
+
+        @MixableSpec()
+        final class HostSpec extends Spec<HostSpec> {
+          @MixableField(
+            forwardStyler: true,
+            stylerSurface: SelectedSpec,
+          )
+          final StyleSpec<ActualSpec>? nested;
+
+          const HostSpec({this.nested});
+        }
+      ''';
+
+        await expectGeneratorOutputResolves(
+          builder: _specStylerPartBuilder(),
+          sources: {
+            ...mixAnnotationsSources,
+            ..._flutterResolveStubs,
+            ..._mixSources,
+            'mix|lib/spike.dart': input,
+          },
+          inputAsset: 'mix|lib/spike.dart',
+          outputAsset: 'mix|lib/spike.g.dart',
+          outputMatcher: allOf([
+            contains('factory HostStyler.state(bool value)'),
+            contains('return nested(ActualStyler().enabled(value));'),
+          ]),
+        );
+      },
+    );
 
     test('resolves contextual shorthand for forwarded factories', () async {
       const input = '''
@@ -1794,6 +2168,48 @@ void main() {
         ]),
       );
     });
+
+    test(
+      'rejects forwarded methods that collide with inherited styler members',
+      () async {
+        const input = '''
+        library spike;
+        import 'package:mix/mix.dart';
+        import 'package:mix_annotations/mix_annotations.dart';
+        part 'spike.g.dart';
+
+        @MixableSpec()
+        final class InnerSpec extends Spec<InnerSpec> {
+          @MixableField(factoryName: 'onHovered')
+          final bool? hovered;
+
+          const InnerSpec({this.hovered});
+        }
+
+        @MixableSpec()
+        final class HostSpec extends Spec<HostSpec> {
+          @MixableField(forwardStyler: true)
+          final StyleSpec<InnerSpec>? nested;
+
+          const HostSpec({this.nested});
+        }
+      ''';
+
+        final message = await _expectSpecStylerValidationError({
+          ...mixAnnotationsSources,
+          ..._mixSources,
+          'mix|lib/spike.dart': input,
+        });
+
+        expect(
+          message,
+          allOf([
+            contains('Forwarded method `HostStyler.onHovered`'),
+            contains('conflicts with an inherited `MixStyler` member'),
+          ]),
+        );
+      },
+    );
 
     test('rejects spec setterType that is not Mix-compatible', () async {
       const input = '''
@@ -2131,8 +2547,7 @@ void main() {
     test('emits curated Box convenience factories', () async {
       const input = '''
         library spike;
-        import 'package:mix/mix.dart'
-            show Alignment, AlignmentGeometry, Matrix4, TextStyler;
+        import 'package:mix/mix.dart';
         import 'package:mix_annotations/mix_annotations.dart';
         part 'spike.g.dart';
 
@@ -2217,7 +2632,7 @@ void main() {
     test('emits curated Text factories and directive methods', () async {
       const input = '''
         library spike;
-        import 'package:mix/mix.dart' show Directive;
+        import 'package:mix/mix.dart';
         import 'package:mix_annotations/mix_annotations.dart';
         part 'spike.g.dart';
 
@@ -2429,7 +2844,7 @@ void main() {
         ''';
       const input = '''
           library combo;
-          import 'package:mix/mix.dart' show Spec, StyleSpec;
+          import 'package:mix/mix.dart';
           import 'package:mix_annotations/mix_annotations.dart';
 
           import '../box/box_spec.dart';
@@ -2508,7 +2923,7 @@ void main() {
         ''';
       const input = '''
           library combo;
-          import 'package:mix/mix.dart' show Spec, StyleSpec;
+          import 'package:mix/mix.dart';
           import 'package:mix_annotations/mix_annotations.dart';
 
           import '../box/box_spec.dart';

--- a/packages/mix_generator/test/integration/spec_styler_generator_smoke_test.dart
+++ b/packages/mix_generator/test/integration/spec_styler_generator_smoke_test.dart
@@ -9,6 +9,11 @@ import '../core/test_helpers.dart';
 
 const _mixSources = {
   'mix|lib/mix.dart': _mixStub,
+  'mix|lib/src/core/mix_element.dart': '''
+    abstract class Mix<T> {
+      const Mix();
+    }
+  ''',
   'mix|lib/src/core/style_spec.dart': _styleSpecStub,
 };
 
@@ -125,14 +130,17 @@ const _mixSourcesWithStyleWidget = {
 /// part styler tests.
 const _mixStub = '''
   import 'package:flutter/foundation.dart';
+  import 'src/core/mix_element.dart';
+  import 'src/core/style_spec.dart';
 
+  export 'src/core/mix_element.dart';
   export 'src/core/style_spec.dart';
 
   abstract class Spec<T extends Spec<T>> {
     const Spec();
   }
 
-  abstract class Style<S extends Spec<S>> {
+  abstract class Style<S extends Spec<S>> extends Mix<StyleSpec<S>> {
     final List<VariantStyle<S>>? \$variants;
     final WidgetModifierConfig? \$modifier;
     final AnimationConfig? \$animation;
@@ -149,6 +157,8 @@ const _mixStub = '''
   abstract class MixStyler<ST extends Style<SP>, SP extends Spec<SP>>
       extends Style<SP> with Diagnosticable {
     const MixStyler({super.variants, super.modifier, super.animation});
+
+    ST onHovered(ST style) => style;
   }
 
   class AnimationConfig {}
@@ -247,33 +257,33 @@ const _mixStub = '''
     T elevation(ElevationShadow value) => decoration(DecorationMix());
     T shadow(BoxShadowMix value) => decoration(DecorationMix());
     T shadows(List<BoxShadowMix> value) => decoration(DecorationMix());
-    T image(DecorationImageMix value);
-    T shape(ShapeBorderMix value);
+    T image(DecorationImageMix value) => decoration(DecorationMix());
+    T shape(ShapeBorderMix value) => decoration(DecorationMix());
     T backgroundImage(
       ImageProvider image, {
       BoxFit? fit,
       AlignmentGeometry? alignment,
       ImageRepeat repeat = .noRepeat,
-    });
+    }) => decoration(DecorationMix());
     T backgroundImageUrl(
       String url, {
       BoxFit? fit,
       AlignmentGeometry? alignment,
       ImageRepeat repeat = .noRepeat,
-    });
+    }) => decoration(DecorationMix());
     T backgroundImageAsset(
       String path, {
       BoxFit? fit,
       AlignmentGeometry? alignment,
       ImageRepeat repeat = .noRepeat,
-    });
+    }) => decoration(DecorationMix());
     T linearGradient({
       required List<Color> colors,
       List<double>? stops,
       AlignmentGeometry? begin,
       AlignmentGeometry? end,
       TileMode? tileMode,
-    });
+    }) => decoration(DecorationMix());
     T radialGradient({
       required List<Color> colors,
       List<double>? stops,
@@ -282,7 +292,7 @@ const _mixStub = '''
       AlignmentGeometry? focal,
       double? focalRadius,
       TileMode? tileMode,
-    });
+    }) => decoration(DecorationMix());
     T sweepGradient({
       required List<Color> colors,
       List<double>? stops,
@@ -290,14 +300,14 @@ const _mixStub = '''
       double? startAngle,
       double? endAngle,
       TileMode? tileMode,
-    });
+    }) => decoration(DecorationMix());
     T foregroundLinearGradient({
       required List<Color> colors,
       List<double>? stops,
       AlignmentGeometry? begin,
       AlignmentGeometry? end,
       TileMode? tileMode,
-    });
+    }) => foregroundDecoration(DecorationMix());
     T foregroundRadialGradient({
       required List<Color> colors,
       List<double>? stops,
@@ -306,7 +316,7 @@ const _mixStub = '''
       AlignmentGeometry? focal,
       double? focalRadius,
       TileMode? tileMode,
-    });
+    }) => foregroundDecoration(DecorationMix());
     T foregroundSweepGradient({
       required List<Color> colors,
       List<double>? stops,
@@ -314,7 +324,7 @@ const _mixStub = '''
       double? startAngle,
       double? endAngle,
       TileMode? tileMode,
-    });
+    }) => foregroundDecoration(DecorationMix());
   }
 
   mixin BorderStyleMixin<T> {}
@@ -1357,6 +1367,433 @@ void main() {
         );
       },
     );
+
+    test(
+      'forwards the canonical factory surface of a nested generated styler',
+      () async {
+        const input = '''
+        library spike;
+        import 'package:mix/mix.dart';
+        import 'package:mix_annotations/mix_annotations.dart';
+        part 'spike.g.dart';
+
+        class EdgeInsetsGeometry {}
+        class BoxConstraints {}
+        class Decoration {}
+
+        @MixableSpec()
+        final class BoxSpec extends Spec<BoxSpec> {
+          final EdgeInsetsGeometry? padding;
+          final BoxConstraints? constraints;
+          final Decoration? decoration;
+          final Matrix4? transform;
+          final AlignmentGeometry? transformAlignment;
+
+          const BoxSpec({
+            this.padding,
+            this.constraints,
+            this.decoration,
+            this.transform,
+            this.transformAlignment,
+          });
+        }
+
+        @MixableSpec()
+        final class CardSpec extends Spec<CardSpec> {
+          @MixableField(forwardStyler: true)
+          final StyleSpec<BoxSpec>? container;
+
+          const CardSpec({this.container});
+        }
+      ''';
+
+        await testBuilder(
+          _specStylerPartBuilder(),
+          {
+            ...mixAnnotationsSources,
+            ..._mixSources,
+            'mix|lib/spike.dart': input,
+          },
+          outputs: {
+            'mix|lib/spike.g.dart': decodedMatches(
+              allOf([
+                contains('factory CardStyler.container(BoxStyler value)'),
+                contains(
+                  'factory CardStyler.padding(EdgeInsetsGeometryMix value)',
+                ),
+                contains('factory CardStyler.color(Color value)'),
+                contains(
+                  'factory CardStyler.scale(double scale, {Alignment alignment = .center})',
+                ),
+                contains('CardStyler color(Color value)'),
+                contains('return container(BoxStyler().color(value));'),
+                isNot(contains('factory CardStyler.paddingAll(')),
+                isNot(contains('factory CardStyler.animate(')),
+              ]),
+            ),
+          },
+        );
+      },
+    );
+
+    test('supports default and restricted nested styler surfaces', () async {
+      const input = '''
+        library spike;
+        import 'package:mix/mix.dart';
+        import 'package:mix_annotations/mix_annotations.dart';
+        part 'spike.g.dart';
+
+        class EdgeInsetsGeometry {}
+        class BoxConstraints {}
+        class Decoration {}
+
+        @MixableSpec()
+        final class BoxSpec extends Spec<BoxSpec> {
+          final EdgeInsetsGeometry? padding;
+          final BoxConstraints? constraints;
+          final Decoration? decoration;
+          final Matrix4? transform;
+          final AlignmentGeometry? transformAlignment;
+
+          const BoxSpec({
+            this.padding,
+            this.constraints,
+            this.decoration,
+            this.transform,
+            this.transformAlignment,
+          });
+        }
+
+        @MixableSpec()
+        final class FlexSpec extends Spec<FlexSpec> {
+          final Axis? direction;
+          const FlexSpec({this.direction});
+        }
+
+        @MixableSpec()
+        final class FlexBoxSpec extends Spec<FlexBoxSpec> {
+          final StyleSpec<BoxSpec>? box;
+          final StyleSpec<FlexSpec>? flex;
+          const FlexBoxSpec({this.box, this.flex});
+        }
+
+        @MixableSpec()
+        final class DefaultCardSpec extends Spec<DefaultCardSpec> {
+          @MixableField(forwardStyler: true)
+          final StyleSpec<FlexBoxSpec>? container;
+          const DefaultCardSpec({this.container});
+        }
+
+        @MixableSpec()
+        final class RestrictedCardSpec extends Spec<RestrictedCardSpec> {
+          @MixableField(forwardStyler: true, stylerSurface: BoxSpec)
+          final StyleSpec<FlexBoxSpec>? container;
+          const RestrictedCardSpec({this.container});
+        }
+      ''';
+
+      await testBuilder(
+        _specStylerPartBuilder(),
+        {...mixAnnotationsSources, ..._mixSources, 'mix|lib/spike.dart': input},
+        outputs: {
+          'mix|lib/spike.g.dart': decodedMatches(
+            allOf([
+              contains('factory DefaultCardStyler.color(Color value)'),
+              contains('factory DefaultCardStyler.row()'),
+              contains('factory DefaultCardStyler.direction(Axis value)'),
+              contains('return container(FlexBoxStyler().row());'),
+              contains('factory RestrictedCardStyler.color(Color value)'),
+              contains('return container(FlexBoxStyler().color(value));'),
+              isNot(contains('factory RestrictedCardStyler.row()')),
+              isNot(
+                contains('factory RestrictedCardStyler.direction(Axis value)'),
+              ),
+            ]),
+          ),
+        },
+      );
+    });
+
+    test(
+      'uses setterType as the forwarded nested styler implementation',
+      () async {
+        const input = '''
+        library spike;
+        import 'package:mix/mix.dart';
+        import 'package:mix_annotations/mix_annotations.dart';
+        part 'spike.g.dart';
+
+        class Decoration {}
+
+        @MixableSpec()
+        final class BoxSpec extends Spec<BoxSpec> {
+          final Decoration? decoration;
+          const BoxSpec({this.decoration});
+        }
+
+        final class CustomBoxStyler extends Mix<StyleSpec<BoxSpec>> {
+          const CustomBoxStyler();
+        }
+
+        @MixableSpec()
+        final class CardSpec extends Spec<CardSpec> {
+          @MixableField(
+            setterType: CustomBoxStyler,
+            forwardStyler: true,
+          )
+          final StyleSpec<BoxSpec>? container;
+          const CardSpec({this.container});
+        }
+      ''';
+
+        await testBuilder(
+          _specStylerPartBuilder(),
+          {
+            ...mixAnnotationsSources,
+            ..._flutterResolveStubs,
+            ..._mixSources,
+            'mix|lib/spike.dart': input,
+          },
+          outputs: {
+            'mix|lib/spike.g.dart': decodedMatches(
+              allOf([
+                contains('factory CardStyler.container(CustomBoxStyler value)'),
+                contains('factory CardStyler.color(Color value)'),
+                contains('return container(CustomBoxStyler().color(value));'),
+              ]),
+            ),
+          },
+        );
+      },
+    );
+
+    test('honors nested factory aliases and skipped factories', () async {
+      const input = '''
+        library spike;
+        import 'package:mix/mix.dart';
+        import 'package:mix_annotations/mix_annotations.dart';
+        part 'spike.g.dart';
+
+        @MixableSpec()
+        final class InnerSpec extends Spec<InnerSpec> {
+          @MixableField(factoryName: 'visibility')
+          final bool? visible;
+
+          @MixableField(skipFactory: true)
+          final int? internalValue;
+
+          const InnerSpec({this.visible, this.internalValue});
+        }
+
+        @MixableSpec()
+        final class CardSpec extends Spec<CardSpec> {
+          @MixableField(forwardStyler: true, skipFactory: true)
+          final StyleSpec<InnerSpec>? container;
+          const CardSpec({this.container});
+        }
+      ''';
+
+      await testBuilder(
+        _specStylerPartBuilder(),
+        {...mixAnnotationsSources, ..._mixSources, 'mix|lib/spike.dart': input},
+        outputs: {
+          'mix|lib/spike.g.dart': decodedMatches(
+            allOf([
+              contains('factory CardStyler.visibility(bool value)'),
+              contains('CardStyler visibility(bool value)'),
+              contains('return container(InnerStyler().visible(value));'),
+              contains(
+                'factory CardStyler.visibility(bool value) => CardStyler().visibility(value);',
+              ),
+              isNot(contains('factory CardStyler.container(')),
+              isNot(contains('factory CardStyler.internalValue(')),
+            ]),
+          ),
+        },
+      );
+    });
+
+    test('resolves contextual shorthand for forwarded factories', () async {
+      const input = '''
+        library spike;
+        import 'package:flutter/foundation.dart';
+        import 'package:flutter/widgets.dart';
+        import 'package:mix/mix.dart';
+        import 'package:mix_annotations/mix_annotations.dart';
+        part 'spike.g.dart';
+
+        class EdgeInsetsGeometry {}
+        class BoxConstraints {}
+        class Decoration {}
+        enum Clip { hardEdge }
+
+        @MixableSpec()
+        final class BoxSpec extends Spec<BoxSpec> {
+          final AlignmentGeometry? alignment;
+          final EdgeInsetsGeometry? padding;
+          final EdgeInsetsGeometry? margin;
+          final BoxConstraints? constraints;
+          final Decoration? decoration;
+          final Decoration? foregroundDecoration;
+          final Matrix4? transform;
+          final AlignmentGeometry? transformAlignment;
+          final Clip? clipBehavior;
+
+          const BoxSpec({
+            this.alignment,
+            this.padding,
+            this.margin,
+            this.constraints,
+            this.decoration,
+            this.foregroundDecoration,
+            this.transform,
+            this.transformAlignment,
+            this.clipBehavior,
+          });
+        }
+
+        @MixableSpec()
+        final class CardSpec extends Spec<CardSpec> {
+          @MixableField(forwardStyler: true)
+          final StyleSpec<BoxSpec>? container;
+          const CardSpec({this.container});
+        }
+
+        CardStyler hoveredCard() =>
+            CardStyler().onHovered(.color(Color()));
+      ''';
+
+      await expectGeneratorOutputResolves(
+        builder: _specStylerPartBuilder(),
+        sources: {
+          ...mixAnnotationsSources,
+          ..._flutterResolveStubs,
+          ..._mixSources,
+          'mix|lib/spike.dart': input,
+        },
+        inputAsset: 'mix|lib/spike.dart',
+        outputAsset: 'mix|lib/spike.g.dart',
+        outputMatcher: contains('factory CardStyler.color(Color value)'),
+      );
+    });
+
+    test('rejects forwarding on a non-StyleSpec field', () async {
+      const input = '''
+        library spike;
+        import 'package:mix_annotations/mix_annotations.dart';
+        part 'spike.g.dart';
+
+        @MixableSpec()
+        final class CardSpec {
+          @MixableField(forwardStyler: true)
+          final int? container;
+          const CardSpec({this.container});
+        }
+      ''';
+
+      final message = await _expectSpecStylerValidationError({
+        ...mixAnnotationsSources,
+        ..._mixSources,
+        'mix|lib/spike.dart': input,
+      });
+
+      expect(
+        message,
+        allOf([
+          contains('@MixableField(forwardStyler: true)'),
+          contains('`container`'),
+          contains('requires an exact `StyleSpec<XSpec>` field'),
+        ]),
+      );
+    });
+
+    test('rejects an incompatible restricted styler surface', () async {
+      const input = '''
+        library spike;
+        import 'package:mix/mix.dart';
+        import 'package:mix_annotations/mix_annotations.dart';
+        part 'spike.g.dart';
+
+        class Decoration {}
+        class TextStyle {}
+
+        @MixableSpec()
+        final class BoxSpec extends Spec<BoxSpec> {
+          final Decoration? decoration;
+          const BoxSpec({this.decoration});
+        }
+
+        @MixableSpec()
+        final class TextSpec extends Spec<TextSpec> {
+          final TextStyle? style;
+          const TextSpec({this.style});
+        }
+
+        @MixableSpec()
+        final class CardSpec extends Spec<CardSpec> {
+          @MixableField(forwardStyler: true, stylerSurface: BoxSpec)
+          final StyleSpec<TextSpec>? label;
+          const CardSpec({this.label});
+        }
+      ''';
+
+      final message = await _expectSpecStylerValidationError({
+        ...mixAnnotationsSources,
+        ..._mixSources,
+        'mix|lib/spike.dart': input,
+      });
+
+      expect(
+        message,
+        allOf([
+          contains('Styler surface `BoxStyler`'),
+          contains('not a compatible subset of `TextStyler`'),
+          contains('factory `decoration(DecorationMix value)` is unavailable'),
+        ]),
+      );
+    });
+
+    test('rejects duplicate names from multiple forwarded fields', () async {
+      const input = '''
+        library spike;
+        import 'package:mix/mix.dart';
+        import 'package:mix_annotations/mix_annotations.dart';
+        part 'spike.g.dart';
+
+        class Decoration {}
+
+        @MixableSpec()
+        final class BoxSpec extends Spec<BoxSpec> {
+          final Decoration? decoration;
+          const BoxSpec({this.decoration});
+        }
+
+        @MixableSpec()
+        final class CardSpec extends Spec<CardSpec> {
+          @MixableField(forwardStyler: true)
+          final StyleSpec<BoxSpec>? primary;
+
+          @MixableField(forwardStyler: true)
+          final StyleSpec<BoxSpec>? secondary;
+
+          const CardSpec({this.primary, this.secondary});
+        }
+      ''';
+
+      final message = await _expectSpecStylerValidationError({
+        ...mixAnnotationsSources,
+        ..._mixSources,
+        'mix|lib/spike.dart': input,
+      });
+
+      expect(
+        message,
+        allOf([
+          contains('Forwarded factory `CardStyler.decoration`'),
+          contains('conflicts with another generated factory'),
+        ]),
+      );
+    });
 
     test('rejects spec setterType that is not Mix-compatible', () async {
       const input = '''


### PR DESCRIPTION
## Summary

Closes #983.

This adds opt-in forwarding of canonical named factories from a nested `StyleSpec<XSpec>` field onto its parent generated Styler.

A component spec can now expose the useful constructor surface of an internal Styler without manually duplicating every factory:

```dart
@MixableSpec()
final class CardSpec extends Spec<CardSpec> {
  @MixableField(forwardStyler: true)
  final StyleSpec<BoxSpec>? container;

  const CardSpec({this.container});
}
```

The generated `CardStyler` exposes the canonical `BoxStyler` factories and matching fluent anchors:

```dart
final blueCard = CardStyler.color(Colors.blue);

final interactiveCard = CardStyler()
    .padding(EdgeInsets.all(16))
    .onHovered(.color(Colors.blue));
```

A compatible subset can be selected while preserving the actual nested setter type:

```dart
@MixableField(
  forwardStyler: true,
  stylerSurface: BoxSpec,
)
final StyleSpec<FlexBoxSpec>? container;
```

This keeps `FlexBoxStyler` as the nested implementation but forwards only the canonical `BoxSpec` surface.

## Behavior

- Forwarding is disabled by default and must be explicitly enabled.
- Canonical named factories and their fluent anchors are forwarded.
- `factoryName` aliases and `skipFactory` are respected.
- `setterType` remains the nested Styler implementation when provided.
- Fluent-only helpers such as `paddingAll` are not promoted.
- Parent lifecycle factories such as `animate` are not forwarded.
- Invalid fields, incompatible restricted surfaces, ambiguous forwarding, and member collisions produce diagnostics on the annotated field.
- Source Spec types are used for `stylerSurface`, allowing clean same-package generation without resolving generated Styler classes.

## Validation

- `melos run gen:build`
- 2,739 `mix` Flutter tests
- 329 `mix_generator` tests
- 37 `mix_lint` tests
- 11 `mix_annotations` tests
- Dart analyzer and DCM for the affected packages
- `git diff --check`

The repository-wide CI and analysis commands were also attempted. Their only failure was the existing `mix_tailwinds` workspace dependency conflict between hosted `mix` and the local path dependency required by `mix_protocol`.