### PR TITLE
docs(mix): refresh agent layout guidance and LLM index

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "mix",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "displayName": "Mix",
-  "description": "Mix Flutter styling framework guidance for agents working on Mix code, projects using package:mix, and the Mix monorepo.",
+  "description": "Mix Flutter styling and layout guidance for agents working on Mix code, projects using package:mix, and the Mix monorepo.",
   "author": {
     "name": "Leo Farias",
     "url": "https://github.com/leoafarias"
@@ -10,5 +10,5 @@
   "homepage": "https://fluttermix.com",
   "repository": "https://github.com/btwld/mix",
   "license": "BSD-3-Clause",
-  "keywords": ["dart", "flutter", "mix", "styling", "design-systems"]
+  "keywords": ["dart", "flutter", "mix", "styling", "layout", "grid", "design-systems"]
 }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mix",
-  "version": "1.0.0",
-  "description": "Mix Flutter styling framework guidance for agents working on Mix code, projects using package:mix, and the Mix monorepo.",
+  "version": "1.1.0",
+  "description": "Mix Flutter styling and layout guidance for agents working on Mix code, projects using package:mix, and the Mix monorepo.",
   "author": {
     "name": "Leo Farias",
     "url": "https://github.com/leoafarias"
@@ -9,18 +9,19 @@
   "homepage": "https://fluttermix.com",
   "repository": "https://github.com/btwld/mix",
   "license": "BSD-3-Clause",
-  "keywords": ["dart", "flutter", "mix", "styling", "design-systems"],
+  "keywords": ["dart", "flutter", "mix", "styling", "layout", "grid", "design-systems"],
   "skills": "./skills/",
   "interface": {
     "displayName": "Mix",
-    "shortDescription": "Work with Mix Flutter styles, specs, and codegen.",
-    "longDescription": "Use the Mix plugin to work on the Mix Flutter styling framework and projects that use the mix package. It provides version-aware guidance for Stylers, Specs, widgets, variants, animations, design tokens, code generation, and monorepo workflows.",
+    "shortDescription": "Work with Mix Flutter styles, layouts, specs, and codegen.",
+    "longDescription": "Use the Mix plugin to work on the Mix Flutter styling framework and projects that use the mix package. It provides version-aware guidance for Stylers, Specs, FlexBox, WrapBox, GridBox, StackBox, variants, animations, design tokens, code generation, and monorepo workflows.",
     "developerName": "Leo Farias",
     "category": "Productivity",
-    "capabilities": ["Code", "Flutter", "Design Systems"],
+    "capabilities": ["Code", "Flutter", "Layouts", "Design Systems"],
     "websiteURL": "https://fluttermix.com",
     "defaultPrompt": [
-      "Use Mix to build a responsive Flutter card style.",
+      "Use Mix to build a container-responsive GridBox dashboard.",
+      "Choose the right Mix layout primitive for this Flutter UI.",
       "Review this Mix style for API correctness.",
       "Help add a new Mix Spec with code generation."
     ],

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,57 @@
+# Mix
+
+> Mix is a type-safe Flutter styling system that separates immutable resolved Specs, fluent Stylers, and rendering Widgets. Repository `main` currently declares `mix 2.2.0-beta.1` and requires Dart 3.11+ and Flutter 3.41+.
+
+Important notes:
+
+- Treat local source and the consuming project's resolved package version as authoritative. `WrapBox` and `GridBox` landed on repository `main` after the `2.2.0-beta.1` release and may not exist in an installed release yet.
+- Keep visual semantics in Mix Stylers. Use `Box` for one styled child, `FlexBox`/`RowBox`/`ColumnBox` for one-dimensional layouts, `WrapBox` for intrinsic wrapping runs, `GridBox` for explicit two-dimensional tracks, and `StackBox` for overlays.
+- `GridBoxStyler.onConstraints` observes the size offered by the Grid's parent; `onBreakpoint` observes the viewport through `MediaQuery`.
+- Grid currently supports fixed and fractional tracks with row-major placement. It does not support content-sized tracks, spans, named areas, masonry packing, direction-aware placement, or baseline alignment.
+- `mix.dart` and `*.g.dart` files are generated. Edit their sources and run the repository generation commands instead of editing generated output.
+
+## Start Here
+
+- [Repository agent instructions](https://raw.githubusercontent.com/conceptadev/mix/main/AGENTS.md): Workspace structure, environment setup, commands, architecture, and critical contribution rules.
+- [Mix package README](https://raw.githubusercontent.com/conceptadev/mix/main/packages/mix/README.md): Current package usage, fluent styling, WrapBox, GridBox, variants, tokens, and animations.
+- [Mix agent skill](https://raw.githubusercontent.com/conceptadev/mix/main/skills/mix/SKILL.md): Version-aware guidance and routing to focused agent references.
+- [API composition guidelines](https://raw.githubusercontent.com/conceptadev/mix/main/guides/api-composition-guidelines.md): Fluent chaining, sizing, merge behavior, and API design policy.
+
+## Layout
+
+- [Layout with Mix agent reference](https://raw.githubusercontent.com/conceptadev/mix/main/skills/mix/references/layout.md): Decision guide for Box, Flex, Wrap, Grid, and Stack; includes responsive Grid use cases, constraints, animation, and limitations.
+- [Grid layout guide](https://raw.githubusercontent.com/conceptadev/mix/main/packages/mix/doc/grid-layout.md): Maintained GridBox contract covering tracks, local constraints, rows, tokens, animation, overflow, and unsupported features.
+- [Grid runnable examples](https://github.com/conceptadev/mix/blob/main/packages/mix/example/lib/grid_example.dart): Dashboard, card catalog, media gallery, and animated 1:1-to-2:1 Grid scenarios.
+- [Grid example guide](https://raw.githubusercontent.com/conceptadev/mix/main/packages/mix/example/README.md): Commands and visual use-case explanations for GridBox and WrapBox.
+- [Fluent API reference](https://raw.githubusercontent.com/conceptadev/mix/main/skills/mix/references/fluent-api.md): Layout/style mixins, callable Stylers, sizing, interaction widgets, and composition.
+
+## Styling and Theming
+
+- [Architecture reference](https://raw.githubusercontent.com/conceptadev/mix/main/skills/mix/references/architecture.md): Spec, Styler, Prop, resolution pipeline, StyleWidget, and modifiers.
+- [Styler API policy](https://raw.githubusercontent.com/conceptadev/mix/main/skills/mix/references/styler-api-policy.md): Top-level constructors, typed dot shorthand, generated factories, and composition rules.
+- [Variants reference](https://raw.githubusercontent.com/conceptadev/mix/main/skills/mix/references/variants.md): Context, named, breakpoint, and widget-state variants with merge priority.
+- [Animations reference](https://raw.githubusercontent.com/conceptadev/mix/main/skills/mix/references/animations.md): Implicit, phase, and keyframe animation patterns.
+- [Design tokens reference](https://raw.githubusercontent.com/conceptadev/mix/main/skills/mix/references/design-tokens.md): MixScope, token types, references, and theming.
+- [Widget modifiers and directives](https://raw.githubusercontent.com/conceptadev/mix/main/skills/mix/references/widget-modifiers-directives.md): Widget wrappers, modifier ordering, text directives, and Prop directives.
+
+## Code Generation
+
+- [Code generation agent reference](https://raw.githubusercontent.com/conceptadev/mix/main/skills/mix/references/code-generation.md): `@MixableSpec`, `@MixWidget`, `@MixableModifier`, `@MixableField`, generated surfaces, and workflow.
+- [MixWidget variant constructor decisions](https://raw.githubusercontent.com/conceptadev/mix/main/guides/mix-widget-variant-constructors.md): Shipped enum constructor behavior, retained unnamed constructor, rejected runtime design, and recorded future decisions.
+- [mix_annotations README](https://raw.githubusercontent.com/conceptadev/mix/main/packages/mix_annotations/README.md): Current annotation contracts and examples.
+- [mix_generator README](https://raw.githubusercontent.com/conceptadev/mix/main/packages/mix_generator/README.md): Generator behavior, parameter curation, plain Widget targets, nested Styler forwarding, and generated output.
+
+## Packages and Machine Contracts
+
+- [mix_protocol guide](https://raw.githubusercontent.com/conceptadev/mix/main/packages/mix_protocol/GUIDE.md): Versioned Mix JSON documents, codecs, schema validation, inspection, and resolver behavior.
+- [mix_protocol wire contract](https://raw.githubusercontent.com/conceptadev/mix/main/packages/mix_protocol/WIRE_CONTRACT.md): Canonical wire vocabulary and compatibility rules.
+- [mix_tailwinds README](https://raw.githubusercontent.com/conceptadev/mix/main/packages/mix_tailwinds/README.md): Tailwind-style parsing and translation into Mix styles.
+- [mix_chart README](https://raw.githubusercontent.com/conceptadev/mix/main/packages/mix_chart/README.md): Mix-owned line, bar, and pie chart APIs.
+- [mix_lint README](https://raw.githubusercontent.com/conceptadev/mix/main/packages/mix_lint/README.md): Mix-specific analyzer and custom lint rules.
+
+## Optional
+
+- [Worked examples](https://raw.githubusercontent.com/conceptadev/mix/main/skills/mix/references/examples.md): End-to-end examples for reusable components and responsive styles.
+- [Testing reference](https://raw.githubusercontent.com/conceptadev/mix/main/skills/mix/references/testing.md): Mix matchers, mock context, merge tests, widget tests, and generated API coverage.
+- [Development workflow](https://raw.githubusercontent.com/conceptadev/mix/main/skills/mix/references/development-workflow.md): Spec authoring, generation, exports, package boundaries, and verification.
+- [Repository changelog](https://raw.githubusercontent.com/conceptadev/mix/main/CHANGELOG.md): Project-level release history.

--- a/skills/mix/SKILL.md
+++ b/skills/mix/SKILL.md
@@ -4,7 +4,9 @@ description: >
   This skill should be used when working on the Mix Flutter styling
   framework or any project using the mix package. Applies when the user
   mentions Mix specs, Mix styles, BoxStyler, TextStyler, Pressable,
-  PressableBox, StyleWidget, MixStyler, fluent chaining, Prop values, Mix types,
+  PressableBox, FlexBox, RowBox, ColumnBox, WrapBox, GridBox, GridTrack,
+  StackBox, responsive layouts, onConstraints, StyleWidget, MixStyler,
+  fluent chaining, Prop values, Mix types,
   Mix annotations (@MixableSpec, @MixWidget, @MixableModifier, legacy
   @MixableStyler, @Mixable), code generation with mix_generator,
   dot-shorthand policy, style variants (NamedVariant,
@@ -13,15 +15,15 @@ description: >
   tokens (MixScope, tokens), widget modifiers (.wrap()), directives, style
   mixins, melos commands for Mix (gen:build, ci, analyze, exports), or the
   Mix monorepo packages (mix, mix_annotations, mix_generator, mix_lint,
-  mix_tailwinds).
+  mix_protocol, mix_tailwinds, mix_chart).
 ---
 
 # Mix Framework
 
 Type-safe styling system for Flutter that separates style semantics from widgets.
 
-**Target version:** `mix: 2.0.3` (Dart >=3.11.0, Flutter >=3.41.0)
-Confirm the project's actual version before applying patterns — check `pubspec.yaml`.
+**Repository target:** current `main` (`mix` pubspec: `2.2.0-beta.1`, Dart >=3.11.0, Flutter >=3.41.0).
+Confirm the consuming project's actual version before applying patterns. `WrapBox` and `GridBox` landed on `main` after `2.2.0-beta.1`, so a released dependency may not expose them yet.
 
 ## Source of Truth
 
@@ -49,12 +51,17 @@ Resolution pipeline: `StyleWidget` → `StyleBuilder` → merge active variants 
 | `TextStyler` | `TextSpec` | `StyledText` | `Text` |
 | `FlexStyler` | `FlexSpec` | — (layout) | `Flex`/`Row`/`Column` |
 | `FlexBoxStyler` | `FlexBoxSpec` | `FlexBox`/`RowBox`/`ColumnBox` | `Column`/`Row` + `Container` |
+| `WrapStyler` | `WrapSpec` | — (layout) | `Wrap` |
+| `WrapBoxStyler` | `WrapBoxSpec` | `WrapBox` | `Wrap` + `Container` |
+| `GridBoxStyler` | `GridBoxSpec` | `GridBox` | Fixed/`fr` track grid |
 | `StackStyler` | `StackSpec` | — (layout) | `Stack` |
 | `StackBoxStyler` | `StackBoxSpec` | `StackBox` | `Stack` + `Container` |
 | `IconStyler` | `IconSpec` | `StyledIcon` | `Icon` |
 | `ImageStyler` | `ImageSpec` | `StyledImage` | `Image` |
 
 Interactive: `Pressable` (gesture + focus + mouse), `PressableBox` (Pressable + Box).
+
+`GridBox` is a Mix-owned layout primitive, but unlike `FlexBox`, `WrapBox`, and `StackBox`, it does not include outer `Box` decoration or padding. Compose it inside `Box` when the grid itself needs chrome.
 
 ## Key Patterns
 
@@ -71,9 +78,21 @@ When styling a Mix surface, keep visual semantics in Stylers instead of nesting 
 | `Theme.of(context).textTheme.bodyMedium` in styles | `TextStyleToken` values from `MixScope`, then `TextStyler().style($body.mix())` |
 | Nested `Padding` / `Align` for a styled widget | Styler methods such as `.paddingAll(16)` and `.alignment(Alignment.center)` |
 
+### Choose the Layout Primitive
+
+| Need | Use |
+|------|-----|
+| One child with size, padding, or decoration | `Box` |
+| One non-wrapping row or column | `RowBox`, `ColumnBox`, or `FlexBox` |
+| Chips, tags, or intrinsic items that flow onto new runs | `WrapBox` |
+| Dashboards, card catalogs, and galleries with explicit two-dimensional tracks | `GridBox` |
+| Overlays or positioned layers | `StackBox` |
+
+Use `GridBoxStyler.onConstraints` when grid geometry should react to the space offered by its parent. Use `onBreakpoint` when a style should react to viewport size through `MediaQuery`. See `references/layout.md` for the complete layout decision guide, responsive Grid patterns, constraints, animation rules, and current limitations.
+
 ### Top-Level Rule
 
-Start top-level declarations with the relevant concrete Styler constructor (`BoxStyler()`, `TextStyler()`, `IconStyler()`, etc.), then chain. Static factories are valid API but discouraged for top-level declarations; bare dot-shorthand is only for typed nested contexts. In nested typed contexts (variants, state callbacks), use bare shorthand `.method()` instead. See `references/styler-api-policy.md` for the complete policy.
+Start ordinary top-level declarations with the relevant concrete Styler constructor (`BoxStyler()`, `TextStyler()`, `IconStyler()`, etc.), then chain. Static factories are valid API but usually discouraged as top-level entry points. Grid declarations are the deliberate exception: use an explicit `GridBoxStyler` type with `.equalColumns(...)` or `.columns(...)` so the required track topology is visible. In typed nested contexts (variants, state callbacks, constraint patches), use bare shorthand `.method()`. See `references/styler-api-policy.md` for the complete policy.
 
 ### Fluent Chaining (recommended)
 
@@ -121,9 +140,11 @@ final combined = base.merge(elevated);
 - **Generated Stylers have `.create()` and default constructors** — many also expose generated factory constructors
 - **Prefer `@MixableSpec(target: Widget.new)`** — `@MixableStyler` is legacy/deprecated
 - **Use `@MixWidget` for generated widgets from style factories** — it wraps top-level `Style<S>` variables or functions
+- **`@MixWidget(target:)` supports plain Widgets** — the target needs a compatible named `style` parameter; it does not need to extend `StyleWidget`
 - **Use `@MixableModifier` for generated modifiers** — it emits the modifier contract mixin and `ModifierMix` class
 - **`mix.dart` is generated** — never edit directly; run `melos run exports`
 - **Run codegen after spec changes** — `melos run gen:build`
+- **Grid constraint branches are geometry-only** — columns, rows, `autoRows`, and gaps; keep clipping, modifiers, animations, and ordinary variants on the base styler
 - **Prop merge semantics** — regular values: last wins (replacement); Mix values: accumulated merge
 - **Variant priority** — ContextVariant/NamedVariant first → StyleVariation second → WidgetStateVariant last (highest)
 
@@ -151,7 +172,9 @@ melos run gen:build && melos run ci && melos run analyze
 | `mix_annotations` | `@MixableSpec`, `@MixWidget`, `@MixableModifier`, `@MixableStyler`, `@Mixable`, `@MixableField` |
 | `mix_generator` | `build_runner` generator producing `*.g.dart` mixins |
 | `mix_lint` | Analysis server plugin with Mix-specific lint rules |
+| `mix_protocol` | Versioned JSON wire contract, codecs, schemas, inspection, and token walking for Mix styles |
 | `mix_tailwinds` | Tailwind-style utility layer (experimental) |
+| `mix_chart` | Mix-owned line, bar, and pie chart APIs |
 
 ## References
 
@@ -159,6 +182,7 @@ Consult these for detailed guidance:
 
 - **[`references/architecture.md`](references/architecture.md)** — Spec, Styler, Prop<V>, resolution pipeline, StyleWidget
 - **[`references/styler-api-policy.md`](references/styler-api-policy.md)** — Top-level rule, dot-shorthand policy, factory constructor table, chain-only methods
+- **[`references/layout.md`](references/layout.md)** — Box/Flex/Wrap/Grid/Stack selection, responsive Grid use cases, constraints, and layout composition
 - **[`references/fluent-api.md`](references/fluent-api.md)** — Chaining, style mixins, sizing decision tree, composition
 - **[`references/code-generation.md`](references/code-generation.md)** — Annotations, generated output, BoxSpec reference impl
 - **[`references/examples.md`](references/examples.md)** — Worked end-to-end examples

--- a/skills/mix/agents/openai.yaml
+++ b/skills/mix/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
   display_name: "Mix"
-  short_description: "Work with Mix Flutter styles, specs, and codegen."
+  short_description: "Work with Mix Flutter styles, layouts, specs, and codegen."
   brand_color: "#13B9FD"
-  default_prompt: "Use Mix to build a responsive Flutter card style."
+  default_prompt: "Use Mix to build a container-responsive Flutter dashboard layout."

--- a/skills/mix/references/code-generation.md
+++ b/skills/mix/references/code-generation.md
@@ -56,7 +56,9 @@ Use legacy `@MixableStyler()` only when maintaining an existing handwritten Styl
 
 ### `@MixWidget()`
 
-Applied to a top-level variable or function returning a `Style<S>`. It generates a `StatelessWidget` wrapper whose `build()` delegates to the styler's `call()`.
+Apply to a top-level variable or function returning a `Style<S>`. It generates a
+`StatelessWidget` wrapper whose `build()` delegates to the styler's `call()` or
+to an explicitly configured plain Widget target.
 
 ```dart
 @MixWidget()
@@ -66,7 +68,58 @@ final cardStyle = BoxStyler().paddingAll(16).borderRounded(12);
 
 By default, the widget name is derived from a lowerCamelCase element name ending in `Style`: `cardStyle` becomes `Card`, and leading underscores are preserved. Override the name with `@MixWidget(name: 'X')`.
 
-`@MixWidget` complements `@MixableSpec(target:)`; it wraps a style factory after a Styler exists, while `@MixableSpec(target:)` generates the Styler and its `call()` support. Mix's own specs use `@MixableSpec(target:)`; `@MixWidget` is mainly a downstream-author convenience.
+For a plain Widget with a compatible named `style` parameter, pass its
+constructor tear-off through `target`. The Widget does not need to extend
+`StyleWidget` or expose a Styler extension `call()` method. This direct-target
+path ships in `mix_generator 2.2.0-beta.2` with
+`mix_annotations 2.2.0-beta.1`:
+
+```dart
+@MixWidget(
+  name: 'AppButton',
+  target: PlainButton.new,
+  widgetParameters: .only({'label', 'onPressed'}),
+  factoryParameters: .only({'variant', 'size'}),
+)
+ButtonStyler appButtonStyle({
+  ButtonVariant variant = .solid,
+  ButtonSize size = .medium,
+  bool highContrast = false,
+}) => switch (variant) {
+  .solid => solidButtonStyle(size, highContrast: highContrast),
+  .soft => softButtonStyle(size, highContrast: highContrast),
+};
+```
+
+Use `widgetParameters` to curate parameters read from the Styler `call()` or
+plain target constructor. Use `factoryParameters` to curate the recipe
+function's own parameters. Required parameters must remain selected; omitted
+optional parameters use their original defaults. The target's `style` and
+`styleSpec` parameters never become generated wrapper fields.
+
+When a recipe function has a named, non-nullable enum parameter named exactly
+`variant` and that parameter remains selected by `factoryParameters`, generate
+one named constructor per accessible enum value while retaining the unnamed
+constructor:
+
+```dart
+AppButton.solid(label: 'Save')
+AppButton.soft(label: 'Save')
+AppButton(variant: selectedVariant, label: 'Save')
+```
+
+Do not add an `EnumVariant` mixin solely for this feature. The enum is a recipe
+switch key and does not enter Mix's runtime variant system. Nullable,
+positional, non-enum, or differently named parameters retain the unnamed-only
+constructor shape. Preserve the unnamed constructor because runtime-selected
+variants cannot choose a named constructor at compile time.
+
+`@MixWidget` complements `@MixableSpec(target:)`; it wraps a style recipe after
+a Styler exists, while `@MixableSpec(target:)` generates the Styler and its
+`call()` support. Mix's own specs use `@MixableSpec(target:)`; `@MixWidget` is
+mainly a downstream-author convenience. Consult
+`guides/mix-widget-variant-constructors.md` before changing this contract; its
+future curation rename is a decision record, not shipped API on current `main`.
 
 ### `@MixableModifier()`
 
@@ -125,7 +178,16 @@ final EdgeInsetsGeometry? padding;
 
 @MixableField(skipMixin: true)
 final Matrix4? transform;
+
+@MixableField(forwardStyler: true)
+final StyleSpec<LabelSpec>? label;
 ```
+
+Nested `StyleSpec<XSpec>` fields derive `XStyler` by convention for generated
+constructors and setters. Use `setterType` only to override that convention.
+Use `forwardStyler: true` to project a nested Styler's canonical factories and
+fluent anchors onto the parent Styler; add `stylerSurface` only when generation
+needs an explicit compatible surface during a same-package clean build.
 
 For legacy handwritten stylers:
 

--- a/skills/mix/references/development-workflow.md
+++ b/skills/mix/references/development-workflow.md
@@ -10,9 +10,11 @@ packages/
   mix_annotations/        # Annotations for codegen
   mix_generator/          # build_runner generator
   mix_lint/               # Analysis server plugin
-  mix_lint_test/          # Lint rule tests
+  mix_protocol/           # Versioned JSON wire contract and codecs
   mix_tailwinds/          # Tailwind utility layer
   mix_tailwinds/example/  # Tailwind example app
+  mix_chart/              # Mix-owned chart API
+  mix_chart/example/      # Chart example app
 ```
 
 **SDK constraints:** Dart >=3.11.0, Flutter >=3.41.0
@@ -122,11 +124,14 @@ Generated Stylers are not edited directly. Edit the spec annotation, fields, wid
 | `melos run gen:build` | Clean + regenerate all `*.g.dart` files |
 | `melos run gen:watch` | Watch mode for codegen |
 | `melos run gen:clean` | Clean generated outputs |
+| `melos run gen:tailwinds-registry` | Regenerate the deterministic Tailwinds parser registry |
 | `melos run ci` | Run all tests (flutter + dart) |
 | `melos run test:flutter` | Flutter tests only |
 | `melos run test:dart` | Dart tests only |
 | `melos run test:coverage` | Tests with coverage report |
 | `melos run analyze` | Dart + DCM analysis |
+| `melos run schema:inventory` | Verify `mix_protocol` schema inventory coverage |
+| `melos run format:check` | Verify Dart formatting without changing files |
 | `melos run fix` | Auto-fix lint issues |
 | `melos run exports` | Regenerate `mix.dart` barrel file |
 | `melos run api-check` | API compatibility checking |

--- a/skills/mix/references/fluent-api.md
+++ b/skills/mix/references/fluent-api.md
@@ -117,6 +117,40 @@ Decoration, color, gradient, border, shadow, shape, background image:
 | `spacing(v)` | Gap between children |
 | `row()` / `column()` | Direction shortcuts |
 
+### WrapStyleMixin (on WrapStyler/WrapBoxStyler)
+
+`WrapBoxStyler` flattens the common Wrap fields while keeping Box collisions
+explicit:
+
+| Method | Description |
+|--------|-------------|
+| `direction(axis)` | Wrap main-axis direction |
+| `spacing(v)` | Space between children within a run |
+| `runSpacing(v)` | Space between runs |
+| `wrapAlignment(v)` | Child alignment within each run |
+| `runAlignment(v)` | Run alignment on the cross axis |
+| `crossAxisAlignment(v)` | Child alignment within a run's cross axis |
+| `wrapClipBehavior(v)` | Inner Wrap clipping |
+| `flow(WrapStyler(...))` | Direct nested Wrap-style composition |
+
+On `WrapBoxStyler`, `alignment()` and `clipBehavior()` belong to the outer Box.
+Use `wrapAlignment()` and `wrapClipBehavior()` for the inner Wrap.
+
+### GridBoxStyler
+
+`GridBoxStyler` is handwritten because Grid adds render-time local constraint
+selection. Prefer an explicitly typed factory initializer:
+
+```dart
+final GridBoxStyler grid = .equalColumns(3)
+    .gap(16)
+    .autoRows(.fixed(220));
+```
+
+Use `columns`, `equalColumns`, `rows`, `autoRows`, `gap`, `columnGap`,
+`rowGap`, `clipBehavior`, and `onConstraints`. See [`layout.md`](layout.md) for
+the Grid track model, use cases, constraints, and animation compatibility.
+
 ### TextStyleMixin (on TextStyler)
 
 | Method | Description |
@@ -211,6 +245,7 @@ Use `Pressable` for interaction state around any child, and `PressableBox` when 
 ## Sizing Decision Tree
 
 See [`styler-api-policy.md`](styler-api-policy.md) for the canonical sizing and composition decision tree.
+See [`layout.md`](layout.md) when choosing among Box, Flex, Wrap, Grid, and Stack.
 
 ## Composition via Merge
 
@@ -218,7 +253,7 @@ Use `merge()` for combining reusable style fragments; see [`styler-api-policy.md
 
 ## Callable Stylers
 
-Widget-backed Stylers support `call()` for inline widget creation. This includes `BoxStyler`, `TextStyler`, `IconStyler`, `ImageStyler`, `FlexBoxStyler`, and `StackBoxStyler`; layout-only stylers such as `FlexStyler` and `StackStyler` do not create widgets directly.
+Widget-backed generated Stylers support `call()` for inline widget creation. This includes `BoxStyler`, `TextStyler`, `IconStyler`, `ImageStyler`, `FlexBoxStyler`, `WrapBoxStyler`, and `StackBoxStyler`; layout-only stylers such as `FlexStyler`, `WrapStyler`, and `StackStyler` do not create widgets directly. `GridBoxStyler` is handwritten and is not callable; construct `GridBox(style: ..., children: ...)` explicitly.
 
 ```dart
 BoxStyler().color(Colors.blue).paddingAll(16)(child: Text('Hello'))

--- a/skills/mix/references/layout.md
+++ b/skills/mix/references/layout.md
@@ -1,0 +1,272 @@
+# Layout with Mix
+
+Choose and compose Mix-owned layout primitives without falling back to raw
+Flutter layout widgets for styling concerns.
+
+## Verify API Availability
+
+Check the consuming package's `pubspec.yaml` and resolved dependency before
+using a layout API. This repository's `main` branch includes `WrapBox` and
+`GridBox`, but both landed after the `mix 2.2.0-beta.1` release. When working in
+the Mix repository, prefer local source. When working downstream, confirm the
+installed version exposes the referenced classes.
+
+## Select the Primitive
+
+| Layout need | Mix primitive | Why |
+|---|---|---|
+| One child with size, padding, constraints, or decoration | `Box` + `BoxStyler` | Owns single-child box styling |
+| One non-wrapping horizontal or vertical sequence | `RowBox`, `ColumnBox`, or `FlexBox` + `FlexBoxStyler` | Combines Flex geometry with outer Box styling |
+| Intrinsic items that should flow onto additional runs | `WrapBox` + `WrapBoxStyler` | Models tags, chips, and button groups without fixed tracks |
+| Explicit two-dimensional rows and columns | `GridBox` + `GridBoxStyler` | Models dashboards, card catalogs, and galleries with fixed/`fr` tracks |
+| Overlapping or positioned children | `StackBox` + `StackBoxStyler` | Combines Stack geometry with outer Box styling |
+
+Prefer the simplest primitive that represents the layout semantics. Do not use
+Grid merely to place a single row, and do not use Wrap when columns must align
+across runs.
+
+## Understand Composite Layouts
+
+`FlexBox`, `WrapBox`, and `StackBox` resolve a layout sub-spec and optionally an
+outer `BoxSpec`. Their Stylers therefore expose both layout and Box methods.
+Keep decoration, padding, margin, transforms, and constraints on the composite
+Styler instead of nesting a raw `Container`.
+
+`GridBox` is different: it owns Grid geometry, clipping, Mix variants,
+modifiers, and animation, but it does not contain an outer `BoxSpec`. Wrap it
+in `Box` when the grid itself needs padding or decoration:
+
+```dart
+Box(
+  style: BoxStyler().paddingAll(16).color(Colors.white),
+  child: GridBox(style: gridStyle, children: cards),
+);
+```
+
+Use the layout-only `FlexStyler`, `WrapStyler`, and `StackStyler` when composing
+the nested sub-style directly. For ordinary widget code, start from the
+corresponding `*BoxStyler`.
+
+## Build One-Dimensional Layouts
+
+Use `RowBox` or `ColumnBox` when direction is fixed by the widget:
+
+```dart
+final toolbarStyle = FlexBoxStyler()
+    .mainAxisAlignment(.spaceBetween)
+    .crossAxisAlignment(.center)
+    .spacing(12)
+    .paddingAll(16);
+
+RowBox(style: toolbarStyle, children: actions);
+```
+
+Do not set a conflicting direction on a `RowBox` or `ColumnBox` style. Use
+`FlexBox` when direction itself is dynamic:
+
+```dart
+final contentStyle = FlexBoxStyler()
+    .direction(isCompact ? .vertical : .horizontal)
+    .spacing(16);
+
+FlexBox(style: contentStyle, children: sections);
+```
+
+Use `.wrap(WidgetModifierConfig.flexible(...))` on a child Styler when that
+child needs Flutter `Flexible` behavior inside a Flex layout. Keep parent
+alignment and spacing on `FlexBoxStyler`.
+
+## Build Wrapping Layouts
+
+Use `WrapBox` for items whose intrinsic widths determine where runs break:
+
+```dart
+final tagCloudStyle = WrapBoxStyler()
+    .paddingAll(16)
+    .spacing(8)
+    .runSpacing(10)
+    .wrapAlignment(.center);
+
+WrapBox(style: tagCloudStyle, children: tags);
+```
+
+Distinguish the collision-safe composite names:
+
+- `.alignment(...)` and `.clipBehavior(...)` configure the outer Box.
+- `.wrapAlignment(...)` and `.wrapClipBehavior(...)` configure the inner Wrap.
+- `.flow(WrapStyler(...))` replaces or merges the nested Wrap style directly.
+- `.wrap(...)` remains Mix's widget-modifier API, so the nested Wrap field is
+  intentionally named `flow`.
+
+Choose Wrap over Grid for tags, filters, and button groups that have varying
+intrinsic widths. Choose Grid when cells need shared column boundaries or
+explicit row heights.
+
+## Build Two-Dimensional Grid Layouts
+
+### Start with explicit tracks
+
+Give a Grid declaration an explicit `GridBoxStyler` type, then use factory
+shorthand to make its topology visible:
+
+```dart
+final GridBoxStyler cardGridStyle = .equalColumns(3)
+    .gap(16)
+    .autoRows(.fixed(220));
+
+GridBox(style: cardGridStyle, children: cards);
+```
+
+Use `.equalColumns(count)` for equal `fr(1)` columns. Use `.columns([...])` for
+mixed geometry:
+
+```dart
+final GridBoxStyler reportGridStyle = .columns([
+  .fixed(240),
+  .fr(2),
+  .fr(1),
+]).columnGap(16).autoRows(.fixed(280));
+```
+
+Interpret tracks as follows:
+
+- `.fixed(240)` consumes 240 logical pixels and does not shrink.
+- `.fr(2)` receives twice the remaining space of `.fr(1)` after fixed tracks
+  and gaps.
+- Fractional columns require bounded width.
+- Fractional rows and fractional `autoRows` require bounded height.
+
+### Provide row geometry
+
+Children fill columns left to right, then advance row by row. Provide enough
+explicit `.rows([...])` tracks for every required row or set `.autoRows(...)`
+for the remaining rows. A non-empty Grid with no applicable row track reports
+an error instead of guessing content-sized geometry.
+
+```dart
+final GridBoxStyler galleryStyle = .equalColumns(2)
+    .rows([.fixed(180)])
+    .autoRows(.fixed(180))
+    .columnGap(12)
+    .rowGap(12);
+```
+
+With five children and two columns, this Grid needs three rows. The first uses
+the explicit track and the next two repeat `autoRows`. In a vertical
+`SingleChildScrollView`, use fixed row tracks because height is unbounded.
+
+### Respond to the offered container
+
+Use `.onConstraints(...)` when a Grid should adapt to the maximum size offered
+by its own parent:
+
+```dart
+final GridBoxStyler responsiveCards = .equalColumns(3)
+    .gap(16)
+    .autoRows(.fixed(220))
+    .onConstraints(
+      .maxWidth(760),
+      .equalColumns(2).gap(12),
+    )
+    .onConstraints(
+      .maxWidth(520),
+      .equalColumns(1).gap(10),
+    );
+```
+
+Apply matching branches in declaration order. In the example, both maximum
+width branches match below 520, so the later one-column patch refines the
+earlier two-column patch.
+
+Keep `onConstraints` patches geometry-only. They may set columns, rows,
+`autoRows`, `columnGap`, and `rowGap`. They may not set clipping, modifiers,
+animations, ordinary variants, or nested constraint branches. Put those values
+on the base `GridBoxStyler`.
+
+Use `.onBreakpoint(...)` instead when the decision should observe viewport
+size through `MediaQuery`. Two Grids in the same viewport can select different
+`onConstraints` branches because their parents offer different widths.
+
+### Pick Grid for concrete use cases
+
+Use responsive `GridBox` for:
+
+- metric dashboards whose panels collapse from four to two to one column;
+- product catalogs with equal card widths and repeated fixed row heights;
+- media galleries with aligned tracks and controlled clipping;
+- asymmetric report layouts using fixed sidebar tracks plus fractional content;
+- nested components that should respond to their container rather than the
+  whole device viewport.
+
+Avoid the current Grid API when the design requires content-sized tracks,
+spans, named areas, masonry packing, direction-aware placement, or baseline
+alignment. Those features are intentionally outside the current contract. Use
+a more suitable Flutter layout or redesign the track model rather than
+pretending the API supports them.
+
+### Animate compatible geometry
+
+Use the standard Mix `.animate(...)` API when state changes Grid geometry:
+
+```dart
+final GridBoxStyler animatedGrid = .columns([
+  .fr(focused ? 2 : 1),
+  .fr(1),
+])
+    .autoRows(.fixed(focused ? 148 : 112))
+    .gap(focused ? 20 : 12)
+    .animate(.easeInOut(const Duration(milliseconds: 400)));
+```
+
+Keep track lists the same length and keep each positional track kind compatible
+(`fixed` with `fixed`, `fr` with `fr`) for continuous interpolation. Compatible
+rows, `autoRows`, and gaps interpolate too. Track-count or track-kind changes,
+clipping, and constraint-patch lists switch at the midpoint. A live
+`onConstraints` branch change remains immediate because selection happens
+during layout rather than creating a new animation target.
+
+### Handle overflow deliberately
+
+Expect fixed tracks to preserve their requested size even when they exceed the
+available extent. Leave `clipBehavior` at `.none` when overflow should remain
+visible with diagnostics, or set it on the base style when painting must be
+contained:
+
+```dart
+final GridBoxStyler clippedGallery = .equalColumns(4)
+    .autoRows(.fixed(160))
+    .gap(12)
+    .clipBehavior(.hardEdge);
+```
+
+## Build Overlays
+
+Use `StackBox` for badges, overlays, and positioned content:
+
+```dart
+final overlayStyle = StackBoxStyler()
+    .paddingAll(12)
+    .borderRounded(16)
+    .stackAlignment(.bottomCenter)
+    .stackClipBehavior(.none);
+
+StackBox(style: overlayStyle, children: layers);
+```
+
+Distinguish `.alignment(...)` and `.clipBehavior(...)` for the outer Box from
+`.stackAlignment(...)` and `.stackClipBehavior(...)` for the inner Stack. Use
+`.stack(StackStyler(...))` for direct nested-style composition.
+
+## Verify Layout Work
+
+Check the smallest source and test surface that owns the behavior:
+
+- Grid guide: `packages/mix/doc/grid-layout.md`
+- Grid runnable use cases: `packages/mix/example/lib/grid_example.dart`
+- Grid contract tests: `packages/mix/test/src/layout/`
+- Wrap runnable use case: `packages/mix/example/lib/main.dart`
+- Flex, Wrap, and Stack composites: `packages/mix/lib/src/specs/`
+
+Run focused widget tests while iterating. Before handing off changes to Mix
+layout internals, run the repository-required generation, test, and analysis
+commands from the main skill.

--- a/skills/mix/references/styler-api-policy.md
+++ b/skills/mix/references/styler-api-policy.md
@@ -6,7 +6,7 @@ Requires Dart SDK >=3.11.0 and Flutter >=3.41.0.
 
 ## The Top-Level Rule
 
-Start every top-level style declaration with an instance constructor, then chain:
+Start ordinary top-level style declarations with an instance constructor, then chain:
 
 ```dart
 // CORRECT — instance constructor at top-level
@@ -22,6 +22,20 @@ BoxStyler.color(Colors.blue)
 
 // WRONG — bare dot-shorthand at top-level
 .color(Colors.blue)
+```
+
+Use an explicitly typed factory initializer when the factory communicates
+required topology better than an empty constructor. Grid is the deliberate
+case in the current API:
+
+```dart
+// CORRECT — the declared type supplies shorthand context
+final GridBoxStyler cards = .equalColumns(3)
+    .gap(16)
+    .autoRows(.fixed(220));
+
+// WRONG — no contextual type for the leading shorthand
+final cards = .equalColumns(3);
 ```
 
 ## Nested Shorthand Rule
@@ -43,9 +57,11 @@ style.onHovered(BoxStyler().color(Colors.blue))
 ```
 
 Common typed contexts:
+- explicitly typed initializers such as `final GridBoxStyler grid = .columns(...)`
 - `.container(.shadow(...))`
 - `.onHovered(.color(...))`
 - `.onDisabled(.color(...))`
+- `.onConstraints(.maxWidth(600), .equalColumns(1))`
 
 ## Dot-Shorthand for Enum/Constant Arguments
 
@@ -68,8 +84,11 @@ Common generated factories include:
 | `BoxStyler` | layout (`alignment`, `padding`, `margin`, constraints), decoration (`color`, `gradient`, `border`, `borderRadius`, `shadow`, `image`, `shape`), transforms (`transform`, `scale`, `rotate`, `translate`, `skew`), gradients/background images, `textStyle`, `animate` |
 | `FlexStyler` | `direction`, `mainAxisAlignment`, `crossAxisAlignment`, `mainAxisSize`, `spacing`, row/column presets |
 | `FlexBoxStyler` | generated flexbox spec fields plus many box-style factories; verify clip/flex naming in `flexbox_spec.g.dart` |
+| `WrapStyler` | `direction`, `alignment`, `spacing`, `runAlignment`, `runSpacing`, `crossAxisAlignment`, `clipBehavior` |
+| `WrapBoxStyler` | generated wrapbox fields plus Box factories; use collision-safe `wrapAlignment` and `wrapClipBehavior` for the inner Wrap |
+| `GridBoxStyler` | handwritten `columns`, `equalColumns`, `rows`, `autoRows`, gaps, `clipBehavior`, `onConstraints`, `animate` |
 | `StackStyler` | `alignment`, `fit`, `clipBehavior` |
-| `StackBoxStyler` | generated stackbox spec fields plus box-style factories; verify stack-specific names in `stackbox_spec.g.dart` |
+| `StackBoxStyler` | generated stackbox fields plus Box factories; use `stackAlignment` and `stackClipBehavior` for the inner Stack |
 | `TextStyler` | layout (`overflow`, `textAlign`, `maxLines`, `softWrap`, direction), typography (`style`, color/font/decoration/spacing), paint/shadow/font-feature fields, text directives (`uppercase`, `lowercase`, `capitalize`, `titlecase`, `sentencecase`) |
 | `IconStyler` | `icon`, `color`, `size`, `weight`, `grade`, `opticalSize`, `fill`, `opacity`, `shadows`, `shadow`, `textDirection`, `applyTextScaling`, `blendMode` |
 | `ImageStyler` | `image`, dimensions, `color`, `repeat`, `fit`, `alignment`, `centerSlice`, `filterQuality`, `colorBlendMode`, `gaplessPlayback`, `isAntiAlias`, `matchTextDirection` |
@@ -84,7 +103,7 @@ These are mid-chain or end-of-chain policy choices. Some may also have generated
 | Compound border | `border(.all())`, `border(.top())`, `borderRadius(.circular())` |
 | Compound box | `shadow(.color(...).blurRadius(...))`, `backgroundImageUrl` |
 | Text directives | `uppercase`, `lowercase`, `capitalize`, `titlecase`, `sentencecase` |
-| Variants | `onHovered`, `onPressed`, `onDark`, `onLight`, `onDisabled`, `onFocused`, `variant`, `onBreakpoint` |
+| Variants and local constraints | `onHovered`, `onPressed`, `onDark`, `onLight`, `onDisabled`, `onFocused`, `variant`, `onBreakpoint`, Grid `onConstraints` |
 | Advanced modifiers | `wrap`, `phaseAnimation`, `keyframeAnimation` |
 
 **Rationale:** Factory constructors are reserved for primitives that map to stable style concepts. Compound convenience methods remain as instance methods to keep the static API focused.
@@ -96,6 +115,7 @@ These are mid-chain or end-of-chain policy choices. Some may also have generated
 - Min/max bounds? → `BoxStyler().minWidth(100).maxWidth(300)`
 - Pre-built Size/constraints? → Pass via constructor
 - Combining fragments? → `merge()`
+- Choosing a multi-child layout? → Use the decision guide in [`layout.md`](layout.md)
 - Otherwise → Chain on the Styler instance
 
 ## Composition Examples


### PR DESCRIPTION
#### Related issue

None.

### Description

Refreshes the Mix agent plugin for current `main`, with practical WrapBox/GridBox layout guidance and a curated root `llms.txt`.

### Changes

- Add focused Box/Flex/Wrap/Grid/Stack guidance covering Grid use cases, local constraints, row sizing, animation, overflow, and current limitations
- Update skill triggers, plugin metadata, fluent/codegen/workflow references, and package coverage for recent APIs
- Add a standards-shaped `llms.txt` that routes agents to current source, examples, and machine-contract documentation

**Review Checklist**

- [x] **Testing**: Focused Grid/Wrap and `@MixWidget` suites, metadata, links, `llms.txt`, and diff checks pass
- [x] **Breaking Changes**: Reviewed; no runtime or package API changes
- [x] **Documentation Updates**: Agent skill, references, plugin metadata, and LLM index are updated
- [ ] **Website Updates**: A separate `mix-docs` update is still needed to expose the Mix `llms.txt` route

### Additional Information (optional)

Validation:

- `fvm flutter test test/src/layout/grid_public_api_test.dart test/src/specs/wrapbox/wrapbox_style_test.dart test/src/specs/wrapbox/wrapbox_widget_test.dart` — 13 passed
- `fvm dart test test/integration/mix_widget_variant_constructor_test.dart test/integration/mix_widget_spec_styler_test.dart` — 21 passed
- JSON/YAML, relative-link, `llms.txt`, and `git diff --check` checks — passed

`WrapBox` and `GridBox` are labeled as repository-main APIs that landed after `mix 2.2.0-beta.1`.
