### PR TITLE
fix(mix): preserve BoxShadow blur style

### DIFF
--- a/packages/mix/lib/src/properties/painting/shadow_mix.dart
+++ b/packages/mix/lib/src/properties/painting/shadow_mix.dart
@@ -90,10 +90,12 @@ class ShadowMix extends BaseShadowMix<Shadow>
 
 /// Mix representation of [BoxShadow].
 ///
-/// Extends [ShadowMix] with spread radius support.
+/// Extends [ShadowMix] with blur style and spread radius support.
 @mixable
 class BoxShadowMix extends BaseShadowMix<BoxShadow>
     with DefaultValue<BoxShadow>, Diagnosticable, _$BoxShadowMixMixin {
+  @override
+  final Prop<BlurStyle>? $blurStyle;
   @override
   final Prop<double>? $spreadRadius;
 
@@ -101,11 +103,13 @@ class BoxShadowMix extends BaseShadowMix<BoxShadow>
     Color? color,
     Offset? offset,
     double? blurRadius,
+    BlurStyle? blurStyle,
     double? spreadRadius,
   }) : this.create(
          color: Prop.maybe(color),
          offset: Prop.maybe(offset),
          blurRadius: Prop.maybe(blurRadius),
+         blurStyle: Prop.maybe(blurStyle),
          spreadRadius: Prop.maybe(spreadRadius),
        );
 
@@ -113,8 +117,10 @@ class BoxShadowMix extends BaseShadowMix<BoxShadow>
     super.color,
     super.offset,
     super.blurRadius,
+    Prop<BlurStyle>? blurStyle,
     Prop<double>? spreadRadius,
-  }) : $spreadRadius = spreadRadius;
+  }) : $blurStyle = blurStyle,
+       $spreadRadius = spreadRadius;
 
   /// Creates a [BoxShadowMix] from an existing [BoxShadow].
   BoxShadowMix.value(BoxShadow boxShadow)
@@ -122,6 +128,7 @@ class BoxShadowMix extends BaseShadowMix<BoxShadow>
         color: boxShadow.color,
         offset: boxShadow.offset,
         blurRadius: boxShadow.blurRadius,
+        blurStyle: boxShadow.blurStyle,
         spreadRadius: boxShadow.spreadRadius,
       );
 
@@ -138,6 +145,11 @@ class BoxShadowMix extends BaseShadowMix<BoxShadow>
   /// Creates a box shadow with the specified blur radius.
   factory BoxShadowMix.blurRadius(double value) {
     return BoxShadowMix(blurRadius: value);
+  }
+
+  /// Creates a box shadow with the specified blur style.
+  factory BoxShadowMix.blurStyle(BlurStyle value) {
+    return BoxShadowMix(blurStyle: value);
   }
 
   /// Creates a box shadow with the specified spread radius.
@@ -172,6 +184,11 @@ class BoxShadowMix extends BaseShadowMix<BoxShadow>
   /// Copy with blur radius.
   BoxShadowMix blurRadius(double value) {
     return merge(BoxShadowMix.blurRadius(value));
+  }
+
+  /// Copy with blur style.
+  BoxShadowMix blurStyle(BlurStyle value) {
+    return merge(BoxShadowMix.blurStyle(value));
   }
 
   /// Returns a copy with the specified spread radius.

