### PR TITLE
chore(mix): prepare skill for skills.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@
 .history
 .svn/
 
+# Public skills live in /skills; keep CLI-installed local copies untracked.
+/.agents/
+/.claude/skills
+
 # IntelliJ related
 *.iml
 *.ipr

--- a/README.md
+++ b/README.md
@@ -6,13 +6,48 @@
 ![GitHub stars](https://img.shields.io/github/stars/btwld/mix?style=for-the-badge&logo=GitHub&logoColor=black&labelColor=white&color=dddddd)
 [![Pub Version](https://img.shields.io/pub/v/mix?label=version&style=for-the-badge)](https://pub.dev/packages/mix/changelog)
 ![Pub Likes](https://img.shields.io/pub/likes/mix?label=Pub%20Likes&style=for-the-badge)
-![Pub Points](https://img.shields.io/pub/points/mix?label=Pub%20Points&style=for-the-badge) [![MIT Licence](https://img.shields.io/github/license/btwld/mix?style=for-the-badge&longCache=true)](https://opensource.org/license/mit) [![Awesome Flutter](https://img.shields.io/badge/awesome-flutter-purple?longCache=true&style=for-the-badge)](https://github.com/Solido/awesome-flutter)
+![Pub Points](https://img.shields.io/pub/points/mix?label=Pub%20Points&style=for-the-badge) [![MIT Licence](https://img.shields.io/github/license/btwld/mix?style=for-the-badge&longCache=true)](https://opensource.org/license/mit) [![Awesome Flutter](https://img.shields.io/badge/awesome-flutter-purple?longCache=true&style=for-the-badge)](https://github.com/Solido/awesome-flutter) [![skills.sh](https://skills.sh/b/btwld/mix)](https://skills.sh/btwld/mix)
 
 **Mix** is a styling system for Flutter that separates style definitions from widget structure. It provides a composable, type-safe way to define and apply styles using a fluent API, design tokens, and context-aware variants.
 
 - Compose, merge, and apply styles across widgets
 - Write maintainable styling definitions separate from widget code
 - Adapt styles conditionally based on interactions and context
+
+## Agent skill
+
+The [`mix`](https://skills.sh/btwld/mix/mix) skill helps coding agents build
+Flutter UI with Mix and maintain this monorepo's specs, generators, variants,
+animations, tokens, modifiers, and packages.
+
+List the repository's available skills without installing them:
+
+```bash
+npx skills add btwld/mix --list
+```
+
+Install the skill in the current project:
+
+```bash
+npx skills add btwld/mix --skill mix -y
+```
+
+Project installation creates a local agent-skills directory such as
+`.agents/`. It is ignored because [`skills/`](skills) is the committed source
+catalog. Install globally or invoke the skill ephemerally when you do not want
+a project-local copy:
+
+```bash
+npx skills add btwld/mix --skill mix -g -y
+npx skills use btwld/mix@mix
+```
+
+List installed skills and update them later:
+
+```bash
+npx skills ls
+npx skills update
+```
 
 ## Why Mix?
 

--- a/skills/mix/SKILL.md
+++ b/skills/mix/SKILL.md
@@ -1,29 +1,38 @@
 ---
 name: mix
-description: >
-  This skill should be used when working on the Mix Flutter styling
-  framework or any project using the mix package. Applies when the user
-  mentions Mix specs, Mix styles, BoxStyler, TextStyler, Pressable,
-  PressableBox, FlexBox, RowBox, ColumnBox, WrapBox, GridBox, GridTrack,
-  StackBox, responsive layouts, onConstraints, StyleWidget, MixStyler,
-  fluent chaining, Prop values, Mix types,
-  Mix annotations (@MixableSpec, @MixWidget, @MixableModifier, legacy
-  @MixableStyler, @Mixable), code generation with mix_generator,
-  dot-shorthand policy, style variants (NamedVariant,
-  ContextVariant, WidgetStateVariant, onHovered, onPressed, onDark), implicit
-  animations with .animate(), Phase animations, Keyframe animations, design
-  tokens (MixScope, tokens), widget modifiers (.wrap()), directives, style
-  mixins, melos commands for Mix (gen:build, ci, analyze, exports), or the
-  Mix monorepo packages (mix, mix_annotations, mix_generator, mix_lint,
-  mix_protocol, mix_winds, mix_chart).
+description: >-
+  Use when building or maintaining Flutter UI with the Mix styling framework:
+  Mix specs and stylers, BoxStyler, TextStyler, Pressable, FlexBox, WrapBox,
+  GridBox, StackBox, responsive layouts, fluent chaining, Prop values, Mix
+  annotations and mix_generator code generation, dot shorthand, variants,
+  animations, design tokens and MixScope, widget modifiers, directives, style
+  mixins, or the Mix monorepo packages (mix, mix_annotations, mix_generator,
+  mix_lint, mix_protocol, mix_winds, and mix_chart). Also trigger for UI work in
+  a project that already depends on `mix`. Do not trigger for generic Flutter
+  work when Mix is neither present nor requested.
 ---
 
 # Mix Framework
 
 Type-safe styling system for Flutter that separates style semantics from widgets.
 
-**Repository target:** current `main` (`mix` pubspec: `2.2.0-beta.2`, Dart >=3.11.0, Flutter >=3.41.0).
-Confirm the consuming project's actual version before applying patterns. `WrapBox` and `GridBox` ship in `2.2.0-beta.2`, so an older resolved dependency may not expose them yet.
+## Set Up Mix
+
+Inspect the consuming project's `pubspec.yaml` or lockfile before assuming Mix
+is available or applying version-specific APIs.
+
+```bash
+flutter pub add mix
+```
+
+```dart
+import 'package:mix/mix.dart';
+```
+
+In the Mix repository, read `packages/mix/pubspec.yaml` for the current SDK,
+Flutter, and package versions. In a consumer repository, follow its resolved
+version; older releases may not expose newer primitives such as `WrapBox` and
+`GridBox`.
 
 ## Source of Truth
 

--- a/skills/mix/agents/openai.yaml
+++ b/skills/mix/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
   display_name: "Mix"
-  short_description: "Work with Mix Flutter styles, layouts, specs, and codegen."
+  short_description: "Build Flutter UI with Mix styles and codegen"
   brand_color: "#13B9FD"
-  default_prompt: "Use Mix to build a container-responsive Flutter dashboard layout."
+  default_prompt: "Use $mix to build this Flutter interface with composable Mix stylers, variants, and tokens."

--- a/skills/mix/evals/evals.json
+++ b/skills/mix/evals/evals.json
@@ -1,0 +1,53 @@
+{
+  "skill_name": "mix",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "This Flutter app depends on mix. Build a reusable profile card with padding, rounded corners, a background color, an avatar, and styled title/subtitle text.",
+      "expected_output": "Imports package:mix/mix.dart, keeps visual semantics in Mix widgets and stylers (such as Box/BoxStyler and StyledText/TextStyler), starts top-level styles from concrete styler constructors, and avoids replacing the requested Mix styling with nested Container/Padding/TextStyle boilerplate.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "Create a dashboard that uses one column when its parent is narrow and three explicit fractional columns when wide. The dashboard can appear inside a side panel, so viewport width is not reliable.",
+      "expected_output": "Chooses GridBox with an explicitly typed GridBoxStyler and uses onConstraints for parent-offered width rather than onBreakpoint/MediaQuery; keeps grid geometry in constraint branches and explains that GridBox needs an outer Box when decoration or padding is required.",
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "Set up brand color, spacing, and body typography tokens with a light/dark theme, then consume them from a Mix-styled card.",
+      "expected_output": "Defines the appropriate ColorToken, SpaceToken, and TextStyleToken values, provides them through MixScope, consumes token references inside stylers (including textToken.mix() for typography), and uses context variants or scope replacement for theme changes instead of resolving raw Theme values inside reusable style declarations.",
+      "files": []
+    },
+    {
+      "id": 4,
+      "prompt": "Make a PressableBox darken on hover, shrink while pressed, show a keyboard-only focus ring, and animate between those states.",
+      "expected_output": "Uses PressableBox with BoxStyler widget-state variants onHovered/onPressed/onFocusVisible and an AnimationConfig via animate; uses bare dot shorthand in typed nested variant and animation contexts and does not manually manage hover/press booleans.",
+      "files": []
+    },
+    {
+      "id": 5,
+      "prompt": "Inside the Mix monorepo, add a new widget-backed BannerSpec with generated styling APIs. Which annotations, files, and commands should I use?",
+      "expected_output": "Uses an immutable spec with @MixableSpec(target: Banner.new), a compatible widget style parameter, generated part files and exports, runs melos run gen:build and melos run exports, and treats @MixableStyler as legacy rather than the default implementation path.",
+      "files": []
+    },
+    {
+      "id": 6,
+      "prompt": "I need opacity, clipping, and uppercase text to remain composable when several Mix styles merge. Should these be raw wrapper widgets and pre-transformed strings?",
+      "expected_output": "Keeps wrapper behavior in widget modifiers via wrap() and value transformations in directives, explains modifier ordering and merge-safe resolution, and avoids hard-coding wrapper widgets or eagerly transforming the source string outside the style.",
+      "files": []
+    },
+    {
+      "id": 7,
+      "prompt": "I changed a generated Mix spec and the public mix.dart barrel in this monorepo. Give me the repository verification sequence before I commit.",
+      "expected_output": "Regenerates with melos run gen:build, regenerates the barrel with melos run exports when needed, then runs melos run ci and melos run analyze; it does not edit generated mix.dart or generated .g.dart files by hand.",
+      "files": []
+    },
+    {
+      "id": 8,
+      "prompt": "In a plain Flutter project with no Mix dependency, write a CustomPainter that draws a waveform.",
+      "expected_output": "Does not trigger or invoke the Mix skill, does not add the mix package, and answers with ordinary Flutter CustomPainter guidance.",
+      "files": []
+    }
+  ]
+}

--- a/skills/mix/references/animations.md
+++ b/skills/mix/references/animations.md
@@ -2,6 +2,13 @@
 
 Three animation systems in Mix, from simple to full control.
 
+## Table of Contents
+
+- [Implicit animations](#implicit-animations)
+- [Phase animations](#phase-animations)
+- [Keyframe animations](#keyframe-animations)
+- [Comparison](#comparison)
+
 ## Implicit Animations
 
 Simplest approach. Call `.animate()` on any Styler — Mix interpolates between old and new values automatically when state or variants change.

--- a/skills/mix/references/architecture.md
+++ b/skills/mix/references/architecture.md
@@ -2,6 +2,16 @@
 
 Core abstractions of the Mix styling system.
 
+## Table of Contents
+
+- [Spec](#spec--immutable-resolved-data)
+- [Style and Styler](#style--styler--immutable-fluent-builder)
+- [Prop](#propv--unified-property-system)
+- [StyleWidget](#stylewidget--base-widget)
+- [Resolution pipeline](#resolution-pipeline)
+- [WidgetModifier](#widgetmodifier--widget-wrapper)
+- [Mix values](#mixv--resolvable-dto)
+
 ## Spec — Immutable Resolved Data
 
 **File:** `packages/mix/lib/src/core/spec.dart`

--- a/skills/mix/references/code-generation.md
+++ b/skills/mix/references/code-generation.md
@@ -2,6 +2,16 @@
 
 Annotations, generators, and the codegen workflow in Mix.
 
+## Table of Contents
+
+- [Spec-driven generation](#current-default-spec-driven-styler-generation)
+- [Annotations](#annotations)
+- [File structure](#file-structure-per-widget-spec)
+- [Type metadata](#type-metadata-registry)
+- [Run code generation](#running-code-generation)
+- [Box reference implementation](#reference-implementation-box)
+- [Generator flags](#generator-flags)
+
 ## Current Default: Spec-Driven Styler Generation
 
 For widget-backed specs, prefer `@MixableSpec(target: Widget.new)`. The generator emits both:
@@ -117,9 +127,10 @@ variants cannot choose a named constructor at compile time.
 `@MixWidget` complements `@MixableSpec(target:)`; it wraps a style recipe after
 a Styler exists, while `@MixableSpec(target:)` generates the Styler and its
 `call()` support. Mix's own specs use `@MixableSpec(target:)`; `@MixWidget` is
-mainly a downstream-author convenience. Consult
-`guides/mix-widget-variant-constructors.md` before changing this contract; its
-future curation rename is a decision record, not shipped API on current `main`.
+mainly a downstream-author convenience. When changing this contract inside the
+Mix repository, also consult its `guides/mix-widget-variant-constructors.md`
+decision record if present; do not treat a proposed curation rename as shipped
+API unless the current source exposes it.
 
 ### `@MixableModifier()`
 

--- a/skills/mix/references/design-tokens.md
+++ b/skills/mix/references/design-tokens.md
@@ -2,6 +2,17 @@
 
 Centralized visual properties via `MixToken` and `MixScope`.
 
+## Table of Contents
+
+- [Overview](#overview)
+- [Token workflow](#token-workflow)
+- [Built-in token types](#built-in-token-types)
+- [MixScope](#mixscope)
+- [Theme switching](#theme-switching)
+- [Custom token types](#custom-token-types)
+- [Programmatic resolution](#programmatic-resolution)
+- [Material integration](#mixscopewithmaterial)
+
 ## Overview
 
 Design tokens define visual properties (colors, typography, spacing) in a centralized, swappable way. Mix provides token types and `MixScope` (an `InheritedModel`) to provide values to the widget tree.

--- a/skills/mix/references/development-workflow.md
+++ b/skills/mix/references/development-workflow.md
@@ -2,6 +2,15 @@
 
 Creating, modifying, and maintaining specs in the Mix monorepo.
 
+## Table of Contents
+
+- [Monorepo structure](#monorepo-structure)
+- [Create a widget-backed spec](#creating-a-new-widget-backed-spec)
+- [Modify a spec](#modifying-an-existing-spec)
+- [Commands](#commands-reference)
+- [Pre-commit verification](#pre-commit-verification)
+- [Type metadata](#adding-type-metadata)
+
 ## Monorepo Structure
 
 ```text

--- a/skills/mix/references/examples.md
+++ b/skills/mix/references/examples.md
@@ -2,6 +2,12 @@
 
 Worked examples that show current Mix APIs in complete Flutter snippets.
 
+## Table of Contents
+
+- [Themed profile page](#themed-profile-page)
+- [Dark and light toggle](#darklight-toggle)
+- [Pressable button](#pressable-button)
+
 ## Themed Profile Page
 
 Tokens define the visual vocabulary, `MixScope` provides concrete values, and Stylers consume token refs with `$token()` or `$token.mix()`.

--- a/skills/mix/references/fluent-api.md
+++ b/skills/mix/references/fluent-api.md
@@ -2,6 +2,15 @@
 
 Chaining patterns, style mixins, and composition in Mix.
 
+## Table of Contents
+
+- [Core principle](#core-principle)
+- [Style mixins](#style-mixins)
+- [Interaction widgets](#interaction-widgets)
+- [Sizing](#sizing-decision-tree)
+- [Composition](#composition-via-merge)
+- [Callable stylers](#callable-stylers)
+
 ## Core Principle
 
 Prefer fluent chaining on Styler types. Each setter returns a new merged instance:

--- a/skills/mix/references/layout.md
+++ b/skills/mix/references/layout.md
@@ -3,6 +3,17 @@
 Choose and compose Mix-owned layout primitives without falling back to raw
 Flutter layout widgets for styling concerns.
 
+## Table of Contents
+
+- [Verify API availability](#verify-api-availability)
+- [Select a primitive](#select-the-primitive)
+- [Understand composites](#understand-composite-layouts)
+- [One-dimensional layouts](#build-one-dimensional-layouts)
+- [Wrapping layouts](#build-wrapping-layouts)
+- [Grid layouts](#build-two-dimensional-grid-layouts)
+- [Overlays](#build-overlays)
+- [Verification](#verify-layout-work)
+
 ## Verify API Availability
 
 Check the consuming package's `pubspec.yaml` and resolved dependency before

--- a/skills/mix/references/styler-api-policy.md
+++ b/skills/mix/references/styler-api-policy.md
@@ -2,6 +2,15 @@
 
 Rules for static factory constructors on Styler classes and Dart 3.11+ dot-shorthand usage.
 
+## Table of Contents
+
+- [Top-level rule](#the-top-level-rule)
+- [Nested shorthand](#nested-shorthand-rule)
+- [Enum shorthand](#dot-shorthand-for-enumconstant-arguments)
+- [Factory constructors](#factory-constructors-by-styler)
+- [Chain-only methods](#methods-without-factories-chain-only)
+- [Composition](#composition-decision-tree)
+
 Requires Dart SDK >=3.11.0 and Flutter >=3.41.0.
 
 ## The Top-Level Rule

--- a/skills/mix/references/testing.md
+++ b/skills/mix/references/testing.md
@@ -2,6 +2,16 @@
 
 Testing patterns for Mix, adapted from `packages/mix/test/helpers/testing_utils.dart`.
 
+## Table of Contents
+
+- [Philosophy](#core-philosophy)
+- [Utilities](#utilities)
+- [Testing patterns](#testing-patterns)
+- [MockBuildContext](#mockbuildcontext)
+- [Widget testing](#widget-testing)
+- [Common mistakes](#common-mistakes)
+- [Best practices](#best-practices)
+
 ## Core Philosophy
 
 Testing in Mix focuses on **resolution testing**: verify what `Resolvable` types, `Prop` values, Mix value objects, Stylers, and modifier Mix classes resolve to in a `BuildContext`.

--- a/skills/mix/references/variants.md
+++ b/skills/mix/references/variants.md
@@ -2,6 +2,16 @@
 
 Context-aware and state-driven styling in Mix.
 
+## Table of Contents
+
+- [Variant hierarchy](#variant-hierarchy)
+- [Priority order](#priority-order)
+- [Built-in variants](#built-in-variant-methods)
+- [Usage patterns](#usage-patterns)
+- [Named variants](#pre-defined-named-variants)
+- [ContextVariant factories](#contextvariant-factory-methods)
+- [StyleVariation](#stylevariation)
+
 ## Variant Hierarchy
 
 **File:** `packages/mix/lib/src/variants/variant.dart`

--- a/skills/mix/references/widget-modifiers-directives.md
+++ b/skills/mix/references/widget-modifiers-directives.md
@@ -1,5 +1,15 @@
 # Widget Modifiers & Directives
 
+## Table of Contents
+
+- [Widget modifiers](#widget-modifiers)
+- [Modifier usage](#usage)
+- [Built-in modifiers](#built-in-modifiers)
+- [Authoring modifiers](#authoring-modifiers)
+- [Modifier ordering](#modifier-ordering)
+- [Fluent chaining](#fluent-chaining)
+- [Directives](#directives)
+
 ## Widget Modifiers
 
 Modifiers wrap a widget with another widget (`Transform`, `Padding`, `Opacity`, etc.) without changing the styled widget API. Apply them with `.wrap()` on a Styler, or use convenience methods such as `BoxStyler().rotate(...)` when the Styler exposes them.


### PR DESCRIPTION
#### Related issue

No related issue.

### Description

Prepare the repository-owned Mix agent skill for discovery and installation through skills.sh and the `skills` CLI. This keeps the public source in `skills/mix` while preventing project-local installer copies from appearing as repository changes.

### Changes

- Harden the Mix skill trigger and setup guidance, add navigable reference tables of contents, and add positive and negative evaluation cases.
- Add skills.sh discovery and `npx skills` install/update instructions to the README.
- Ignore only installer-managed `.agents/` and `.claude/skills` paths; existing `.claude/hooks` and settings remain tracked.
- Refresh the OpenAI-facing skill metadata and default `$mix` invocation prompt.

**Review Checklist**

- [x] **Testing**: Skill validation, clean-room CLI installation, generation, and the full Dart/Flutter test suite were run.
- [x] **Breaking Changes**: No runtime or package API changes.
- [x] **Documentation Updates**: The root README and skill references describe installation and use.
- [x] **Website Updates**: No website change is required; skills.sh reads the repository catalog.

### Additional Information (optional)

Validation:

- `quick_validate.py skills/mix` — passed.
- `npx skills add . --list` — discovered exactly the `mix` skill.
- Clean-room `npx skills add <repo> --skill mix --agent codex --copy -y` — installed the complete skill, metadata, evals, and references.
- `melos run gen:build` — passed.
- `melos run ci` — passed after the documented `melos bootstrap` step.
- `melos run analyze` — schema inventory and Dart analysis passed; DCM still reports 14 pre-existing findings in unchanged `mix_annotations` and `mix_generator` source files.
