### PR TITLE
chore(mix): prepare 2.2.0-beta.1

### DIFF
--- a/packages/mix/CHANGELOG.md
+++ b/packages/mix/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.2.0-beta.1
+
+### Fixes
+
+- **Box shadow blur styles:** `BoxShadowMix` now preserves non-default
+  `BoxShadow.blurStyle` values across construction, conversion, merging,
+  resolution, diagnostics, equality, and its fluent and factory APIs (#992).
+
 ## 2.2.0-beta.0
 
 ### New features

--- a/packages/mix/pubspec.yaml
+++ b/packages/mix/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mix
 description: An expressive way to effortlessly build design systems in Flutter.
-version: 2.2.0-beta.0
+version: 2.2.0-beta.1
 homepage: https://github.com/btwld/mix
 repository: https://github.com/btwld/mix/tree/main/packages/mix
 


### PR DESCRIPTION
#### Related issue

Follows #992.

### Description

Prepares `mix` 2.2.0-beta.1 with the `BoxShadow.blurStyle` preservation fix from #992.

### Changes

- Bump `packages/mix` from `2.2.0-beta.0` to `2.2.0-beta.1`.
- Add the beta.1 changelog entry for the box-shadow blur-style fix.

**Review Checklist**

- [x] **Testing**: Version/changelog verification, the 45 affected shadow tests, package analysis, and `flutter pub publish --dry-run` pass.
- [x] **Breaking Changes**: No breaking changes; this beta contains an additive bug fix.
- [x] **Documentation Updates**: The Mix changelog documents the release.
- [x] **Website Updates**: No website updates are required.

### Additional Information (optional)

- Release scope: Mix only; `mix_annotations` and `mix_generator` remain at `2.2.0-beta.0`.
- Publish trigger after merge: `mix-v2.2.0-beta.1`.
- Dry-run result: zero warnings and one existing local dependency-override hint.
