### PR TITLE
chore(mix): point 2.2.0-beta.0 internal deps at the coordinated beta

### DIFF
--- a/packages/mix/pubspec.yaml
+++ b/packages/mix/pubspec.yaml
@@ -11,13 +11,14 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  mix_annotations: ^2.1.0
+  mix_annotations: ^2.2.0-beta.0
 
 dev_dependencies:
   flutter_lints: ^6.0.0
   dart_code_metrics_presets: ^2.24.0
   build_runner: ^2.11.0
   mix_generator:
+    version: ^2.2.0-beta.0
     path: ../mix_generator
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
Follow-up to #988, which was merged before the internal dependency constraints were bumped.

`mix` `2.2.0-beta.0` is on `main`, but its internal deps still point at the old line. This updates them to the coordinated beta:

- `mix_annotations`: `^2.1.0` → `^2.2.0-beta.0`
- `mix_generator` (dev): add `version: ^2.2.0-beta.0` alongside the local `path` (validated that pub accepts the path+version form)

Should merge before publishing `mix` `2.2.0-beta.0` to pub.dev so beta consumers resolve the matching `mix_annotations` beta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)