### PR TITLE
chore: release mix_annotations 2.2.0-beta.0

### DIFF
--- a/packages/mix_annotations/CHANGELOG.md
+++ b/packages/mix_annotations/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.2.0-beta.0
+
+ - **FEAT**: Add `MixableField.forwardStyler` and `stylerSurface` for opt-in
+   projection of a nested generated Styler's canonical named-factory surface
+   onto its parent Styler (#983).
+ - **DOCS**: Document the construction and fluent-method contract for a custom
+   `setterType` combined with `forwardStyler`.
+
 ## 2.1.3
 
  - **FEAT**: Add `MixWidgetParameterSelection` and the
@@ -5,11 +13,6 @@
    `.all()`, while `.only({...})` supports opt-in curation of generated widget
    value parameters. Factory parameters, valid `Key? key`, and method-level
    type parameters remain automatic.
- - **FEAT**: Add `MixableField.forwardStyler` and `stylerSurface` for opt-in
-   projection of a nested generated Styler's canonical named-factory surface
-   onto its parent Styler (#983).
- - **DOCS**: Document the construction and fluent-method contract for a custom
-   `setterType` combined with `forwardStyler`.
 
 ## 2.1.2
 

--- a/packages/mix_annotations/pubspec.yaml
+++ b/packages/mix_annotations/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mix_annotations
 description: Annotations for mix and mix_generator
-version: 2.1.3
+version: 2.2.0-beta.0
 repository: https://github.com/btwld/mix/tree/main/packages/mix_annotations
 
 environment:


### PR DESCRIPTION
Bumps **mix_annotations** `2.1.3` → `2.2.0-beta.0`.

### Changes
- `pubspec.yaml`: version → `2.2.0-beta.0`
- `CHANGELOG.md`: moves the `MixableField.forwardStyler` / `stylerSurface` entries (#985) out of the already-published `## 2.1.3` section into a new `## 2.2.0-beta.0` section — they shipped after the 2.1.3 tag was cut, so they were misfiled.

### Release order
Part of a coordinated `2.2.0-beta.0`. **Merge/publish this first** — `mix_generator` 2.2.0-beta.0 depends on `mix_annotations: ^2.2.0-beta.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)