### PR TITLE
chore: release mix 2.2.0-beta.0

### DIFF
--- a/packages/mix/CHANGELOG.md
+++ b/packages/mix/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 2.2.0-beta.0
 
 ### New features
 

--- a/packages/mix/pubspec.yaml
+++ b/packages/mix/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mix
 description: An expressive way to effortlessly build design systems in Flutter.
-version: 2.1.0
+version: 2.2.0-beta.0
 homepage: https://github.com/btwld/mix
 repository: https://github.com/btwld/mix/tree/main/packages/mix
 


### PR DESCRIPTION
Bumps **mix** `2.1.0` → `2.2.0-beta.0`.

### Changes
- `pubspec.yaml`: version → `2.2.0-beta.0`
- `CHANGELOG.md`: promotes the `## Unreleased` section to `## 2.2.0-beta.0` (style-state override scope, `CssKeywordLinearTransform`, typed context variants, variant merge-key fix, etc.)

### Release order
`mix` does not consume the new annotation APIs, so its `mix_annotations: ^2.1.0` constraint is unchanged and this can ship independently of #986 / the generator PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)