### PR TITLE
chore: release mix_generator 2.2.0-beta.0

### DIFF
--- a/packages/mix_generator/CHANGELOG.md
+++ b/packages/mix_generator/CHANGELOG.md
@@ -1,11 +1,5 @@
-## 2.1.3
+## 2.2.0-beta.0
 
- - **FEAT**: Support `@MixWidget(widgetParameters: .only({...}))` for a stable,
-   curated generated widget value-parameter API. Factory parameters, valid
-   `Key? key` forwarding, and method-level type parameters remain automatic;
-   excluded optional parameters use the styler method's defaults and are not
-   validated for generated-widget visibility or name collisions. Annotations
-   from older `mix_annotations` releases retain `.all()` behavior.
  - **FEAT**: Forward canonical named factories and matching fluent anchors from
    nested `StyleSpec<XSpec>` fields with
    `@MixableField(forwardStyler: true)`. A source-Spec `stylerSurface` override
@@ -16,6 +10,15 @@
    delegate restricted aliases through the actual nested implementation,
    validate custom forwarding `setterType` construction and method
    compatibility, and reject collisions with inherited `MixStyler` members.
+
+## 2.1.3
+
+ - **FEAT**: Support `@MixWidget(widgetParameters: .only({...}))` for a stable,
+   curated generated widget value-parameter API. Factory parameters, valid
+   `Key? key` forwarding, and method-level type parameters remain automatic;
+   excluded optional parameters use the styler method's defaults and are not
+   validated for generated-widget visibility or name collisions. Annotations
+   from older `mix_annotations` releases retain `.all()` behavior.
 
 ## 2.1.2
 

--- a/packages/mix_generator/pubspec.yaml
+++ b/packages/mix_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mix_generator
 description: A code generator for Mix, an expressive way to effortlessly build design systems in Flutter.
-version: 2.1.3
+version: 2.2.0-beta.0
 homepage: https://github.com/btwld/mix
 repository: https://github.com/btwld/mix/tree/main/packages/mix_generator
 
@@ -8,7 +8,7 @@ environment:
   sdk: ">=3.11.0 <4.0.0"
   
 dependencies:
-  mix_annotations: ^2.1.1
+  mix_annotations: ^2.2.0-beta.0
   dart_style: ^3.0.0
   source_gen: ">=3.0.0 <5.0.0"
   analyzer: '>=9.0.0 <11.0.0'


### PR DESCRIPTION
Bumps **mix_generator** `2.1.3` → `2.2.0-beta.0`.

### Changes
- `pubspec.yaml`: version → `2.2.0-beta.0`; **`mix_annotations: ^2.1.1` → `^2.2.0-beta.0`** — the generator now reads `forwardStyler` / `stylerSurface`, so it requires the matching annotations beta.
- `CHANGELOG.md`: moves the nested-Styler forwarding entries (#985) out of the already-published `## 2.1.3` section into a new `## 2.2.0-beta.0` section.

### Release order
Depends on #986 (mix_annotations 2.2.0-beta.0). **Merge/publish after** the annotations beta is on pub.dev, otherwise `^2.2.0-beta.0` won't resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)