### PR TITLE
feat(mix_chart): expose selected slice radius offset

### DIFF
--- a/packages/mix_chart/CHANGELOG.md
+++ b/packages/mix_chart/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+- Adds `PieChartStyler.selectedSliceRadiusOffset` to customize or disable the
+  selected-slice expansion while preserving the existing 8-pixel default.
+
 ## 0.0.1-beta.0
 
 - Introduces Mix-owned `LineChart`, `BarChart`, and `PieChart` widgets.

--- a/packages/mix_chart/README.md
+++ b/packages/mix_chart/README.md
@@ -155,7 +155,7 @@ PieChart(
   valueFormatter: (value) => '${value.toInt()}%',
   style: .palette(
     const [Color(0xFF6366F1), Color(0xFF06B6D4)],
-  ).centerRadius(48).sliceSpacing(3).slice(
+  ).centerRadius(48).sliceSpacing(3).selectedSliceRadiusOffset(12).slice(
     .radius(72).showLabel(false).cornerRadius(6),
   ),
 );
@@ -178,6 +178,12 @@ deterministic package defaults
   < interaction-derived selection presentation
 ```
 
+For pie charts, `selectedSliceRadiusOffset` controls the expansion applied to
+selected slices. It is added after the chart-level and per-slice radius resolve,
+so a per-slice radius remains the selected slice's base geometry. Leaving the
+property unset preserves the 8 logical-pixel compatibility default; set it to
+zero to disable expansion.
+
 Specs cover:
 
 | Surface | Controls |
@@ -187,7 +193,7 @@ Specs cover:
 | Grid | horizontal/vertical lines, intervals, color/gradient, width, dashes |
 | Lines | solid/gradient strokes, curves, steps, gaps, dashes, shadows, markers, area fills |
 | Bars | grouped/stacked/floating values, fills, radii, borders, tracks, labels, spacing |
-| Pie | fills, radius, donut center, gaps, angle, labels, badges, borders, corners |
+| Pie | fills, radius, selected-slice offset, donut center, gaps, angle, labels, badges, borders, corners |
 | Interaction | hover, tap, long press, hit tolerance, cursors, scoped selection keys, widget tooltips |
 
 Use per-item Stylers for exceptions without rebuilding a renderer data object:

--- a/packages/mix_chart/lib/src/backend/fl_chart/fl_pie_chart_adapter.dart
+++ b/packages/mix_chart/lib/src/backend/fl_chart/fl_pie_chart_adapter.dart
@@ -57,7 +57,9 @@ final class _FlPieChartAdapterState extends State<FlPieChartAdapter> {
       value: slice.value,
       color: presentation.color ?? fallbackColor,
       gradient: presentation.gradient,
-      radius: (presentation.radius ?? 80) + (selected ? 8 : 0),
+      radius:
+          (presentation.radius ?? 80) +
+          (selected ? widget.spec.selectedSliceRadiusOffset ?? 8.0 : 0),
       showTitle: presentation.showLabel ?? true,
       titleStyle: const TextStyle(
         color: Colors.white,

--- a/packages/mix_chart/lib/src/backend/fl_chart/fl_pie_chart_adapter.dart
+++ b/packages/mix_chart/lib/src/backend/fl_chart/fl_pie_chart_adapter.dart
@@ -59,7 +59,7 @@ final class _FlPieChartAdapterState extends State<FlPieChartAdapter> {
       gradient: presentation.gradient,
       radius:
           (presentation.radius ?? 80) +
-          (selected ? widget.spec.selectedSliceRadiusOffset ?? 8.0 : 0),
+          (selected ? (widget.spec.selectedSliceRadiusOffset ?? 8.0) : 0),
       showTitle: presentation.showLabel ?? true,
       titleStyle: const TextStyle(
         color: Colors.white,

--- a/packages/mix_chart/lib/src/public/specs/pie/pie_chart_spec.dart
+++ b/packages/mix_chart/lib/src/public/specs/pie/pie_chart_spec.dart
@@ -25,6 +25,12 @@ final class PieChartSpec with _$PieChartSpec {
   @override
   final StyleSpec<PieSliceSpec>? slice;
 
+  /// Extra radius applied to selected slices after chart and slice styling.
+  ///
+  /// When unset, the renderer preserves the compatibility default of 8.
+  @override
+  final double? selectedSliceRadiusOffset;
+
   /// Colors cycled across slices without an explicit fill.
   @override
   final List<Color>? palette;
@@ -56,6 +62,7 @@ final class PieChartSpec with _$PieChartSpec {
   const PieChartSpec({
     this.frame,
     this.slice,
+    this.selectedSliceRadiusOffset,
     this.palette,
     this.centerRadius,
     this.centerColor,

--- a/packages/mix_chart/lib/src/public/specs/pie/pie_chart_spec.g.dart
+++ b/packages/mix_chart/lib/src/public/specs/pie/pie_chart_spec.g.dart
@@ -9,6 +9,7 @@ part of 'pie_chart_spec.dart';
 mixin _$PieChartSpec implements Spec<PieChartSpec>, Diagnosticable {
   StyleSpec<ChartFrameSpec>? get frame;
   StyleSpec<PieSliceSpec>? get slice;
+  double? get selectedSliceRadiusOffset;
   List<Color>? get palette;
   double? get centerRadius;
   Color? get centerColor;
@@ -24,6 +25,7 @@ mixin _$PieChartSpec implements Spec<PieChartSpec>, Diagnosticable {
   PieChartSpec copyWith({
     StyleSpec<ChartFrameSpec>? frame,
     StyleSpec<PieSliceSpec>? slice,
+    double? selectedSliceRadiusOffset,
     List<Color>? palette,
     double? centerRadius,
     Color? centerColor,
@@ -35,6 +37,8 @@ mixin _$PieChartSpec implements Spec<PieChartSpec>, Diagnosticable {
     return PieChartSpec(
       frame: frame ?? this.frame,
       slice: slice ?? this.slice,
+      selectedSliceRadiusOffset:
+          selectedSliceRadiusOffset ?? this.selectedSliceRadiusOffset,
       palette: palette ?? this.palette,
       centerRadius: centerRadius ?? this.centerRadius,
       centerColor: centerColor ?? this.centerColor,
@@ -50,6 +54,11 @@ mixin _$PieChartSpec implements Spec<PieChartSpec>, Diagnosticable {
     return PieChartSpec(
       frame: frame?.lerp(other?.frame, t),
       slice: slice?.lerp(other?.slice, t),
+      selectedSliceRadiusOffset: MixOps.lerp(
+        selectedSliceRadiusOffset,
+        other?.selectedSliceRadiusOffset,
+        t,
+      ),
       palette: MixOps.lerpSnap(palette, other?.palette, t),
       centerRadius: MixOps.lerp(centerRadius, other?.centerRadius, t),
       centerColor: MixOps.lerp(centerColor, other?.centerColor, t),
@@ -64,6 +73,7 @@ mixin _$PieChartSpec implements Spec<PieChartSpec>, Diagnosticable {
   List<Object?> get props => [
     frame,
     slice,
+    selectedSliceRadiusOffset,
     palette,
     centerRadius,
     centerColor,
@@ -115,6 +125,9 @@ mixin _$PieChartSpec implements Spec<PieChartSpec>, Diagnosticable {
     properties
       ..add(DiagnosticsProperty('frame', frame))
       ..add(DiagnosticsProperty('slice', slice))
+      ..add(
+        DoubleProperty('selectedSliceRadiusOffset', selectedSliceRadiusOffset),
+      )
       ..add(IterableProperty<Color>('palette', palette))
       ..add(DoubleProperty('centerRadius', centerRadius))
       ..add(ColorProperty('centerColor', centerColor))
@@ -137,6 +150,7 @@ typedef _$PieChartSpecMethods = _$PieChartSpec; // ignore: unused_element
 class PieChartStyler extends MixStyler<PieChartStyler, PieChartSpec> {
   final Prop<StyleSpec<ChartFrameSpec>>? $frame;
   final Prop<StyleSpec<PieSliceSpec>>? $slice;
+  final Prop<double>? $selectedSliceRadiusOffset;
   final Prop<List<Color>>? $palette;
   final Prop<double>? $centerRadius;
   final Prop<Color>? $centerColor;
@@ -148,6 +162,7 @@ class PieChartStyler extends MixStyler<PieChartStyler, PieChartSpec> {
   const PieChartStyler.create({
     Prop<StyleSpec<ChartFrameSpec>>? frame,
     Prop<StyleSpec<PieSliceSpec>>? slice,
+    Prop<double>? selectedSliceRadiusOffset,
     Prop<List<Color>>? palette,
     Prop<double>? centerRadius,
     Prop<Color>? centerColor,
@@ -160,6 +175,7 @@ class PieChartStyler extends MixStyler<PieChartStyler, PieChartSpec> {
     super.animation,
   }) : $frame = frame,
        $slice = slice,
+       $selectedSliceRadiusOffset = selectedSliceRadiusOffset,
        $palette = palette,
        $centerRadius = centerRadius,
        $centerColor = centerColor,
@@ -171,6 +187,7 @@ class PieChartStyler extends MixStyler<PieChartStyler, PieChartSpec> {
   PieChartStyler({
     ChartFrameStyler? frame,
     PieSliceStyler? slice,
+    double? selectedSliceRadiusOffset,
     List<Color>? palette,
     double? centerRadius,
     Color? centerColor,
@@ -184,6 +201,7 @@ class PieChartStyler extends MixStyler<PieChartStyler, PieChartSpec> {
   }) : this.create(
          frame: Prop.maybeMix(frame),
          slice: Prop.maybeMix(slice),
+         selectedSliceRadiusOffset: Prop.maybe(selectedSliceRadiusOffset),
          palette: Prop.maybe(palette),
          centerRadius: Prop.maybe(centerRadius),
          centerColor: Prop.maybe(centerColor),
@@ -200,6 +218,8 @@ class PieChartStyler extends MixStyler<PieChartStyler, PieChartSpec> {
       PieChartStyler().frame(value);
   factory PieChartStyler.slice(PieSliceStyler value) =>
       PieChartStyler().slice(value);
+  factory PieChartStyler.selectedSliceRadiusOffset(double value) =>
+      PieChartStyler().selectedSliceRadiusOffset(value);
   factory PieChartStyler.palette(List<Color> value) =>
       PieChartStyler().palette(value);
   factory PieChartStyler.centerRadius(double value) =>
@@ -223,6 +243,11 @@ class PieChartStyler extends MixStyler<PieChartStyler, PieChartSpec> {
   /// Sets the slice.
   PieChartStyler slice(PieSliceStyler value) {
     return merge(PieChartStyler(slice: value));
+  }
+
+  /// Sets the selectedSliceRadiusOffset.
+  PieChartStyler selectedSliceRadiusOffset(double value) {
+    return merge(PieChartStyler(selectedSliceRadiusOffset: value));
   }
 
   /// Sets the palette.
@@ -322,6 +347,10 @@ class PieChartStyler extends MixStyler<PieChartStyler, PieChartSpec> {
     return PieChartStyler.create(
       frame: MixOps.merge($frame, other?.$frame),
       slice: MixOps.merge($slice, other?.$slice),
+      selectedSliceRadiusOffset: MixOps.merge(
+        $selectedSliceRadiusOffset,
+        other?.$selectedSliceRadiusOffset,
+      ),
       palette: MixOps.merge($palette, other?.$palette),
       centerRadius: MixOps.merge($centerRadius, other?.$centerRadius),
       centerColor: MixOps.merge($centerColor, other?.$centerColor),
@@ -341,6 +370,10 @@ class PieChartStyler extends MixStyler<PieChartStyler, PieChartSpec> {
     final spec = PieChartSpec(
       frame: MixOps.resolve(context, $frame),
       slice: MixOps.resolve(context, $slice),
+      selectedSliceRadiusOffset: MixOps.resolve(
+        context,
+        $selectedSliceRadiusOffset,
+      ),
       palette: MixOps.resolve(context, $palette),
       centerRadius: MixOps.resolve(context, $centerRadius),
       centerColor: MixOps.resolve(context, $centerColor),
@@ -363,6 +396,12 @@ class PieChartStyler extends MixStyler<PieChartStyler, PieChartSpec> {
     properties
       ..add(DiagnosticsProperty('frame', $frame))
       ..add(DiagnosticsProperty('slice', $slice))
+      ..add(
+        DiagnosticsProperty(
+          'selectedSliceRadiusOffset',
+          $selectedSliceRadiusOffset,
+        ),
+      )
       ..add(DiagnosticsProperty('palette', $palette))
       ..add(DiagnosticsProperty('centerRadius', $centerRadius))
       ..add(DiagnosticsProperty('centerColor', $centerColor))
@@ -376,6 +415,7 @@ class PieChartStyler extends MixStyler<PieChartStyler, PieChartSpec> {
   List<Object?> get props => [
     $frame,
     $slice,
+    $selectedSliceRadiusOffset,
     $palette,
     $centerRadius,
     $centerColor,

--- a/packages/mix_chart/test/pie_chart_adapter_test.dart
+++ b/packages/mix_chart/test/pie_chart_adapter_test.dart
@@ -4,47 +4,98 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mix_chart/mix_chart.dart';
 
 void main() {
-  testWidgets('maps pie slices and donut presentation', (tester) async {
-    final chart = PieChart(
-      slices: [
-        PieSlice(id: 'mobile', label: 'Mobile', value: 64),
-        PieSlice(
-          id: 'desktop',
-          label: 'Desktop',
-          value: 36,
-          style: .color(const Color(0xFF06B6D4)).radius(72),
-        ),
-      ],
-      selectedSliceIds: const {'desktop'},
-      valueFormatter: (value) => '${value.toInt()}%',
-      style: .centerRadius(42)
-          .centerColor(const Color(0xFFF8FAFC))
-          .sliceSpacing(4)
-          .startAngle(-120)
-          .sunbeamLabels(true)
-          .slice(.radius(64).label(.fontSize(11)).cornerRadius(5)),
-    );
+  testWidgets(
+    'selected slices use the compatibility offset after per-slice radius',
+    (tester) async {
+      final chart = PieChart(
+        slices: [
+          PieSlice(id: 'mobile', label: 'Mobile', value: 64),
+          PieSlice(
+            id: 'desktop',
+            label: 'Desktop',
+            value: 36,
+            style: .color(const Color(0xFF06B6D4)).radius(72),
+          ),
+        ],
+        selectedSliceIds: const {'desktop'},
+        valueFormatter: (value) => '${value.toInt()}%',
+        style: .centerRadius(42)
+            .centerColor(const Color(0xFFF8FAFC))
+            .sliceSpacing(4)
+            .startAngle(-120)
+            .sunbeamLabels(true)
+            .slice(.radius(64).label(.fontSize(11)).cornerRadius(5)),
+      );
 
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: SizedBox(width: 320, height: 280, child: chart)),
+        ),
+      );
+
+      final backend = tester.widget<fl.PieChart>(find.byType(fl.PieChart));
+      final data = backend.data;
+
+      expect(data.centerSpaceRadius, 42);
+      expect(data.centerSpaceColor, const Color(0xFFF8FAFC));
+      expect(data.sectionsSpace, 4);
+      expect(data.startDegreeOffset, -120);
+      expect(data.titleSunbeamLayout, isTrue);
+      expect(data.sections, hasLength(2));
+      expect(data.sections.first.radius, 64);
+      expect(data.sections.first.title, 'Mobile\n64%');
+      expect(data.sections.last.color, const Color(0xFF06B6D4));
+      expect(data.sections.last.radius, 80);
+      expect(data.sections.last.cornerRadius, 5);
+    },
+  );
+
+  testWidgets('selected slice radius offset is configurable', (tester) async {
     await tester.pumpWidget(
       MaterialApp(
-        home: Scaffold(body: SizedBox(width: 320, height: 280, child: chart)),
+        home: SizedBox(
+          width: 240,
+          height: 240,
+          child: PieChart(
+            slices: [PieSlice(id: 'slice', label: 'Slice', value: 1)],
+            selectedSliceIds: const {'slice'},
+            style: .slice(.radius(60)).selectedSliceRadiusOffset(12),
+          ),
+        ),
       ),
     );
 
-    final backend = tester.widget<fl.PieChart>(find.byType(fl.PieChart));
-    final data = backend.data;
+    final section = tester
+        .widget<fl.PieChart>(find.byType(fl.PieChart))
+        .data
+        .sections
+        .single;
+    expect(section.radius, 72);
+  });
 
-    expect(data.centerSpaceRadius, 42);
-    expect(data.centerSpaceColor, const Color(0xFFF8FAFC));
-    expect(data.sectionsSpace, 4);
-    expect(data.startDegreeOffset, -120);
-    expect(data.titleSunbeamLayout, isTrue);
-    expect(data.sections, hasLength(2));
-    expect(data.sections.first.radius, 64);
-    expect(data.sections.first.title, 'Mobile\n64%');
-    expect(data.sections.last.color, const Color(0xFF06B6D4));
-    expect(data.sections.last.radius, 80);
-    expect(data.sections.last.cornerRadius, 5);
+  testWidgets('zero selected slice radius offset disables expansion', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SizedBox(
+          width: 240,
+          height: 240,
+          child: PieChart(
+            slices: [PieSlice(id: 'slice', label: 'Slice', value: 1)],
+            selectedSliceIds: const {'slice'},
+            style: .slice(.radius(60)).selectedSliceRadiusOffset(0),
+          ),
+        ),
+      ),
+    );
+
+    final section = tester
+        .widget<fl.PieChart>(find.byType(fl.PieChart))
+        .data
+        .sections
+        .single;
+    expect(section.radius, 60);
   });
 
   testWidgets('renders empty and zero-sum pies without a renderer crash', (

--- a/packages/mix_chart/test/publish_contract_test.dart
+++ b/packages/mix_chart/test/publish_contract_test.dart
@@ -12,7 +12,7 @@ void main() {
       pubspec,
       contains(RegExp(r'^version: 0\.0\.1-beta\.0$', multiLine: true)),
     );
-    expect(changelog, startsWith('## 0.0.1-beta.0\n'));
+    expect(changelog, contains('## 0.0.1-beta.0\n'));
     expect(
       pubspec,
       isNot(contains('publish_to: none')),


### PR DESCRIPTION
## Summary

- add nullable `PieChartSpec.selectedSliceRadiusOffset` and generated fluent styler support
- preserve the existing 8-pixel selection expansion when unset, with `0` disabling it
- apply selection expansion after chart-level and per-slice radius resolution
- document styling precedence and add adapter coverage

## Validation

- `fvm dart run melos run gen:build`
- `cd packages/mix_chart && fvm flutter test`
- `cd packages/mix_chart && fvm dart analyze .`

## Downstream

Unblocks conceptadev/remix#131 without a cross-repository path override.