### PR TITLE
chore(mix): prepare 2.2.0-beta.3

### DIFF
--- a/packages/mix/CHANGELOG.md
+++ b/packages/mix/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 2.2.0-beta.3
 
 ### New features
 

--- a/packages/mix/pubspec.yaml
+++ b/packages/mix/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mix
 description: An expressive way to effortlessly build design systems in Flutter.
-version: 2.2.0-beta.2
+version: 2.2.0-beta.3
 homepage: https://github.com/btwld/mix
 repository: https://github.com/btwld/mix/tree/main/packages/mix
 


### PR DESCRIPTION
## Summary

- bump `mix` from `2.2.0-beta.2` to `2.2.0-beta.3`
- finalize the unreleased changelog for the focus-visible variant, Pressable behavior and semantics, nested widget-state discovery, and interaction/focus fixes

## Validation

- `melos run gen:build`
- `melos run ci`
- `dart analyze` across all packages
- Mix DCM analysis (no issues)
- `flutter pub publish --dry-run` (0 warnings; expected local Melos override hint)
- Mix changelog version matches its pubspec

## Known repository-wide baseline

The aggregate DCM command still reports pre-existing issues in `mix_annotations` and `mix_generator`; neither package is changed by this release PR.