--- a/packages/mix/lib/src/properties/painting/shadow_mix.g.dart
+++ b/packages/mix/lib/src/properties/painting/shadow_mix.g.dart
@@ -48,6 +48,7 @@ mixin _$ShadowMixMixin on Mix<Shadow>, DefaultValue<Shadow>, Diagnosticable {
 mixin _$BoxShadowMixMixin
     on Mix<BoxShadow>, DefaultValue<BoxShadow>, Diagnosticable {
   Prop<double>? get $blurRadius;
+  Prop<BlurStyle>? get $blurStyle;
   Prop<Color>? get $color;
   Prop<Offset>? get $offset;
   Prop<double>? get $spreadRadius;
@@ -57,6 +58,7 @@ mixin _$BoxShadowMixMixin
   BoxShadowMix merge(BoxShadowMix? other) {
     return BoxShadowMix.create(
       blurRadius: MixOps.merge($blurRadius, other?.$blurRadius),
+      blurStyle: MixOps.merge($blurStyle, other?.$blurStyle),
       color: MixOps.merge($color, other?.$color),
       offset: MixOps.merge($offset, other?.$offset),
       spreadRadius: MixOps.merge($spreadRadius, other?.$spreadRadius),
@@ -69,6 +71,7 @@ mixin _$BoxShadowMixMixin
     return BoxShadow(
       blurRadius:
           MixOps.resolve(context, $blurRadius) ?? defaultValue.blurRadius,
+      blurStyle: MixOps.resolve(context, $blurStyle) ?? defaultValue.blurStyle,
       color: MixOps.resolve(context, $color) ?? defaultValue.color,
       offset: MixOps.resolve(context, $offset) ?? defaultValue.offset,
       spreadRadius:
@@ -81,11 +84,18 @@ mixin _$BoxShadowMixMixin
     super.debugFillProperties(properties);
     properties
       ..add(DiagnosticsProperty('blurRadius', $blurRadius))
+      ..add(DiagnosticsProperty('blurStyle', $blurStyle))
       ..add(DiagnosticsProperty('color', $color))
       ..add(DiagnosticsProperty('offset', $offset))
       ..add(DiagnosticsProperty('spreadRadius', $spreadRadius));
   }
 
   @override
-  List<Object?> get props => [$blurRadius, $color, $offset, $spreadRadius];
+  List<Object?> get props => [
+    $blurRadius,
+    $blurStyle,
+    $color,
+    $offset,
+    $spreadRadius,
+  ];
 }

--- a/packages/mix/test/src/properties/painting/shadow_mix_test.dart
+++ b/packages/mix/test/src/properties/painting/shadow_mix_test.dart
@@ -207,12 +207,14 @@ void main() {
       test('creates BoxShadowMix with all properties', () {
         final boxShadowMix = BoxShadowMix(
           blurRadius: 10.0,
+          blurStyle: BlurStyle.inner,
           color: Colors.blue,
           offset: const Offset(5.0, 8.0),
           spreadRadius: 2.0,
         );
 
         expect(boxShadowMix.$blurRadius, resolvesTo(10.0));
+        expect(boxShadowMix.$blurStyle, resolvesTo(BlurStyle.inner));
         expect(boxShadowMix.$color, resolvesTo(Colors.blue));
         expect(boxShadowMix.$offset, resolvesTo(const Offset(5.0, 8.0)));
         expect(boxShadowMix.$spreadRadius, resolvesTo(2.0));
@@ -222,6 +224,7 @@ void main() {
         final boxShadowMix = BoxShadowMix();
 
         expect(boxShadowMix.$blurRadius, isNull);
+        expect(boxShadowMix.$blurStyle, isNull);
         expect(boxShadowMix.$color, isNull);
         expect(boxShadowMix.$offset, isNull);
         expect(boxShadowMix.$spreadRadius, isNull);
@@ -256,6 +259,16 @@ void main() {
         expect(boxShadowMix.$spreadRadius, isNull);
       });
 
+      test('blurStyle factory creates BoxShadowMix with blurStyle', () {
+        final boxShadowMix = BoxShadowMix.blurStyle(BlurStyle.outer);
+
+        expect(boxShadowMix.$blurStyle, resolvesTo(BlurStyle.outer));
+        expect(boxShadowMix.$blurRadius, isNull);
+        expect(boxShadowMix.$color, isNull);
+        expect(boxShadowMix.$offset, isNull);
+        expect(boxShadowMix.$spreadRadius, isNull);
+      });
+
       test('spreadRadius factory creates BoxShadowMix with spreadRadius', () {
         final boxShadowMix = BoxShadowMix.spreadRadius(3.0);
 
@@ -280,6 +293,7 @@ void main() {
       test('creates BoxShadowMix from BoxShadow', () {
         const boxShadow = BoxShadow(
           blurRadius: 15.0,
+          blurStyle: BlurStyle.inner,
           color: Colors.red,
           offset: Offset(3.0, 6.0),
           spreadRadius: 4.0,
@@ -288,9 +302,11 @@ void main() {
         final boxShadowMix = BoxShadowMix.value(boxShadow);
 
         expect(boxShadowMix.$blurRadius, resolvesTo(15.0));
+        expect(boxShadowMix.$blurStyle, resolvesTo(BlurStyle.inner));
         expect(boxShadowMix.$color, resolvesTo(Colors.red));
         expect(boxShadowMix.$offset, resolvesTo(const Offset(3.0, 6.0)));
         expect(boxShadowMix.$spreadRadius, resolvesTo(4.0));
+        expect(boxShadowMix, resolvesTo(boxShadow));
       });
 
       test('maybeValue returns null for null boxShadow', () {
@@ -298,12 +314,18 @@ void main() {
       });
 
       test('maybeValue returns BoxShadowMix for non-null boxShadow', () {
-        const boxShadow = BoxShadow(blurRadius: 5.0, spreadRadius: 1.0);
+        const boxShadow = BoxShadow(
+          blurRadius: 5.0,
+          blurStyle: BlurStyle.outer,
+          spreadRadius: 1.0,
+        );
         final boxShadowMix = BoxShadowMix.maybeValue(boxShadow);
 
         expect(boxShadowMix, isNotNull);
         expect(boxShadowMix!.$blurRadius, resolvesTo(5.0));
+        expect(boxShadowMix.$blurStyle, resolvesTo(BlurStyle.outer));
         expect(boxShadowMix.$spreadRadius, resolvesTo(1.0));
+        expect(boxShadowMix, resolvesTo(boxShadow));
       });
     });
 
@@ -326,6 +348,12 @@ void main() {
         expect(boxShadowMix.$blurRadius, resolvesTo(12.0));
       });
 
+      test('blurStyle utility works correctly', () {
+        final boxShadowMix = BoxShadowMix().blurStyle(BlurStyle.solid);
+
+        expect(boxShadowMix.$blurStyle, resolvesTo(BlurStyle.solid));
+      });
+
       test('spreadRadius utility works correctly', () {
         final boxShadowMix = BoxShadowMix().spreadRadius(4.0);
 
@@ -337,6 +365,7 @@ void main() {
       test('resolves to BoxShadow with correct properties', () {
         final boxShadowMix = BoxShadowMix(
           blurRadius: 12.0,
+          blurStyle: BlurStyle.inner,
           color: Colors.green,
           offset: const Offset(2.0, 4.0),
           spreadRadius: 3.0,
@@ -344,6 +373,7 @@ void main() {
 
         const resolvedValue = BoxShadow(
           blurRadius: 12.0,
+          blurStyle: BlurStyle.inner,
           color: Colors.green,
           offset: Offset(2.0, 4.0),
           spreadRadius: 3.0,
@@ -370,11 +400,13 @@ void main() {
       test('merges properties correctly', () {
         final first = BoxShadowMix(
           blurRadius: 10.0,
+          blurStyle: BlurStyle.inner,
           color: Colors.blue,
           spreadRadius: 1.0,
         );
 
         final second = BoxShadowMix(
+          blurStyle: BlurStyle.outer,
           color: Colors.red,
           offset: const Offset(3.0, 3.0),
           spreadRadius: 2.0,
@@ -383,12 +415,30 @@ void main() {
         final merged = first.merge(second);
 
         expect(merged.$blurRadius, resolvesTo(10.0)); // from first
+        expect(
+          merged.$blurStyle,
+          resolvesTo(BlurStyle.outer),
+        ); // second overrides
         expect(merged.$color, resolvesTo(Colors.red)); // second overrides
         expect(
           merged.$offset,
           resolvesTo(const Offset(3.0, 3.0)),
         ); // from second
         expect(merged.$spreadRadius, resolvesTo(2.0)); // second overrides
+      });
+
+      test('later blurStyle overrides earlier blurStyle', () {
+        final first = BoxShadowMix.value(
+          const BoxShadow(blurStyle: BlurStyle.inner),
+        );
+        final second = BoxShadowMix.value(
+          const BoxShadow(blurStyle: BlurStyle.solid),
+        );
+
+        expect(
+          first.merge(second),
+          resolvesTo(const BoxShadow(blurStyle: BlurStyle.solid)),
+        );
       });
 
       test('returns equivalent instance when other is null', () {
@@ -404,12 +454,14 @@ void main() {
       test('equal box shadows have same hashCode', () {
         final boxShadow1 = BoxShadowMix(
           blurRadius: 10.0,
+          blurStyle: BlurStyle.inner,
           color: Colors.blue,
           spreadRadius: 2.0,
         );
 
         final boxShadow2 = BoxShadowMix(
           blurRadius: 10.0,
+          blurStyle: BlurStyle.inner,
           color: Colors.blue,
           spreadRadius: 2.0,
         );
@@ -424,19 +476,28 @@ void main() {
 
         expect(boxShadow1, isNot(equals(boxShadow2)));
       });
+
+      test('different blur styles are not equal', () {
+        final boxShadow1 = BoxShadowMix(blurStyle: BlurStyle.inner);
+        final boxShadow2 = BoxShadowMix(blurStyle: BlurStyle.outer);
+
+        expect(boxShadow1, isNot(equals(boxShadow2)));
+      });
     });
 
     group('Props getter', () {
       test('props includes all properties', () {
         final boxShadowMix = BoxShadowMix(
           blurRadius: 10.0,
+          blurStyle: BlurStyle.inner,
           color: Colors.blue,
           offset: const Offset(5.0, 8.0),
           spreadRadius: 2.0,
         );
 
-        expect(boxShadowMix.props.length, 4);
+        expect(boxShadowMix.props.length, 5);
         expect(boxShadowMix.props, contains(boxShadowMix.$blurRadius));
+        expect(boxShadowMix.props, contains(boxShadowMix.$blurStyle));
         expect(boxShadowMix.props, contains(boxShadowMix.$color));
         expect(boxShadowMix.props, contains(boxShadowMix.$offset));
         expect(boxShadowMix.props, contains(boxShadowMix.$spreadRadius));

--- a/packages/mix_protocol/lib/src/inventory/schema_inventory_manifest.dart
+++ b/packages/mix_protocol/lib/src/inventory/schema_inventory_manifest.dart
@@ -433,6 +433,10 @@ const _v1UnsupportedInventory = <SchemaInventoryEntry>[
     _v1OutOfScope,
   ),
   SchemaInventoryEntry.knownUnsupported(
+    r'mix:BoxShadowMix.$blurStyle',
+    _v1OutOfScope,
+  ),
+  SchemaInventoryEntry.knownUnsupported(
     r'mix:CircleBorderMix.$eccentricity',
     _v1OutOfScope,
   ),


### PR DESCRIPTION
#### Related issue

Closes #990

### Description

Preserves non-default `BoxShadow.blurStyle` values through the complete `BoxShadowMix` lifecycle so converting and resolving a Flutter box shadow is lossless.

### Changes

- Add public constructor, factory, fluent setter, conversion, merge, resolution, diagnostics, and equality support for `blurStyle`.
- Add regression coverage for non-default round-tripping, `maybeValue`, merge precedence, and equality.
- Classify the new field as outside the existing Mix Protocol v1 wire contract without changing that format.

**Review Checklist**

- [x] **Testing**: Focused tests, workspace generation, full CI, schema inventory, Dart analysis, and DCM analysis pass.
- [x] **Breaking Changes**: No breaking changes; the API addition is additive.
- [x] **Documentation Updates**: Updated the public API documentation; no separate guide changes are required.
- [x] **Website Updates**: No website updates are required.

### Additional Information (optional)

The API compatibility script could not generate a report because `dart_apitool` cannot disambiguate the repository's existing `WidgetModifierConfig.translate` members.
