### PR TITLE
chore(mix): prepare 2.2.0-beta.4

### DIFF
--- a/packages/mix/CHANGELOG.md
+++ b/packages/mix/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 2.2.0-beta.4
 
 ### Fixes
 

--- a/packages/mix/pubspec.yaml
+++ b/packages/mix/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mix
 description: An expressive way to effortlessly build design systems in Flutter.
-version: 2.2.0-beta.3
+version: 2.2.0-beta.4
 homepage: https://github.com/btwld/mix
 repository: https://github.com/btwld/mix/tree/main/packages/mix
 


### PR DESCRIPTION
#### Related issue

None. Release preparation.

### Description

Cuts `mix` `2.2.0-beta.4`. The only change since `beta.3` is #1016, which corrects variant merge priority.

### Changes

- `packages/mix/pubspec.yaml`: `2.2.0-beta.3` → `2.2.0-beta.4`
- `packages/mix/CHANGELOG.md`: `## Unreleased` → `## 2.2.0-beta.4`

Release contents:

- **Variant merge priority follows declared state dependencies.** Priority groups active variants by whether they declare `ContextVariant.widgetStateDependencies` rather than by whether they are a `WidgetStateVariant`, so `onFocusVisible(...)` competes by declaration order instead of always losing to any widget-state variant sharing a property. Variants built on `ContextVariant.not(...)` move with their inner variant, so `onEnabled(...)` now outranks an ambient variant such as `onDark(...)` declared after it.
- **Declaration order within a priority group is reliable.** Grouping is a stable partition rather than a `List.sort`, which fell back to an unstable quicksort at 32 elements.

**Review Checklist**

- [x] **Testing**: No code change. `mix` suite verified green on #1016 before merge.
- [ ] **Breaking Changes**: None. No API change and no migration; see #1016 for the resolved-styling cases the fix corrects.
- [x] **Documentation Updates**: CHANGELOG heading dated to the release.
- [ ] **Website Updates**: Not applicable to a version bump.

### Additional Information

Publishing is tag-driven — `.github/workflows/publish.yml` fires on `mix-v*`. After this merges, `mix-v2.2.0-beta.4` needs to be tagged on `main` to publish to pub.dev. This PR does not tag.

Unrelated pre-existing issue noticed while running `melos run verify_version_pubspec_changelog`: it fails on `mix_winds`, whose CHANGELOG (`0.0.1-alpha.1`) does not match its pubspec (`0.1.0-alpha.0`). Confirmed identical on `main` before this branch, and the script does not run in CI, so it does not block this release — but it will need fixing before `mix_winds` is published.
