### PR TITLE
chore(mix): prepare 2.2.0-beta.2

### DIFF
--- a/packages/mix/CHANGELOG.md
+++ b/packages/mix/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.2.0-beta.1
+## 2.2.0-beta.2
 
 ### New features
 
@@ -12,6 +12,8 @@
   `WrapBoxStyler`, and `WrapBox` family with flattened fluent Wrap styling,
   collision-safe Box/Wrap names, generated constructors and factories, and a
   runnable gallery example.
+
+## 2.2.0-beta.1
 
 ### Fixes
 

--- a/packages/mix/pubspec.yaml
+++ b/packages/mix/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mix
 description: An expressive way to effortlessly build design systems in Flutter.
-version: 2.2.0-beta.1
+version: 2.2.0-beta.2
 homepage: https://github.com/btwld/mix
 repository: https://github.com/btwld/mix/tree/main/packages/mix
 

--- a/skills/mix/SKILL.md
+++ b/skills/mix/SKILL.md
@@ -22,8 +22,8 @@ description: >
 
 Type-safe styling system for Flutter that separates style semantics from widgets.
 
-**Repository target:** current `main` (`mix` pubspec: `2.2.0-beta.1`, Dart >=3.11.0, Flutter >=3.41.0).
-Confirm the consuming project's actual version before applying patterns. `WrapBox` and `GridBox` landed on `main` after `2.2.0-beta.1`, so a released dependency may not expose them yet.
+**Repository target:** current `main` (`mix` pubspec: `2.2.0-beta.2`, Dart >=3.11.0, Flutter >=3.41.0).
+Confirm the consuming project's actual version before applying patterns. `WrapBox` and `GridBox` ship in `2.2.0-beta.2`, so an older resolved dependency may not expose them yet.
 
 ## Source of Truth
 

--- a/skills/mix/references/layout.md
+++ b/skills/mix/references/layout.md
@@ -7,7 +7,7 @@ Flutter layout widgets for styling concerns.
 
 Check the consuming package's `pubspec.yaml` and resolved dependency before
 using a layout API. This repository's `main` branch includes `WrapBox` and
-`GridBox`, but both landed after the `mix 2.2.0-beta.1` release. When working in
+`GridBox`, both first shipped in the `mix 2.2.0-beta.2` release. When working in
 the Mix repository, prefer local source. When working downstream, confirm the
 installed version exposes the referenced classes.
 


### PR DESCRIPTION
## Summary

Prepares the `mix` package for the `2.2.0-beta.2` release.

- Bump `packages/mix/pubspec.yaml` to `2.2.0-beta.2`.
- Fix the changelog: the GridBox (#1002) and WrapBox (#1001) entries had been added under the `2.2.0-beta.1` heading, which was already published to pub.dev. They now live in a new `2.2.0-beta.2` section, leaving `2.2.0-beta.1` with only the BoxShadow blur-style fix (#992) that actually shipped in it.
- Update `skills/mix/SKILL.md` and `skills/mix/references/layout.md` so the "WrapBox / GridBox are not in a release yet" caveats point at `2.2.0-beta.2`.

No library code changes.

Out of scope: `mix_annotations` (`2.2.0-beta.1`) and `mix_generator` (`2.2.0-beta.2`) are untouched.

## Test plan

- `dart pub publish --dry-run` in `packages/mix` — clean apart from the expected uncommitted-files warning
- `flutter analyze` — no issues
- `flutter test` in `packages/mix` — 2831 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)