### PR TITLE
chore(mix_chart): prepare 0.0.1-beta.1

### DIFF
--- a/packages/mix_chart/CHANGELOG.md
+++ b/packages/mix_chart/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.0.1-beta.1
 
 - Adds `PieChartStyler.selectedSliceRadiusOffset` to customize or disable the
   selected-slice expansion while preserving the existing 8-pixel default.

--- a/packages/mix_chart/pubspec.yaml
+++ b/packages/mix_chart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mix_chart
 description: Type-safe Flutter chart widgets styled with Mix.
-version: 0.0.1-beta.0
+version: 0.0.1-beta.1
 homepage: https://github.com/btwld/mix
 repository: https://github.com/btwld/mix/tree/main/packages/mix_chart
 

--- a/packages/mix_chart/test/publish_contract_test.dart
+++ b/packages/mix_chart/test/publish_contract_test.dart
@@ -10,9 +10,9 @@ void main() {
     expect(pubspec, contains(RegExp(r'^name: mix_chart$', multiLine: true)));
     expect(
       pubspec,
-      contains(RegExp(r'^version: 0\.0\.1-beta\.0$', multiLine: true)),
+      contains(RegExp(r'^version: 0\.0\.1-beta\.1$', multiLine: true)),
     );
-    expect(changelog, contains('## 0.0.1-beta.0\n'));
+    expect(changelog, startsWith('## 0.0.1-beta.1\n'));
     expect(
       pubspec,
       isNot(contains('publish_to: none')),


### PR DESCRIPTION
## Summary

- bump `mix_chart` to `0.0.1-beta.1`
- finalize the changelog for the selected-slice radius offset
- update the publish contract to pin the new prerelease

## Validation

- `cd packages/mix_chart && fvm flutter test`
- `cd packages/mix_chart && fvm dart analyze .`
- `cd packages/mix_chart && dcm analyze . --fatal-style --fatal-warnings`
- `cd packages/mix_chart && fvm dart pub publish --dry-run` (clean tree; hints only for intentional workspace overrides)