### PR TITLE
fix(mix_generator): preserve generic widget target parameters

### DIFF
--- a/lints.yaml
+++ b/lints.yaml
@@ -1,7 +1,5 @@
 include: package:flutter_lints/flutter.yaml
 
-analyzer:
-  exclude:
 linter:
   rules:
     # TODO: Turn this to true when all public apis are documented 

--- a/packages/mix/example/test/grid_box_example_test.dart
+++ b/packages/mix/example/test/grid_box_example_test.dart
@@ -172,8 +172,8 @@ const _goldens = [
     Size(450, 820),
     precisionTolerance: 0.04,
   ),
-  // Text, icons, and rounded card edges rasterize just beyond the shared
-  // macOS/Linux tolerance; geometry is asserted by the widget test above.
+  // Animation text, icons, and rounded card edges rasterize just beyond the
+  // shared macOS/Linux tolerance; geometry is asserted by the test above.
   _GridGolden(
     'animation_balanced',
     GridExampleKind.animation,
@@ -186,6 +186,7 @@ const _goldens = [
     GridExampleKind.animation,
     760,
     Size(840, 620),
+    precisionTolerance: 0.04,
     focusAnimation: true,
   ),
 ];

--- a/packages/mix_generator/CHANGELOG.md
+++ b/packages/mix_generator/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 2.2.0-beta.3
+
+ - **FIX**: Preserve type parameters and bounds from uninstantiated generic
+   targets in generated `@MixableSpec(target:)` `call()` methods, and reject
+   instantiated or aliased generic targets instead of silently widening them in
+   `@MixableSpec(target:)` or `@MixWidget(target:)`. Reject a target type
+   parameter named `Key` when it would shadow the generated Flutter key
+   parameter (#1023).
+
 ## 2.2.0-beta.2
 
  - **FEAT**: Generate `@MixWidget(target:)` wrappers for plain Widget

--- a/packages/mix_generator/README.md
+++ b/packages/mix_generator/README.md
@@ -32,6 +32,7 @@ The generator emits several surfaces with deliberately different shapes, chosen 
 
 - **`@MixableSpec`** emits a *rich* mixin (`mixin _$<Name> implements Spec<T>, Diagnosticable`) that fully completes the Spec contract on its own. Specs are immutable value types with no shared concrete behavior to inherit, so the generated mixin can be self-contained — user code only writes `with _$<Name>`.
 - **`@MixableSpec(target: Widget.new)`** also emits a full generated Styler class into the same `.g.dart` part file as the spec mixin. The generated class owns fields, constructors, factories, fluent methods, `call()`, merge, resolve, diagnostics, and props.
+  Direct, uninstantiated generic targets are supported; generated `call()` methods preserve and forward their type parameters and bounds. Instantiated targets such as `Widget<int>.new` and generic constructor tear-offs through typedefs are rejected because their substitutions are not yet supported. A target type parameter named `Key` is also rejected when the constructor forwards Flutter's `key`, because it would shadow the generated `Key? key` parameter.
 - **`@MixableStyler`** emits a legacy *slim* mixin (`mixin _$<Name>Mixin on Style<S>, Diagnosticable`) that fills in per-field plumbing for handwritten styler classes.
 - **`@Mixable`** emits a *slim* mixin (`mixin _$<Name>Mixin on Mix<T>[, DefaultValue<T>][, Diagnosticable]`) for the same reason — Mix subclasses commonly compose intermediate base classes (e.g., `class BoxConstraintsMix extends ConstraintsMix<BoxConstraints>`) and the user keeps that inheritance chain.
 - **`@MixableModifier`** emits a self-contained modifier mixin (`mixin _$<Name> implements WidgetModifier<T>, Diagnosticable`) plus its corresponding `<Name>Mix` class.
@@ -200,7 +201,9 @@ This path reads widget parameters and generic type parameters from the target
 constructor, omits `style` and `styleSpec`, and instantiates the target
 directly with the recipe result passed through `style`. It does not require
 the target to extend `StyleWidget` and does not inspect extension `call()`
-methods.
+methods. Generic targets must be passed uninstantiated (for example,
+`RemixButton.new`); constructor tear-offs with fixed type arguments or through
+typedefs are rejected.
 
 For compatibility, an annotation from an older `mix_annotations` release that
 does not define `widgetParameters` is interpreted as `.all()`. Using

--- a/packages/mix_generator/lib/src/core/helpers/library_scope.dart
+++ b/packages/mix_generator/lib/src/core/helpers/library_scope.dart
@@ -97,6 +97,10 @@ String typeCode(DartType type, {LibraryElement? visibleFrom}) {
     return '$name<$arguments>$nullableSuffix';
   }
 
+  if (type is RecordType) {
+    return _recordTypeCode(type, visibleFrom: visibleFrom);
+  }
+
   if (type is FunctionType) {
     return _functionTypeCode(type, visibleFrom: visibleFrom);
   }
@@ -105,6 +109,11 @@ String typeCode(DartType type, {LibraryElement? visibleFrom}) {
 }
 
 /// Returns the first type name in [type] that is not visible from [library].
+///
+/// This deliberately does not recurse into a [TypeParameterType]'s bound.
+/// Bounds are checked once at their declaration site by `extractTypeParams`;
+/// following them here would recurse forever for F-bounded parameters such as
+/// `T extends Comparable<T>`.
 String? firstInvisibleTypeName(DartType type, LibraryElement library) {
   final alias = type.alias;
   if (alias != null) {
@@ -147,6 +156,15 @@ String? firstInvisibleTypeName(DartType type, LibraryElement library) {
         return hiddenName;
       }
     }
+
+    for (final typeParameter in type.typeParameters) {
+      final bound = typeParameter.bound;
+      if (bound == null) continue;
+      final hiddenName = firstInvisibleTypeName(bound, library);
+      if (hiddenName != null) {
+        return hiddenName;
+      }
+    }
   }
 
   if (type is RecordType) {
@@ -170,8 +188,29 @@ String? firstInvisibleTypeName(DartType type, LibraryElement library) {
 String _nullableSuffix(DartType type) =>
     type.nullabilitySuffix == .question ? '?' : '';
 
+String _recordTypeCode(RecordType type, {LibraryElement? visibleFrom}) {
+  final positional = [
+    for (final field in type.positionalFields)
+      typeCode(field.type, visibleFrom: visibleFrom),
+  ];
+  final named = [
+    for (final field in type.namedFields)
+      '${typeCode(field.type, visibleFrom: visibleFrom)} ${field.name}',
+  ];
+  final fields = [
+    ...positional,
+    if (named.isNotEmpty) '{${named.join(', ')}}',
+  ].join(', ');
+  final trailingComma = positional.length == 1 && named.isEmpty ? ',' : '';
+
+  return '($fields$trailingComma)${_nullableSuffix(type)}';
+}
+
 String _functionTypeCode(FunctionType type, {LibraryElement? visibleFrom}) {
   final returnType = typeCode(type.returnType, visibleFrom: visibleFrom);
+  final typeParameters = type.typeParameters.isEmpty
+      ? ''
+      : '<${type.typeParameters.map((parameter) => _functionTypeParameterCode(parameter, visibleFrom: visibleFrom)).join(', ')}>';
   final requiredPositional = <String>[];
   final optionalPositional = <String>[];
   final named = <String>[];
@@ -197,7 +236,19 @@ String _functionTypeCode(FunctionType type, {LibraryElement? visibleFrom}) {
     if (named.isNotEmpty) '{${named.join(', ')}}',
   ].join(', ');
 
-  return '$returnType Function($parameters)${_nullableSuffix(type)}';
+  return '$returnType Function$typeParameters($parameters)'
+      '${_nullableSuffix(type)}';
+}
+
+String _functionTypeParameterCode(
+  TypeParameterElement parameter, {
+  LibraryElement? visibleFrom,
+}) {
+  final name = parameter.name ?? parameter.displayName;
+  final bound = parameter.bound;
+  if (bound == null) return name;
+
+  return '$name extends ${typeCode(bound, visibleFrom: visibleFrom)}';
 }
 
 String _functionParameterCode(

--- a/packages/mix_generator/lib/src/core/helpers/widget_call_planner.dart
+++ b/packages/mix_generator/lib/src/core/helpers/widget_call_planner.dart
@@ -47,6 +47,12 @@ String? buildMixableSpecTargetCall({
 
   final constructor = mixableSpecTargetTearOff(target, specElement);
   final widgetName = mixableSpecTargetWidgetName(constructor);
+  validateGenericTargetTearOff(
+    target: target,
+    constructor: constructor,
+    anchor: specElement,
+    annotationLabel: '@MixableSpec(target:)',
+  );
   if (validateTargetVisibility) {
     final widgetElement = constructor.enclosingElement;
     final hiddenWidgetType = firstInvisibleTypeName(
@@ -81,11 +87,31 @@ String? buildMixableSpecTargetCall({
     annotationLabel: '@MixableSpec(target:)',
     keyOwner: 'the target constructor',
   );
+  if (call.forwardsKey) {
+    for (final typeParameter in constructor.enclosingElement.typeParameters) {
+      if (typeParameter.name != 'Key') continue;
+      fail(
+        typeParameter,
+        'Target widget type parameter `Key` conflicts with the generated '
+        'Flutter `Key? key` parameter in @MixableSpec(target:) call().',
+        todo: 'Rename the target widget type parameter.',
+      );
+    }
+  }
+  // Generated stylers and legacy styler mixins are never generic today, so
+  // target type parameters cannot shadow host type parameters. Revisit this
+  // if generic specs or stylers become supported.
+  final typeParams = extractTypeParams(
+    constructor.enclosingElement.typeParameters,
+    library: hostLibrary,
+    context: .mixableSpecTarget,
+  );
 
   return renderWidgetCall(
     widgetName: widgetName,
     params: call.params,
     forwardsKey: call.forwardsKey,
+    typeParams: typeParams,
     indent: indent,
   );
 }
@@ -117,6 +143,42 @@ ConstructorElement mixableSpecTargetTearOff(
   }
 
   return constructor;
+}
+
+/// Ensures a generic target is the class constructor's direct, uninstantiated
+/// tear-off. The raw [ConstructorElement] does not retain type arguments or
+/// typedef substitutions, so accepting either would silently change the API.
+void validateGenericTargetTearOff({
+  required ConstantReader target,
+  required ConstructorElement constructor,
+  required Element anchor,
+  required String annotationLabel,
+}) {
+  final classTypeParams = constructor.enclosingElement.typeParameters;
+  final tearOffType = target.objectValue.type;
+  if (classTypeParams.isEmpty) return;
+
+  final preservesClassTypeParams =
+      tearOffType is FunctionType &&
+      tearOffType.typeParameters.length == classTypeParams.length &&
+      tearOffType.typeParameters.indexed.every(
+        (entry) =>
+            entry.$2.baseElement == classTypeParams[entry.$1].baseElement,
+      );
+  if (preservesClassTypeParams) return;
+
+  final widgetName = requireName(
+    constructor.enclosingElement,
+    orFailWith: '$annotationLabel target widget class must have a name.',
+  );
+  fail(
+    anchor,
+    '$annotationLabel only supports direct, uninstantiated constructor '
+    'tear-offs for generic target `$widgetName`.',
+    todo:
+        'Use the class constructor tear-off directly, without type arguments '
+        'or a typedef, so the generated API can preserve its generics.',
+  );
 }
 
 String mixableSpecTargetWidgetName(ConstructorElement constructor) {
@@ -219,12 +281,83 @@ void validateMixableSpecTargetConstructor({
   return (params: params, forwardsKey: forwardsKey);
 }
 
+enum WidgetCallTypeParamContext {
+  mixWidgetCall,
+  mixableSpecTarget;
+
+  String get missingNameMessage => switch (this) {
+    mixWidgetCall => '@MixWidget call type parameter must have a name.',
+    mixableSpecTarget =>
+      '@MixableSpec(target:) target widget type parameter must have a name.',
+  };
+
+  String invisibleBoundMessage(
+    String name,
+    String hiddenType,
+  ) => switch (this) {
+    mixWidgetCall =>
+      'Call type parameter `$name` has bound `$hiddenType`, but that type '
+          'is not visible from the annotated library.',
+    mixableSpecTarget =>
+      'Target widget type parameter `$name` has bound `$hiddenType`, but that '
+          'type is not visible from the annotated library.',
+  };
+}
+
+List<WidgetCallTypeParam> extractTypeParams(
+  Iterable<TypeParameterElement> typeParameters, {
+  required LibraryElement library,
+  WidgetCallTypeParamContext context = .mixWidgetCall,
+}) {
+  return [
+    for (final typeParameter in typeParameters)
+      _typeParam(typeParameter, library: library, context: context),
+  ];
+}
+
+WidgetCallTypeParam _typeParam(
+  TypeParameterElement typeParameter, {
+  required LibraryElement library,
+  required WidgetCallTypeParamContext context,
+}) {
+  final name = requireName(
+    typeParameter,
+    orFailWith: context.missingNameMessage,
+  );
+  final bound = typeParameter.bound;
+
+  if (bound == null) {
+    return WidgetCallTypeParam(name: name);
+  }
+
+  final hiddenType = firstInvisibleTypeName(bound, library);
+  if (hiddenType != null) {
+    fail(
+      typeParameter,
+      context.invisibleBoundMessage(name, hiddenType),
+      todo: 'Import or re-export `$hiddenType` where the annotation lives.',
+    );
+  }
+
+  return WidgetCallTypeParam(
+    name: name,
+    boundCode: typeCode(bound, visibleFrom: library),
+  );
+}
+
 String renderWidgetCall({
   required String widgetName,
   required List<WidgetCallParam> params,
   required bool forwardsKey,
+  List<WidgetCallTypeParam> typeParams = const [],
   String indent = '',
 }) {
+  final declarationSuffix = typeParams.isEmpty
+      ? ''
+      : '<${typeParams.map((p) => p.declarationCode).join(', ')}>';
+  final invocationSuffix = typeParams.isEmpty
+      ? ''
+      : '<${typeParams.map((p) => p.name).join(', ')}>';
   final positional = params.where((p) => p.isPositional).toList();
   final named = params.where((p) => !p.isPositional).toList();
   final signatureParams = [
@@ -240,8 +373,8 @@ String renderWidgetCall({
   ];
 
   return '''
-$indent$widgetName call(${signatureParams.join(', ')}) {
-$indent  return $widgetName(${invocationArgs.join(', ')});
+$indent$widgetName$invocationSuffix call$declarationSuffix(${signatureParams.join(', ')}) {
+$indent  return $widgetName$invocationSuffix(${invocationArgs.join(', ')});
 $indent}
 ''';
 }

--- a/packages/mix_generator/lib/src/mix_widget_generator.dart
+++ b/packages/mix_generator/lib/src/mix_widget_generator.dart
@@ -167,8 +167,14 @@ class MixWidgetGenerator extends GeneratorForAnnotation<MixWidget> {
       callTypeParams: targetConstructor == null
           ? (callSource.isGenerated
                 ? const []
-                : _extractCallTypeParams(callSource.call, library: library))
-          : _extractTargetTypeParams(targetConstructor, library: library),
+                : extractTypeParams(
+                    callSource.call.typeParameters,
+                    library: library,
+                  ))
+          : extractTypeParams(
+              targetConstructor.enclosingElement.typeParameters,
+              library: library,
+            ),
       stylerCallForwardsKey: call.forwardsKey,
       targetTypeReference: callSource.targetTypeReference,
       targetConstructorName: callSource.targetConstructorName,
@@ -246,8 +252,14 @@ class MixWidgetGenerator extends GeneratorForAnnotation<MixWidget> {
     final callTypeParams = targetConstructor == null
         ? (callSource.isGenerated
               ? const <WidgetCallTypeParam>[]
-              : _extractCallTypeParams(callSource.call, library: library))
-        : _extractTargetTypeParams(targetConstructor, library: library);
+              : extractTypeParams(
+                  callSource.call.typeParameters,
+                  library: library,
+                ))
+        : extractTypeParams(
+            targetConstructor.enclosingElement.typeParameters,
+            library: library,
+          );
     final variantConstructors =
         factoryParams.any((parameter) => parameter.name == _variantParamName)
         ? _extractVariantConstructors(
@@ -447,16 +459,6 @@ class MixWidgetGenerator extends GeneratorForAnnotation<MixWidget> {
     return acceptedSpec is InterfaceType &&
         acceptedSpec.element.name == spec.name &&
         acceptedSpec.element.library.uri == spec.library.uri;
-  }
-
-  List<WidgetCallTypeParam> _extractTargetTypeParams(
-    ConstructorElement constructor, {
-    required LibraryElement library,
-  }) {
-    return [
-      for (final typeParameter in constructor.enclosingElement.typeParameters)
-        _callTypeParam(typeParameter, library: library),
-    ];
   }
 
   List<WidgetVariantConstructor>? _extractVariantConstructors(
@@ -847,46 +849,6 @@ class MixWidgetGenerator extends GeneratorForAnnotation<MixWidget> {
     return null;
   }
 
-  List<WidgetCallTypeParam> _extractCallTypeParams(
-    ExecutableElement callMethod, {
-    required LibraryElement library,
-  }) {
-    return [
-      for (final typeParameter in callMethod.typeParameters)
-        _callTypeParam(typeParameter, library: library),
-    ];
-  }
-
-  WidgetCallTypeParam _callTypeParam(
-    TypeParameterElement typeParameter, {
-    required LibraryElement library,
-  }) {
-    final name = requireName(
-      typeParameter,
-      orFailWith: '$_annotationLabel call type parameter must have a name.',
-    );
-    final bound = typeParameter.bound;
-
-    if (bound == null) {
-      return WidgetCallTypeParam(name: name);
-    }
-
-    final hiddenType = firstInvisibleTypeName(bound, library);
-    if (hiddenType != null) {
-      fail(
-        typeParameter,
-        'Call type parameter `$name` has bound `$hiddenType`, but that type '
-        'is not visible from the annotated library.',
-        todo: 'Import or re-export `$hiddenType` where the annotation lives.',
-      );
-    }
-
-    return WidgetCallTypeParam(
-      name: name,
-      boundCode: typeCode(bound, visibleFrom: library),
-    );
-  }
-
   List<WidgetCallParam> _extractFactoryParams(
     TopLevelFunctionElement function, {
     required LibraryElement library,
@@ -1252,6 +1214,13 @@ class MixWidgetGenerator extends GeneratorForAnnotation<MixWidget> {
         '(e.g., RemixButton.new).',
       );
     }
+    validateGenericTargetTearOff(
+      target: target,
+      constructor: constructor,
+      anchor: anchor,
+      annotationLabel: '@MixWidget(target:)',
+    );
+
     return constructor;
   }
 }

--- a/packages/mix_generator/pubspec.yaml
+++ b/packages/mix_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mix_generator
 description: A code generator for Mix, an expressive way to effortlessly build design systems in Flutter.
-version: 2.2.0-beta.2
+version: 2.2.0-beta.3
 homepage: https://github.com/btwld/mix
 repository: https://github.com/btwld/mix/tree/main/packages/mix_generator
 

--- a/packages/mix_generator/test/core/helpers/library_scope_test.dart
+++ b/packages/mix_generator/test/core/helpers/library_scope_test.dart
@@ -111,6 +111,18 @@ void main() {
         'HiddenAlias',
       );
     });
+
+    test('checks generic function type parameter bounds', () async {
+      final libraries = await _resolveHiddenLibraryScope();
+      final hiddenValue = libraries.hidden.getTopLevelFunction(
+        'hiddenGenericBound',
+      )!;
+
+      expect(
+        firstInvisibleTypeName(hiddenValue.returnType, libraries.input),
+        'HiddenType',
+      );
+    });
   });
 
   group('typeCode', () {
@@ -192,6 +204,8 @@ _resolveHiddenLibraryScope() {
 
         HiddenType hiddenValue() => throw UnimplementedError();
         HiddenAlias<int> hiddenAlias() => throw UnimplementedError();
+        S Function<S extends HiddenType>(S) hiddenGenericBound() =>
+            throw UnimplementedError();
       ''',
       'test_pkg|lib/input.dart': '''
         library input;

--- a/packages/mix_generator/test/integration/generator_validation_test.dart
+++ b/packages/mix_generator/test/integration/generator_validation_test.dart
@@ -614,6 +614,72 @@ class _Stub extends StatelessWidget {
       expect(errors, contains('not visible from the annotated library'));
     });
 
+    /// This visibility split is only reachable through the legacy
+    /// `@MixableStyler` path because generated specs and their stylers share a
+    /// library.
+    test('StylerGenerator rejects a target widget type parameter bound that '
+        'is not visible from the annotated library', () async {
+      const stylerSource = r'''
+library styler_validation;
+
+import 'package:mix_annotations/mix_annotations.dart';
+import 'package:mix/src/core/style.dart';
+import 'target.dart';
+
+@MixableStyler()
+class GenericStyler extends Style<GenericSpec> {
+  const GenericStyler();
+}
+''';
+
+      final result = await testBuilder(
+        partBuilder(const StylerGenerator()),
+        {
+          ...mixAnnotationsSources,
+          ...widgetStub,
+          'mix|lib/src/core/style.dart': styleStub,
+          'mix|lib/src/core/style_widget.dart': r'''
+import 'package:flutter/widgets.dart';
+import 'style.dart';
+
+abstract class StyleWidget<S> extends Widget {
+  final Style<S> style;
+
+  const StyleWidget({required this.style});
+}
+''',
+          'mix_generator|lib/hidden_bound.dart': r'''
+class HiddenBound {}
+''',
+          'mix_generator|lib/target.dart': r'''
+import 'package:flutter/widgets.dart';
+import 'package:mix_annotations/mix_annotations.dart';
+import 'package:mix/src/core/style_widget.dart';
+import 'hidden_bound.dart';
+
+@MixableSpec(target: GenericWidget.new)
+class GenericSpec {
+  const GenericSpec();
+}
+
+class GenericWidget<T extends HiddenBound> extends StyleWidget<GenericSpec> {
+  const GenericWidget({required super.style});
+}
+''',
+          'mix_generator|lib/styler_validation.dart': stylerSource,
+        },
+        generateFor: {'mix_generator|lib/styler_validation.dart'},
+      );
+
+      expect(result.succeeded, isFalse);
+      final errors = result.errors.join('\n');
+      expect(
+        errors,
+        contains('Target widget type parameter `T` has bound `HiddenBound`'),
+      );
+      expect(errors, contains('not visible from the annotated library'));
+    });
+
     test(
       'MixWidgetGenerator rejects optional positional factory params',
       () async {

--- a/packages/mix_generator/test/integration/mix_widget_spec_styler_test.dart
+++ b/packages/mix_generator/test/integration/mix_widget_spec_styler_test.dart
@@ -541,6 +541,45 @@ RadioStyler fortalRadioStyler() => RadioStyler();
       );
     });
 
+    test('rejects instantiated generic target constructor tear-offs', () async {
+      const body = r'''
+final class ButtonSpec extends Spec<ButtonSpec> {
+  const ButtonSpec();
+}
+
+class ButtonStyler extends Style<ButtonSpec> {
+  const ButtonStyler();
+}
+
+class GenericWidget<T> extends StatelessWidget {
+  const GenericWidget({required this.style, required this.value});
+
+  final Style<ButtonSpec> style;
+  final T value;
+
+  @override
+  Widget build(BuildContext context) => const _Leaf();
+}
+
+class _Leaf extends Widget {
+  const _Leaf();
+}
+
+@MixWidget(target: GenericWidget<int>.new)
+final genericStyle = const ButtonStyler();
+''';
+
+      final errors = await _expectMixWidgetError(body);
+
+      expect(
+        errors,
+        contains(
+          '@MixWidget(target:) only supports direct, uninstantiated '
+          'constructor tear-offs for generic target `GenericWidget`',
+        ),
+      );
+    });
+
     test('rejects a target without a named style parameter', () async {
       const body = r'''
 @MixableSpec()

--- a/packages/mix_generator/test/integration/spec_styler_generator_smoke_test.dart
+++ b/packages/mix_generator/test/integration/spec_styler_generator_smoke_test.dart
@@ -777,6 +777,346 @@ void main() {
     });
 
     test(
+      'preserves generic target widget type parameters, including bounds',
+      () async {
+        const input = '''
+          library generic_target;
+          import 'package:flutter/widgets.dart';
+          import 'package:mix/mix.dart';
+          import 'package:mix/src/core/style_widget.dart';
+          import 'package:mix_annotations/mix_annotations.dart';
+          part 'generic_target.g.dart';
+
+          @MixableSpec(target: GenericWidget.new)
+          final class GenericSpec extends Spec<GenericSpec> {
+            const GenericSpec();
+          }
+
+          class GenericWidget<T, U extends Object>
+              extends StyleWidget<GenericSpec> {
+            const GenericWidget({
+              super.key,
+              required super.style,
+              required this.value,
+              required this.other,
+            });
+
+            final T value;
+            final U other;
+          }
+        ''';
+
+        await expectGeneratorOutputResolves(
+          builder: _specStylerPartBuilder(),
+          sources: {
+            ...mixAnnotationsSources,
+            ..._flutterResolveStubs,
+            ..._mixSourcesWithStyleWidget,
+            'mix|lib/generic_target.dart': input,
+          },
+          inputAsset: 'mix|lib/generic_target.dart',
+          outputAsset: 'mix|lib/generic_target.g.dart',
+          outputMatcher: allOf(
+            contains(
+              'GenericWidget<T, U> call<T, U extends Object>({\n'
+              '    Key? key,\n'
+              '    required T value,\n'
+              '    required U other,\n'
+              '  })',
+            ),
+            contains(
+              'return GenericWidget<T, U>(\n'
+              '      key: key,\n'
+              '      style: this,\n'
+              '      value: value,\n'
+              '      other: other,\n'
+              '    );',
+            ),
+          ),
+        );
+      },
+    );
+
+    test('forwards F-bounded target widget type parameters', () async {
+      const input = '''
+        library f_bounded_target;
+        import 'package:flutter/widgets.dart';
+        import 'package:mix/mix.dart';
+        import 'package:mix/src/core/style_widget.dart';
+        import 'package:mix_annotations/mix_annotations.dart';
+        part 'f_bounded_target.g.dart';
+
+        @MixableSpec(target: ComparableWidget.new)
+        final class ComparableSpec extends Spec<ComparableSpec> {
+          const ComparableSpec();
+        }
+
+        class ComparableWidget<T extends Comparable<T>>
+            extends StyleWidget<ComparableSpec> {
+          const ComparableWidget({
+            super.key,
+            required super.style,
+            required this.value,
+          });
+
+          final T value;
+        }
+      ''';
+
+      await expectGeneratorOutputResolves(
+        builder: _specStylerPartBuilder(),
+        sources: {
+          ...mixAnnotationsSources,
+          ..._flutterResolveStubs,
+          ..._mixSourcesWithStyleWidget,
+          'mix|lib/f_bounded_target.dart': input,
+        },
+        inputAsset: 'mix|lib/f_bounded_target.dart',
+        outputAsset: 'mix|lib/f_bounded_target.g.dart',
+        outputMatcher: allOf(
+          contains(
+            'ComparableWidget<T> call<T extends Comparable<T>>({\n'
+            '    Key? key,\n'
+            '    required T value,\n'
+            '  })',
+          ),
+          contains(
+            'return ComparableWidget<T>(key: key, style: this, value: value);',
+          ),
+        ),
+      );
+    });
+
+    test('preserves generic function type bounds', () async {
+      const input = '''
+        library generic_function_bound_target;
+        import 'package:flutter/widgets.dart';
+        import 'package:mix/mix.dart';
+        import 'package:mix/src/core/style_widget.dart';
+        import 'package:mix_annotations/mix_annotations.dart';
+        part 'generic_function_bound_target.g.dart';
+
+        @MixableSpec(target: GenericFunctionWidget.new)
+        final class GenericFunctionSpec extends Spec<GenericFunctionSpec> {
+          const GenericFunctionSpec();
+        }
+
+        class GenericFunctionWidget<T extends S Function<S>(S)>
+            extends StyleWidget<GenericFunctionSpec> {
+          const GenericFunctionWidget({super.key, required super.style});
+        }
+      ''';
+
+      await expectGeneratorOutputResolves(
+        builder: _specStylerPartBuilder(),
+        sources: {
+          ...mixAnnotationsSources,
+          ..._flutterResolveStubs,
+          ..._mixSourcesWithStyleWidget,
+          'mix|lib/generic_function_bound_target.dart': input,
+        },
+        inputAsset: 'mix|lib/generic_function_bound_target.dart',
+        outputAsset: 'mix|lib/generic_function_bound_target.g.dart',
+        outputMatcher: allOf(
+          contains(
+            'GenericFunctionWidget<T> '
+            'call<T extends S Function<S>(S)>({Key? key})',
+          ),
+          contains('return GenericFunctionWidget<T>(key: key, style: this);'),
+        ),
+      );
+    });
+
+    test('preserves visible prefixes inside record bounds', () async {
+      const input = '''
+        library record_bound_target;
+        import 'package:flutter/widgets.dart';
+        import 'package:mix/mix.dart';
+        import 'package:mix/src/core/style_widget.dart';
+        import 'package:mix_annotations/mix_annotations.dart';
+        import 'bound.dart' as b;
+        part 'record_bound_target.g.dart';
+
+        @MixableSpec(target: RecordWidget.new)
+        final class RecordSpec extends Spec<RecordSpec> {
+          const RecordSpec();
+        }
+
+        class RecordWidget<T extends (b.Visible,)>
+            extends StyleWidget<RecordSpec> {
+          const RecordWidget({super.key, required super.style});
+        }
+      ''';
+
+      await expectGeneratorOutputResolves(
+        builder: _specStylerPartBuilder(),
+        sources: {
+          ...mixAnnotationsSources,
+          ..._flutterResolveStubs,
+          ..._mixSourcesWithStyleWidget,
+          'mix|lib/bound.dart': 'class Visible {}',
+          'mix|lib/record_bound_target.dart': input,
+        },
+        inputAsset: 'mix|lib/record_bound_target.dart',
+        outputAsset: 'mix|lib/record_bound_target.g.dart',
+        outputMatcher: allOf(
+          contains('RecordWidget<T> call<T extends (b.Visible,)>({Key? key})'),
+          contains('return RecordWidget<T>(key: key, style: this);'),
+        ),
+      );
+    });
+
+    test(
+      'preserves target widget type parameters unused by constructor params',
+      () async {
+        const input = '''
+          library unused_generic_target;
+          import 'package:flutter/widgets.dart';
+          import 'package:mix/mix.dart';
+          import 'package:mix/src/core/style_widget.dart';
+          import 'package:mix_annotations/mix_annotations.dart';
+          part 'unused_generic_target.g.dart';
+
+          @MixableSpec(target: WrapperWidget.new)
+          final class WrapperSpec extends Spec<WrapperSpec> {
+            const WrapperSpec();
+          }
+
+          class WrapperWidget<T> extends StyleWidget<WrapperSpec> {
+            const WrapperWidget({super.key, required super.style});
+          }
+        ''';
+
+        await expectGeneratorOutputResolves(
+          builder: _specStylerPartBuilder(),
+          sources: {
+            ...mixAnnotationsSources,
+            ..._flutterResolveStubs,
+            ..._mixSourcesWithStyleWidget,
+            'mix|lib/unused_generic_target.dart': input,
+          },
+          inputAsset: 'mix|lib/unused_generic_target.dart',
+          outputAsset: 'mix|lib/unused_generic_target.g.dart',
+          outputMatcher: allOf(
+            contains('WrapperWidget<T> call<T>({Key? key})'),
+            contains('return WrapperWidget<T>(key: key, style: this);'),
+          ),
+        );
+      },
+    );
+
+    test('rejects target type parameters that shadow Flutter Key', () async {
+      const input = '''
+        library key_shadow_target;
+        import 'package:mix/mix.dart';
+        import 'package:mix/src/core/style_widget.dart';
+        import 'package:mix_annotations/mix_annotations.dart';
+        part 'key_shadow_target.g.dart';
+
+        @MixableSpec(target: GenericWidget.new)
+        final class GenericSpec extends Spec<GenericSpec> {
+          const GenericSpec();
+        }
+
+        class GenericWidget<Key> extends StyleWidget<GenericSpec> {
+          const GenericWidget({super.key, required super.style});
+        }
+      ''';
+
+      final errors = await _expectSpecStylerValidationError({
+        ...mixAnnotationsSources,
+        ..._flutterResolveStubs,
+        ..._mixSourcesWithStyleWidget,
+        'mix|lib/key_shadow_target.dart': input,
+      }, inputAsset: 'mix|lib/key_shadow_target.dart');
+
+      expect(
+        errors,
+        contains(
+          'Target widget type parameter `Key` conflicts with the generated '
+          'Flutter `Key? key` parameter',
+        ),
+      );
+    });
+
+    test('rejects instantiated generic target constructor tear-offs', () async {
+      const input = '''
+        library spike;
+        import 'package:mix/mix.dart';
+        import 'package:mix/src/core/style_widget.dart';
+        import 'package:mix_annotations/mix_annotations.dart';
+        part 'spike.g.dart';
+
+        @MixableSpec(target: GenericWidget<int>.new)
+        final class GenericSpec extends Spec<GenericSpec> {
+          const GenericSpec();
+        }
+
+        class GenericWidget<T> extends StyleWidget<GenericSpec> {
+          const GenericWidget({required super.style, required this.value});
+
+          final T value;
+        }
+      ''';
+
+      final errors = await _expectSpecStylerValidationError({
+        ...mixAnnotationsSources,
+        ..._flutterResolveStubs,
+        ..._mixSourcesWithStyleWidget,
+        'mix|lib/spike.dart': input,
+      });
+
+      expect(
+        errors,
+        contains(
+          '@MixableSpec(target:) only supports direct, uninstantiated '
+          'constructor tear-offs for generic target `GenericWidget`',
+        ),
+      );
+    });
+
+    test(
+      'rejects generic target constructor tear-offs through typedefs',
+      () async {
+        const input = '''
+        library spike;
+        import 'package:mix/mix.dart';
+        import 'package:mix/src/core/style_widget.dart';
+        import 'package:mix_annotations/mix_annotations.dart';
+        part 'spike.g.dart';
+
+        typedef GenericAlias<T> = GenericWidget<T>;
+
+        @MixableSpec(target: GenericAlias.new)
+        final class GenericSpec extends Spec<GenericSpec> {
+          const GenericSpec();
+        }
+
+        class GenericWidget<T> extends StyleWidget<GenericSpec> {
+          const GenericWidget({required super.style, required this.value});
+
+          final T value;
+        }
+      ''';
+
+        final errors = await _expectSpecStylerValidationError({
+          ...mixAnnotationsSources,
+          ..._flutterResolveStubs,
+          ..._mixSourcesWithStyleWidget,
+          'mix|lib/spike.dart': input,
+        });
+
+        expect(
+          errors,
+          contains(
+            '@MixableSpec(target:) only supports direct, uninstantiated '
+            'constructor tear-offs for generic target `GenericWidget`',
+          ),
+        );
+      },
+    );
+
+    test(
       'uses source imports needed by target widgets from the host part',
       () async {
         const specInput = '''

--- a/packages/mix_winds/tool/gen_registry.dart
+++ b/packages/mix_winds/tool/gen_registry.dart
@@ -175,16 +175,16 @@ void _writeGeneratedDart(String path, String output) {
 }
 
 void _checkGeneratedDart(String path, String output) {
-  final tempDir = Directory.systemTemp.createTempSync(
-    'mix_winds_registry_check_',
-  );
+  final target = File(path);
+  // Keep the temporary source in the package so `dart format` resolves the
+  // same package language version for both files.
+  final tempDir = target.parent.createTempSync('.mix_winds_registry_check_');
   try {
     final temporary = File(
       '${tempDir.path}/${File(path).uri.pathSegments.last}',
     )..writeAsStringSync(output);
     if (!_formatGeneratedDart(temporary)) return;
 
-    final target = File(path);
     if (!target.existsSync() ||
         target.readAsStringSync() != temporary.readAsStringSync()) {
       stderr.writeln(

--- a/skills/mix/references/code-generation.md
+++ b/skills/mix/references/code-generation.md
@@ -57,6 +57,7 @@ Optional method flags:
 - `GeneratedSpecMethods.skipLerp`
 
 With `target: Widget.new`, it also drives generated Styler and `call()` support from the target widget constructor.
+Direct, uninstantiated generic targets are supported; generated `call()` methods preserve and forward their type parameters and bounds. Instantiated targets such as `Widget<int>.new` and generic constructor tear-offs through typedefs are rejected because their substitutions are not yet supported. A target type parameter named `Key` is also rejected when the constructor forwards Flutter's `key`, because it would shadow the generated `Key? key` parameter.
 
 ### `@MixableStyler()` Legacy
 


### PR DESCRIPTION
#### Related issue

Closes #1023

### Description

Preserves generic widget target parameters and their bounds in generated `@MixableSpec(target:)` `call()` methods so the result analyzes cleanly and retains the target contract.

### Changes

- Forward direct, uninstantiated target generics through method declarations, return types, and constructor invocations
- Reject instantiated or typedef-aliased generic tear-offs and `Key` shadowing with actionable diagnostics
- Render generic-function and record bounds with visible prefixes, share extraction with `@MixWidget`, and update tests and docs for `mix_generator` 2.2.0-beta.3
- Remove the empty shared `analyzer.exclude` block rejected by the stable Dart analyzer in CI; no files were excluded by it
- Make the registry freshness check use the package language version and align the animation golden tolerance with Flutter 3.47 Linux rasterization

**Review Checklist**

- [x] **Testing**: `dart test -r failures-only` (361 passed), `dart analyze`, and `melos run gen:build`
- [x] **Breaking Changes**: Instantiated and typedef-aliased generic targets now fail explicitly rather than silently widening
- [x] **Documentation Updates**: Updated the package README, changelog, and Mix code-generation reference
- [x] **Website Updates**: No website update is required for this generator-only fix

### Additional Information (optional)

`melos run gen:build` completed successfully with no tracked generated-file drift. Under Flutter 3.47.0 / Dart 3.13.0, all 532 `mix_winds` tests, 14 Mix example tests, and 361 `mix_generator` tests pass; all three affected packages analyze cleanly.
