### PR TITLE
feat(mix_generator): emit styler field metadata

### DIFF
--- a/packages/mix/CHANGELOG.md
+++ b/packages/mix/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 2.2.0-beta.5
+
+### New features
+
+- **Generated Styler field metadata:** Every generated Styler now exposes its
+  complete source-field inventory through
+  `StylerFieldMetadata.$stylerFieldNames`, allowing schema tooling to validate
+  coverage without maintaining duplicate string manifests. Handwritten and
+  previously generated Stylers do not implement this capability until they opt
+  in or are regenerated.
+
 ## 2.2.0-beta.4
 
 ### Fixes

--- a/packages/mix/lib/src/core/style.dart
+++ b/packages/mix/lib/src/core/style.dart
@@ -16,6 +16,16 @@ sealed class StyleElement {
   const StyleElement();
 }
 
+/// Field metadata exposed by Styler classes produced by Mix's generator.
+///
+/// Protocols and tooling can use this capability to inspect a Styler's complete
+/// field surface without duplicating generated field names. Handwritten Stylers
+/// can implement this interface when they want to expose the same metadata.
+abstract interface class StylerFieldMetadata {
+  /// Names of every field represented by the Styler's [Mix.props].
+  Set<String> get $stylerFieldNames;
+}
+
 /// Base class for style classes that can be resolved to specifications.
 ///
 /// Provides variant support, modifiers, and animation configuration for styled elements.

--- a/packages/mix/lib/src/layout/grid_box.dart
+++ b/packages/mix/lib/src/layout/grid_box.dart
@@ -30,7 +30,8 @@ export 'grid_box_spec.dart';
 /// size when they overflow; clipping changes paint containment, not geometry.
 /// Numeric geometry accepts `SpaceToken` and `DoubleToken` references and
 /// resolves them before [GridBoxSpec] validation.
-class GridBoxStyler extends MixStyler<GridBoxStyler, GridBoxSpec> {
+class GridBoxStyler extends MixStyler<GridBoxStyler, GridBoxSpec>
+    implements StylerFieldMetadata {
   /// Unresolved column tracks, or `null` to use one `fr(1)` column.
   final List<GridTrack>? $columns;
 
@@ -253,6 +254,20 @@ class GridBoxStyler extends MixStyler<GridBoxStyler, GridBoxSpec> {
       animation: MixOps.mergeAnimation($animation, other.$animation),
     );
   }
+
+  @override
+  Set<String> get $stylerFieldNames => const {
+    'columns',
+    'rows',
+    'autoRows',
+    'columnGap',
+    'rowGap',
+    'clipBehavior',
+    'constraintBranches',
+    'variants',
+    'modifier',
+    'animation',
+  };
 
   @override
   List<Object?> get props => [

--- a/packages/mix/lib/src/specs/box/box_spec.g.dart
+++ b/packages/mix/lib/src/specs/box/box_spec.g.dart
@@ -150,7 +150,8 @@ class BoxStyler extends MixStyler<BoxStyler, BoxSpec>
         BorderStyleMixin<BoxStyler>,
         BorderRadiusStyleMixin<BoxStyler>,
         ShadowStyleMixin<BoxStyler>,
-        TransformStyleMixin<BoxStyler> {
+        TransformStyleMixin<BoxStyler>
+    implements StylerFieldMetadata {
   final Prop<AlignmentGeometry>? $alignment;
   final Prop<EdgeInsetsGeometry>? $padding;
   final Prop<EdgeInsetsGeometry>? $margin;
@@ -390,6 +391,22 @@ class BoxStyler extends MixStyler<BoxStyler, BoxSpec>
   BoxStyler transform(Matrix4 value, {Alignment alignment = .center}) {
     return merge(BoxStyler(transform: value, transformAlignment: alignment));
   }
+
+  @override
+  Set<String> get $stylerFieldNames => const {
+    'alignment',
+    'padding',
+    'margin',
+    'constraints',
+    'decoration',
+    'foregroundDecoration',
+    'transform',
+    'transformAlignment',
+    'clipBehavior',
+    'animation',
+    'modifier',
+    'variants',
+  };
 
   /// Sets the alignment.
   BoxStyler alignment(AlignmentGeometry value) {

--- a/packages/mix/lib/src/specs/flex/flex_spec.g.dart
+++ b/packages/mix/lib/src/specs/flex/flex_spec.g.dart
@@ -156,7 +156,8 @@ typedef _$FlexSpecMethods = _$FlexSpec; // ignore: unused_element
 // **************************************************************************
 
 class FlexStyler extends MixStyler<FlexStyler, FlexSpec>
-    with FlexStyleMixin<FlexStyler> {
+    with FlexStyleMixin<FlexStyler>
+    implements StylerFieldMetadata {
   final Prop<Axis>? $direction;
   final Prop<MainAxisAlignment>? $mainAxisAlignment;
   final Prop<CrossAxisAlignment>? $crossAxisAlignment;
@@ -241,6 +242,22 @@ class FlexStyler extends MixStyler<FlexStyler, FlexSpec>
   FlexStyler flex(FlexStyler value) {
     return merge(value);
   }
+
+  @override
+  Set<String> get $stylerFieldNames => const {
+    'direction',
+    'mainAxisAlignment',
+    'crossAxisAlignment',
+    'mainAxisSize',
+    'verticalDirection',
+    'textDirection',
+    'textBaseline',
+    'clipBehavior',
+    'spacing',
+    'animation',
+    'modifier',
+    'variants',
+  };
 
   /// Sets the direction.
   @override

--- a/packages/mix/lib/src/specs/flexbox/flexbox_spec.g.dart
+++ b/packages/mix/lib/src/specs/flexbox/flexbox_spec.g.dart
@@ -92,7 +92,8 @@ class FlexBoxStyler extends MixStyler<FlexBoxStyler, FlexBoxSpec>
         BorderRadiusStyleMixin<FlexBoxStyler>,
         ShadowStyleMixin<FlexBoxStyler>,
         TransformStyleMixin<FlexBoxStyler>,
-        FlexStyleMixin<FlexBoxStyler> {
+        FlexStyleMixin<FlexBoxStyler>
+    implements StylerFieldMetadata {
   final Prop<StyleSpec<BoxSpec>>? $box;
   final Prop<StyleSpec<FlexSpec>>? $flex;
 
@@ -416,6 +417,15 @@ class FlexBoxStyler extends MixStyler<FlexBoxStyler, FlexBoxSpec>
   FlexBoxStyler flex(FlexStyler value) {
     return merge(FlexBoxStyler.create(flex: Prop.maybeMix(value)));
   }
+
+  @override
+  Set<String> get $stylerFieldNames => const {
+    'box',
+    'flex',
+    'animation',
+    'modifier',
+    'variants',
+  };
 
   /// Sets the animation configuration.
   @override

--- a/packages/mix/lib/src/specs/icon/icon_spec.g.dart
+++ b/packages/mix/lib/src/specs/icon/icon_spec.g.dart
@@ -168,7 +168,8 @@ typedef _$IconSpecMethods = _$IconSpec; // ignore: unused_element
 // SpecStylerGenerator
 // **************************************************************************
 
-class IconStyler extends MixStyler<IconStyler, IconSpec> {
+class IconStyler extends MixStyler<IconStyler, IconSpec>
+    implements StylerFieldMetadata {
   final Prop<Color>? $color;
   final Prop<double>? $size;
   final Prop<double>? $weight;
@@ -272,6 +273,26 @@ class IconStyler extends MixStyler<IconStyler, IconSpec> {
   IconStyler shadow(ShadowMix value) {
     return merge(IconStyler(shadows: [value]));
   }
+
+  @override
+  Set<String> get $stylerFieldNames => const {
+    'color',
+    'size',
+    'weight',
+    'grade',
+    'opticalSize',
+    'shadows',
+    'textDirection',
+    'applyTextScaling',
+    'fill',
+    'semanticsLabel',
+    'opacity',
+    'blendMode',
+    'icon',
+    'animation',
+    'modifier',
+    'variants',
+  };
 
   /// Sets the color.
   IconStyler color(Color value) {

--- a/packages/mix/lib/src/specs/image/image_spec.g.dart
+++ b/packages/mix/lib/src/specs/image/image_spec.g.dart
@@ -202,7 +202,8 @@ typedef _$ImageSpecMethods = _$ImageSpec; // ignore: unused_element
 // SpecStylerGenerator
 // **************************************************************************
 
-class ImageStyler extends MixStyler<ImageStyler, ImageSpec> {
+class ImageStyler extends MixStyler<ImageStyler, ImageSpec>
+    implements StylerFieldMetadata {
   final Prop<ImageProvider<Object>>? $image;
   final Prop<double>? $width;
   final Prop<double>? $height;
@@ -315,6 +316,28 @@ class ImageStyler extends MixStyler<ImageStyler, ImageSpec> {
       ImageStyler().isAntiAlias(value);
   factory ImageStyler.matchTextDirection(bool value) =>
       ImageStyler().matchTextDirection(value);
+
+  @override
+  Set<String> get $stylerFieldNames => const {
+    'image',
+    'width',
+    'height',
+    'color',
+    'repeat',
+    'fit',
+    'alignment',
+    'centerSlice',
+    'filterQuality',
+    'colorBlendMode',
+    'semanticLabel',
+    'excludeFromSemantics',
+    'gaplessPlayback',
+    'isAntiAlias',
+    'matchTextDirection',
+    'animation',
+    'modifier',
+    'variants',
+  };
 
   /// Sets the image.
   ImageStyler image(ImageProvider<Object> value) {

--- a/packages/mix/lib/src/specs/stack/stack_spec.g.dart
+++ b/packages/mix/lib/src/specs/stack/stack_spec.g.dart
@@ -99,7 +99,8 @@ typedef _$StackSpecMethods = _$StackSpec; // ignore: unused_element
 // SpecStylerGenerator
 // **************************************************************************
 
-class StackStyler extends MixStyler<StackStyler, StackSpec> {
+class StackStyler extends MixStyler<StackStyler, StackSpec>
+    implements StylerFieldMetadata {
   final Prop<AlignmentGeometry>? $alignment;
   final Prop<StackFit>? $fit;
   final Prop<TextDirection>? $textDirection;
@@ -143,6 +144,17 @@ class StackStyler extends MixStyler<StackStyler, StackSpec> {
       StackStyler().textDirection(value);
   factory StackStyler.clipBehavior(Clip value) =>
       StackStyler().clipBehavior(value);
+
+  @override
+  Set<String> get $stylerFieldNames => const {
+    'alignment',
+    'fit',
+    'textDirection',
+    'clipBehavior',
+    'animation',
+    'modifier',
+    'variants',
+  };
 
   /// Sets the alignment.
   StackStyler alignment(AlignmentGeometry value) {

--- a/packages/mix/lib/src/specs/stackbox/stackbox_spec.g.dart
+++ b/packages/mix/lib/src/specs/stackbox/stackbox_spec.g.dart
@@ -94,7 +94,8 @@ class StackBoxStyler extends MixStyler<StackBoxStyler, StackBoxSpec>
         BorderStyleMixin<StackBoxStyler>,
         BorderRadiusStyleMixin<StackBoxStyler>,
         ShadowStyleMixin<StackBoxStyler>,
-        TransformStyleMixin<StackBoxStyler> {
+        TransformStyleMixin<StackBoxStyler>
+    implements StylerFieldMetadata {
   final Prop<StyleSpec<BoxSpec>>? $box;
   final Prop<StyleSpec<StackSpec>>? $stack;
 
@@ -413,6 +414,15 @@ class StackBoxStyler extends MixStyler<StackBoxStyler, StackBoxSpec>
   StackBoxStyler stackClipBehavior(Clip value) {
     return merge(StackBoxStyler(stackClipBehavior: value));
   }
+
+  @override
+  Set<String> get $stylerFieldNames => const {
+    'box',
+    'stack',
+    'animation',
+    'modifier',
+    'variants',
+  };
 
   /// Sets the animation configuration.
   @override

--- a/packages/mix/lib/src/specs/text/text_spec.g.dart
+++ b/packages/mix/lib/src/specs/text/text_spec.g.dart
@@ -175,7 +175,8 @@ typedef _$TextSpecMethods = _$TextSpec; // ignore: unused_element
 // **************************************************************************
 
 class TextStyler extends MixStyler<TextStyler, TextSpec>
-    with TextStyleMixin<TextStyler> {
+    with TextStyleMixin<TextStyler>
+    implements StylerFieldMetadata {
   final Prop<TextOverflow>? $overflow;
   final Prop<StrutStyle>? $strutStyle;
   final Prop<TextAlign>? $textAlign;
@@ -364,6 +365,27 @@ class TextStyler extends MixStyler<TextStyler, TextSpec>
       TextStyler(textDirectives: [const SentenceCaseStringDirective()]),
     );
   }
+
+  @override
+  Set<String> get $stylerFieldNames => const {
+    'overflow',
+    'strutStyle',
+    'textAlign',
+    'textScaler',
+    'maxLines',
+    'style',
+    'textWidthBasis',
+    'textHeightBehavior',
+    'textDirection',
+    'softWrap',
+    'textDirectives',
+    'selectionColor',
+    'semanticsLabel',
+    'locale',
+    'animation',
+    'modifier',
+    'variants',
+  };
 
   /// Sets the overflow.
   TextStyler overflow(TextOverflow value) {

--- a/packages/mix/lib/src/specs/wrap/wrap_spec.g.dart
+++ b/packages/mix/lib/src/specs/wrap/wrap_spec.g.dart
@@ -145,7 +145,8 @@ typedef _$WrapSpecMethods = _$WrapSpec; // ignore: unused_element
 // **************************************************************************
 
 class WrapStyler extends MixStyler<WrapStyler, WrapSpec>
-    with WrapStyleMixin<WrapStyler> {
+    with WrapStyleMixin<WrapStyler>
+    implements StylerFieldMetadata {
   final Prop<Axis>? $direction;
   final Prop<WrapAlignment>? $alignment;
   final Prop<double>? $spacing;
@@ -231,6 +232,22 @@ class WrapStyler extends MixStyler<WrapStyler, WrapSpec>
   WrapStyler flow(WrapStyler value) {
     return merge(value);
   }
+
+  @override
+  Set<String> get $stylerFieldNames => const {
+    'direction',
+    'alignment',
+    'spacing',
+    'runAlignment',
+    'runSpacing',
+    'crossAxisAlignment',
+    'textDirection',
+    'verticalDirection',
+    'clipBehavior',
+    'animation',
+    'modifier',
+    'variants',
+  };
 
   /// Sets the direction.
   @override

--- a/packages/mix/lib/src/specs/wrapbox/wrapbox_spec.g.dart
+++ b/packages/mix/lib/src/specs/wrapbox/wrapbox_spec.g.dart
@@ -92,7 +92,8 @@ class WrapBoxStyler extends MixStyler<WrapBoxStyler, WrapBoxSpec>
         BorderRadiusStyleMixin<WrapBoxStyler>,
         ShadowStyleMixin<WrapBoxStyler>,
         TransformStyleMixin<WrapBoxStyler>,
-        WrapStyleMixin<WrapBoxStyler> {
+        WrapStyleMixin<WrapBoxStyler>
+    implements StylerFieldMetadata {
   final Prop<StyleSpec<BoxSpec>>? $box;
   final Prop<StyleSpec<WrapSpec>>? $flow;
 
@@ -416,6 +417,15 @@ class WrapBoxStyler extends MixStyler<WrapBoxStyler, WrapBoxSpec>
   WrapBoxStyler flow(WrapStyler value) {
     return merge(WrapBoxStyler.create(flow: Prop.maybeMix(value)));
   }
+
+  @override
+  Set<String> get $stylerFieldNames => const {
+    'box',
+    'flow',
+    'animation',
+    'modifier',
+    'variants',
+  };
 
   /// Sets the animation configuration.
   @override

--- a/packages/mix/pubspec.yaml
+++ b/packages/mix/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mix
 description: An expressive way to effortlessly build design systems in Flutter.
-version: 2.2.0-beta.4
+version: 2.2.0-beta.5
 homepage: https://github.com/btwld/mix
 repository: https://github.com/btwld/mix/tree/main/packages/mix
 
@@ -18,7 +18,7 @@ dev_dependencies:
   dart_code_metrics_presets: ^2.24.0
   build_runner: ^2.11.0
   mix_generator:
-    version: ^2.2.0-beta.0
+    version: ^2.2.0-beta.3
     path: ../mix_generator
   flutter_test:
     sdk: flutter

--- a/packages/mix/test/src/style/styler_mixin_conformance_test.dart
+++ b/packages/mix/test/src/style/styler_mixin_conformance_test.dart
@@ -85,6 +85,20 @@ void main() {
         expect(IconStyler(), isA<WidgetStateVariantMixin>());
         expect(ImageStyler(), isA<WidgetStateVariantMixin>());
       });
+
+      test('all Stylers name every equality field', () {
+        _verifyFieldInventory(BoxStyler());
+        _verifyFieldInventory(FlexStyler());
+        _verifyFieldInventory(FlexBoxStyler());
+        _verifyFieldInventory(StackStyler());
+        _verifyFieldInventory(StackBoxStyler());
+        _verifyFieldInventory(WrapStyler());
+        _verifyFieldInventory(WrapBoxStyler());
+        _verifyFieldInventory(GridBoxStyler());
+        _verifyFieldInventory(TextStyler());
+        _verifyFieldInventory(IconStyler());
+        _verifyFieldInventory(ImageStyler());
+      });
     });
 
     // =========================================================================
@@ -367,6 +381,12 @@ void main() {
       });
     });
   });
+}
+
+void _verifyFieldInventory<S extends Spec<S>>(Style<S> styler) {
+  expect(styler, isA<StylerFieldMetadata>());
+  final metadata = styler as StylerFieldMetadata;
+  expect(metadata.$stylerFieldNames, hasLength(styler.props.length));
 }
 
 /// Verifies that a Styler has AnimationStyleMixin by calling its methods.

--- a/packages/mix_annotations/lib/src/annotations.dart
+++ b/packages/mix_annotations/lib/src/annotations.dart
@@ -4,6 +4,8 @@ import 'generator_flags.dart';
 ///
 /// [methods] specifies generated methods within the annotated class.
 /// [components] specifies external generated code like utility classes or extensions.
+/// The source field name `stylerFieldNames` is reserved for generated Styler
+/// metadata.
 class MixableSpec {
   final int methods;
   final int components;
@@ -32,6 +34,11 @@ const mixableSpec = MixableSpec();
 /// - `resolve()` method for resolving to StyleSpec
 /// - `debugFillProperties()` for diagnostics
 /// - `props` getter for equality comparison
+///
+/// The generated mixin always includes `$stylerFieldNames` metadata, even when
+/// [methods] disables `props` or every optional method. A custom `props`
+/// implementation must preserve that complete field surface. The member name
+/// `$stylerFieldNames` is reserved for this metadata.
 ///
 /// Example usage:
 /// ```dart

--- a/packages/mix_chart/CHANGELOG.md
+++ b/packages/mix_chart/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.1-beta.2
+
+- Regenerates chart Stylers with source-field metadata and requires the Mix
+  release that defines the metadata contract.
+
 ## 0.0.1-beta.1
 
 - Adds `PieChartStyler.selectedSliceRadiusOffset` to customize or disable the

--- a/packages/mix_chart/lib/src/public/specs/bar/bar_background_spec.g.dart
+++ b/packages/mix_chart/lib/src/public/specs/bar/bar_background_spec.g.dart
@@ -105,7 +105,8 @@ typedef _$BarBackgroundSpecMethods = _$BarBackgroundSpec; // ignore: unused_elem
 // **************************************************************************
 
 class BarBackgroundStyler
-    extends MixStyler<BarBackgroundStyler, BarBackgroundSpec> {
+    extends MixStyler<BarBackgroundStyler, BarBackgroundSpec>
+    implements StylerFieldMetadata {
   final Prop<bool>? $show;
   final Prop<double>? $fromY;
   final Prop<double>? $toY;
@@ -157,6 +158,18 @@ class BarBackgroundStyler
       BarBackgroundStyler().color(value);
   factory BarBackgroundStyler.gradient(Gradient value) =>
       BarBackgroundStyler().gradient(value);
+
+  @override
+  Set<String> get $stylerFieldNames => const {
+    'show',
+    'fromY',
+    'toY',
+    'color',
+    'gradient',
+    'animation',
+    'modifier',
+    'variants',
+  };
 
   /// Sets the show.
   BarBackgroundStyler show(bool value) {

--- a/packages/mix_chart/lib/src/public/specs/bar/bar_chart_spec.g.dart
+++ b/packages/mix_chart/lib/src/public/specs/bar/bar_chart_spec.g.dart
@@ -164,7 +164,8 @@ typedef _$BarChartSpecMethods = _$BarChartSpec; // ignore: unused_element
 // SpecStylerGenerator
 // **************************************************************************
 
-class BarChartStyler extends MixStyler<BarChartStyler, BarChartSpec> {
+class BarChartStyler extends MixStyler<BarChartStyler, BarChartSpec>
+    implements StylerFieldMetadata {
   final Prop<StyleSpec<ChartFrameSpec>>? $frame;
   final Prop<StyleSpec<ChartAxisSpec>>? $axis;
   final Prop<StyleSpec<ChartAxisSpec>>? $xAxis;
@@ -278,6 +279,27 @@ class BarChartStyler extends MixStyler<BarChartStyler, BarChartSpec> {
       BarChartStyler().alignment(value);
   factory BarChartStyler.tooltip(ChartTooltipStyler value) =>
       BarChartStyler().tooltip(value);
+
+  @override
+  Set<String> get $stylerFieldNames => const {
+    'frame',
+    'axis',
+    'xAxis',
+    'yAxis',
+    'topAxis',
+    'rightAxis',
+    'grid',
+    'bar',
+    'segment',
+    'palette',
+    'groupSpacing',
+    'barSpacing',
+    'alignment',
+    'tooltip',
+    'animation',
+    'modifier',
+    'variants',
+  };
 
   /// Sets the frame.
   BarChartStyler frame(ChartFrameStyler value) {

--- a/packages/mix_chart/lib/src/public/specs/bar/bar_spec.g.dart
+++ b/packages/mix_chart/lib/src/public/specs/bar/bar_spec.g.dart
@@ -233,7 +233,8 @@ typedef _$BarSegmentSpecMethods = _$BarSegmentSpec; // ignore: unused_element
 // SpecStylerGenerator
 // **************************************************************************
 
-class BarStyler extends MixStyler<BarStyler, BarSpec> {
+class BarStyler extends MixStyler<BarStyler, BarSpec>
+    implements StylerFieldMetadata {
   final Prop<Color>? $color;
   final Prop<Gradient>? $gradient;
   final Prop<double>? $width;
@@ -313,6 +314,23 @@ class BarStyler extends MixStyler<BarStyler, BarSpec> {
   factory BarStyler.label(TextStyler value) => BarStyler().label(value);
   factory BarStyler.labelOffset(Offset value) => BarStyler().labelOffset(value);
   factory BarStyler.labelAngle(double value) => BarStyler().labelAngle(value);
+
+  @override
+  Set<String> get $stylerFieldNames => const {
+    'color',
+    'gradient',
+    'width',
+    'borderRadius',
+    'border',
+    'borderDashArray',
+    'background',
+    'label',
+    'labelOffset',
+    'labelAngle',
+    'animation',
+    'modifier',
+    'variants',
+  };
 
   /// Sets the color.
   BarStyler color(Color value) {
@@ -464,7 +482,8 @@ class BarStyler extends MixStyler<BarStyler, BarSpec> {
   ];
 }
 
-class BarSegmentStyler extends MixStyler<BarSegmentStyler, BarSegmentSpec> {
+class BarSegmentStyler extends MixStyler<BarSegmentStyler, BarSegmentSpec>
+    implements StylerFieldMetadata {
   final Prop<Color>? $color;
   final Prop<Gradient>? $gradient;
   final Prop<BorderSide>? $border;
@@ -509,6 +528,17 @@ class BarSegmentStyler extends MixStyler<BarSegmentStyler, BarSegmentSpec> {
       BarSegmentStyler().border(value);
   factory BarSegmentStyler.label(TextStyler value) =>
       BarSegmentStyler().label(value);
+
+  @override
+  Set<String> get $stylerFieldNames => const {
+    'color',
+    'gradient',
+    'border',
+    'label',
+    'animation',
+    'modifier',
+    'variants',
+  };
 
   /// Sets the color.
   BarSegmentStyler color(Color value) {

--- a/packages/mix_chart/lib/src/public/specs/line/line_chart_spec.g.dart
+++ b/packages/mix_chart/lib/src/public/specs/line/line_chart_spec.g.dart
@@ -140,7 +140,8 @@ typedef _$LineChartSpecMethods = _$LineChartSpec; // ignore: unused_element
 // SpecStylerGenerator
 // **************************************************************************
 
-class LineChartStyler extends MixStyler<LineChartStyler, LineChartSpec> {
+class LineChartStyler extends MixStyler<LineChartStyler, LineChartSpec>
+    implements StylerFieldMetadata {
   final Prop<StyleSpec<ChartFrameSpec>>? $frame;
   final Prop<StyleSpec<ChartAxisSpec>>? $axis;
   final Prop<StyleSpec<ChartAxisSpec>>? $xAxis;
@@ -227,6 +228,23 @@ class LineChartStyler extends MixStyler<LineChartStyler, LineChartSpec> {
       LineChartStyler().palette(value);
   factory LineChartStyler.tooltip(ChartTooltipStyler value) =>
       LineChartStyler().tooltip(value);
+
+  @override
+  Set<String> get $stylerFieldNames => const {
+    'frame',
+    'axis',
+    'xAxis',
+    'yAxis',
+    'topAxis',
+    'rightAxis',
+    'grid',
+    'series',
+    'palette',
+    'tooltip',
+    'animation',
+    'modifier',
+    'variants',
+  };
 
   /// Sets the frame.
   LineChartStyler frame(ChartFrameStyler value) {

--- a/packages/mix_chart/lib/src/public/specs/line/line_series_spec.g.dart
+++ b/packages/mix_chart/lib/src/public/specs/line/line_series_spec.g.dart
@@ -176,7 +176,8 @@ typedef _$LineSeriesSpecMethods = _$LineSeriesSpec; // ignore: unused_element
 // SpecStylerGenerator
 // **************************************************************************
 
-class LineSeriesStyler extends MixStyler<LineSeriesStyler, LineSeriesSpec> {
+class LineSeriesStyler extends MixStyler<LineSeriesStyler, LineSeriesSpec>
+    implements StylerFieldMetadata {
   final Prop<bool>? $show;
   final Prop<StyleSpec<ChartStrokeSpec>>? $stroke;
   final Prop<LineCurve>? $curve;
@@ -276,6 +277,25 @@ class LineSeriesStyler extends MixStyler<LineSeriesStyler, LineSeriesSpec> {
       LineSeriesStyler().aboveArea(value);
   factory LineSeriesStyler.shadow(ShadowMix value) =>
       LineSeriesStyler().shadow(value);
+
+  @override
+  Set<String> get $stylerFieldNames => const {
+    'show',
+    'stroke',
+    'curve',
+    'smoothness',
+    'preventCurveOvershooting',
+    'curveOvershootingThreshold',
+    'roundStrokeCap',
+    'roundStrokeJoin',
+    'marker',
+    'belowArea',
+    'aboveArea',
+    'shadow',
+    'animation',
+    'modifier',
+    'variants',
+  };
 
   /// Sets the show.
   LineSeriesStyler show(bool value) {

--- a/packages/mix_chart/lib/src/public/specs/pie/pie_chart_spec.g.dart
+++ b/packages/mix_chart/lib/src/public/specs/pie/pie_chart_spec.g.dart
@@ -147,7 +147,8 @@ typedef _$PieChartSpecMethods = _$PieChartSpec; // ignore: unused_element
 // SpecStylerGenerator
 // **************************************************************************
 
-class PieChartStyler extends MixStyler<PieChartStyler, PieChartSpec> {
+class PieChartStyler extends MixStyler<PieChartStyler, PieChartSpec>
+    implements StylerFieldMetadata {
   final Prop<StyleSpec<ChartFrameSpec>>? $frame;
   final Prop<StyleSpec<PieSliceSpec>>? $slice;
   final Prop<double>? $selectedSliceRadiusOffset;
@@ -234,6 +235,23 @@ class PieChartStyler extends MixStyler<PieChartStyler, PieChartSpec> {
       PieChartStyler().sunbeamLabels(value);
   factory PieChartStyler.tooltip(ChartTooltipStyler value) =>
       PieChartStyler().tooltip(value);
+
+  @override
+  Set<String> get $stylerFieldNames => const {
+    'frame',
+    'slice',
+    'selectedSliceRadiusOffset',
+    'palette',
+    'centerRadius',
+    'centerColor',
+    'sliceSpacing',
+    'startAngle',
+    'sunbeamLabels',
+    'tooltip',
+    'animation',
+    'modifier',
+    'variants',
+  };
 
   /// Sets the frame.
   PieChartStyler frame(ChartFrameStyler value) {

--- a/packages/mix_chart/lib/src/public/specs/pie/pie_slice_spec.g.dart
+++ b/packages/mix_chart/lib/src/public/specs/pie/pie_slice_spec.g.dart
@@ -134,7 +134,8 @@ typedef _$PieSliceSpecMethods = _$PieSliceSpec; // ignore: unused_element
 // SpecStylerGenerator
 // **************************************************************************
 
-class PieSliceStyler extends MixStyler<PieSliceStyler, PieSliceSpec> {
+class PieSliceStyler extends MixStyler<PieSliceStyler, PieSliceSpec>
+    implements StylerFieldMetadata {
   final Prop<Color>? $color;
   final Prop<Gradient>? $gradient;
   final Prop<double>? $radius;
@@ -212,6 +213,22 @@ class PieSliceStyler extends MixStyler<PieSliceStyler, PieSliceSpec> {
       PieSliceStyler().cornerRadius(value);
   factory PieSliceStyler.badgePosition(double value) =>
       PieSliceStyler().badgePosition(value);
+
+  @override
+  Set<String> get $stylerFieldNames => const {
+    'color',
+    'gradient',
+    'radius',
+    'showLabel',
+    'label',
+    'labelPosition',
+    'border',
+    'cornerRadius',
+    'badgePosition',
+    'animation',
+    'modifier',
+    'variants',
+  };
 
   /// Sets the color.
   PieSliceStyler color(Color value) {

--- a/packages/mix_chart/lib/src/public/specs/shared/chart_area_spec.g.dart
+++ b/packages/mix_chart/lib/src/public/specs/shared/chart_area_spec.g.dart
@@ -104,7 +104,8 @@ typedef _$ChartAreaSpecMethods = _$ChartAreaSpec; // ignore: unused_element
 // SpecStylerGenerator
 // **************************************************************************
 
-class ChartAreaStyler extends MixStyler<ChartAreaStyler, ChartAreaSpec> {
+class ChartAreaStyler extends MixStyler<ChartAreaStyler, ChartAreaSpec>
+    implements StylerFieldMetadata {
   final Prop<bool>? $show;
   final Prop<Color>? $color;
   final Prop<Gradient>? $gradient;
@@ -154,6 +155,18 @@ class ChartAreaStyler extends MixStyler<ChartAreaStyler, ChartAreaSpec> {
       ChartAreaStyler().cutoffY(value);
   factory ChartAreaStyler.applyCutoff(bool value) =>
       ChartAreaStyler().applyCutoff(value);
+
+  @override
+  Set<String> get $stylerFieldNames => const {
+    'show',
+    'color',
+    'gradient',
+    'cutoffY',
+    'applyCutoff',
+    'animation',
+    'modifier',
+    'variants',
+  };
 
   /// Sets the show.
   ChartAreaStyler show(bool value) {

--- a/packages/mix_chart/lib/src/public/specs/shared/chart_axis_spec.g.dart
+++ b/packages/mix_chart/lib/src/public/specs/shared/chart_axis_spec.g.dart
@@ -148,7 +148,8 @@ typedef _$ChartAxisSpecMethods = _$ChartAxisSpec; // ignore: unused_element
 // SpecStylerGenerator
 // **************************************************************************
 
-class ChartAxisStyler extends MixStyler<ChartAxisStyler, ChartAxisSpec> {
+class ChartAxisStyler extends MixStyler<ChartAxisStyler, ChartAxisSpec>
+    implements StylerFieldMetadata {
   final Prop<bool>? $showLabels;
   final Prop<StyleSpec<TextSpec>>? $label;
   final Prop<double>? $reservedSize;
@@ -235,6 +236,23 @@ class ChartAxisStyler extends MixStyler<ChartAxisStyler, ChartAxisSpec> {
       ChartAxisStyler().drawBelowEverything(value);
   factory ChartAxisStyler.alignment(ChartAxisLabelAlignment value) =>
       ChartAxisStyler().alignment(value);
+
+  @override
+  Set<String> get $stylerFieldNames => const {
+    'showLabels',
+    'label',
+    'reservedSize',
+    'labelSpace',
+    'labelAngle',
+    'fitInside',
+    'fitInsideDistance',
+    'nameSize',
+    'drawBelowEverything',
+    'alignment',
+    'animation',
+    'modifier',
+    'variants',
+  };
 
   /// Sets the showLabels.
   ChartAxisStyler showLabels(bool value) {

--- a/packages/mix_chart/lib/src/public/specs/shared/chart_frame_spec.g.dart
+++ b/packages/mix_chart/lib/src/public/specs/shared/chart_frame_spec.g.dart
@@ -114,7 +114,8 @@ typedef _$ChartFrameSpecMethods = _$ChartFrameSpec; // ignore: unused_element
 // SpecStylerGenerator
 // **************************************************************************
 
-class ChartFrameStyler extends MixStyler<ChartFrameStyler, ChartFrameSpec> {
+class ChartFrameStyler extends MixStyler<ChartFrameStyler, ChartFrameSpec>
+    implements StylerFieldMetadata {
   final Prop<Color>? $backgroundColor;
   final Prop<Border>? $border;
   final Prop<bool>? $showBorder;
@@ -165,6 +166,18 @@ class ChartFrameStyler extends MixStyler<ChartFrameStyler, ChartFrameSpec> {
   factory ChartFrameStyler.clip(bool value) => ChartFrameStyler().clip(value);
   factory ChartFrameStyler.rotationQuarterTurns(int value) =>
       ChartFrameStyler().rotationQuarterTurns(value);
+
+  @override
+  Set<String> get $stylerFieldNames => const {
+    'backgroundColor',
+    'border',
+    'showBorder',
+    'clip',
+    'rotationQuarterTurns',
+    'animation',
+    'modifier',
+    'variants',
+  };
 
   /// Sets the backgroundColor.
   ChartFrameStyler backgroundColor(Color value) {

--- a/packages/mix_chart/lib/src/public/specs/shared/chart_grid_spec.g.dart
+++ b/packages/mix_chart/lib/src/public/specs/shared/chart_grid_spec.g.dart
@@ -124,7 +124,8 @@ typedef _$ChartGridSpecMethods = _$ChartGridSpec; // ignore: unused_element
 // SpecStylerGenerator
 // **************************************************************************
 
-class ChartGridStyler extends MixStyler<ChartGridStyler, ChartGridSpec> {
+class ChartGridStyler extends MixStyler<ChartGridStyler, ChartGridSpec>
+    implements StylerFieldMetadata {
   final Prop<bool>? $show;
   final Prop<bool>? $showHorizontal;
   final Prop<bool>? $showVertical;
@@ -182,6 +183,19 @@ class ChartGridStyler extends MixStyler<ChartGridStyler, ChartGridSpec> {
       ChartGridStyler().verticalInterval(value);
   factory ChartGridStyler.stroke(ChartStrokeStyler value) =>
       ChartGridStyler().stroke(value);
+
+  @override
+  Set<String> get $stylerFieldNames => const {
+    'show',
+    'showHorizontal',
+    'showVertical',
+    'horizontalInterval',
+    'verticalInterval',
+    'stroke',
+    'animation',
+    'modifier',
+    'variants',
+  };
 
   /// Sets the show.
   ChartGridStyler show(bool value) {

--- a/packages/mix_chart/lib/src/public/specs/shared/chart_marker_spec.g.dart
+++ b/packages/mix_chart/lib/src/public/specs/shared/chart_marker_spec.g.dart
@@ -122,7 +122,8 @@ typedef _$ChartMarkerSpecMethods = _$ChartMarkerSpec; // ignore: unused_element
 // SpecStylerGenerator
 // **************************************************************************
 
-class ChartMarkerStyler extends MixStyler<ChartMarkerStyler, ChartMarkerSpec> {
+class ChartMarkerStyler extends MixStyler<ChartMarkerStyler, ChartMarkerSpec>
+    implements StylerFieldMetadata {
   final Prop<bool>? $show;
   final Prop<ChartMarkerShape>? $shape;
   final Prop<Color>? $color;
@@ -187,6 +188,20 @@ class ChartMarkerStyler extends MixStyler<ChartMarkerStyler, ChartMarkerSpec> {
       ChartMarkerStyler().borderWidth(value);
   factory ChartMarkerStyler.shadow(ShadowMix value) =>
       ChartMarkerStyler().shadow(value);
+
+  @override
+  Set<String> get $stylerFieldNames => const {
+    'show',
+    'shape',
+    'color',
+    'radius',
+    'borderColor',
+    'borderWidth',
+    'shadow',
+    'animation',
+    'modifier',
+    'variants',
+  };
 
   /// Sets the show.
   ChartMarkerStyler show(bool value) {

--- a/packages/mix_chart/lib/src/public/specs/shared/chart_stroke_spec.g.dart
+++ b/packages/mix_chart/lib/src/public/specs/shared/chart_stroke_spec.g.dart
@@ -104,7 +104,8 @@ typedef _$ChartStrokeSpecMethods = _$ChartStrokeSpec; // ignore: unused_element
 // SpecStylerGenerator
 // **************************************************************************
 
-class ChartStrokeStyler extends MixStyler<ChartStrokeStyler, ChartStrokeSpec> {
+class ChartStrokeStyler extends MixStyler<ChartStrokeStyler, ChartStrokeSpec>
+    implements StylerFieldMetadata {
   final Prop<Color>? $color;
   final Prop<Gradient>? $gradient;
   final Prop<double>? $width;
@@ -156,6 +157,18 @@ class ChartStrokeStyler extends MixStyler<ChartStrokeStyler, ChartStrokeSpec> {
       ChartStrokeStyler().dashArray(value);
   factory ChartStrokeStyler.opacity(double value) =>
       ChartStrokeStyler().opacity(value);
+
+  @override
+  Set<String> get $stylerFieldNames => const {
+    'color',
+    'gradient',
+    'width',
+    'dashArray',
+    'opacity',
+    'animation',
+    'modifier',
+    'variants',
+  };
 
   /// Sets the color.
   ChartStrokeStyler color(Color value) {

--- a/packages/mix_chart/lib/src/public/specs/shared/chart_tooltip_spec.g.dart
+++ b/packages/mix_chart/lib/src/public/specs/shared/chart_tooltip_spec.g.dart
@@ -138,8 +138,8 @@ typedef _$ChartTooltipSpecMethods = _$ChartTooltipSpec; // ignore: unused_elemen
 // SpecStylerGenerator
 // **************************************************************************
 
-class ChartTooltipStyler
-    extends MixStyler<ChartTooltipStyler, ChartTooltipSpec> {
+class ChartTooltipStyler extends MixStyler<ChartTooltipStyler, ChartTooltipSpec>
+    implements StylerFieldMetadata {
   final Prop<Color>? $backgroundColor;
   final Prop<BorderSide>? $border;
   final Prop<BorderRadius>? $borderRadius;
@@ -219,6 +219,22 @@ class ChartTooltipStyler
       ChartTooltipStyler().fitVertically(value);
   factory ChartTooltipStyler.text(TextStyler value) =>
       ChartTooltipStyler().text(value);
+
+  @override
+  Set<String> get $stylerFieldNames => const {
+    'backgroundColor',
+    'border',
+    'borderRadius',
+    'padding',
+    'margin',
+    'maxWidth',
+    'fitHorizontally',
+    'fitVertically',
+    'text',
+    'animation',
+    'modifier',
+    'variants',
+  };
 
   /// Sets the backgroundColor.
   ChartTooltipStyler backgroundColor(Color value) {

--- a/packages/mix_chart/pubspec.yaml
+++ b/packages/mix_chart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mix_chart
 description: Type-safe Flutter chart widgets styled with Mix.
-version: 0.0.1-beta.1
+version: 0.0.1-beta.2
 homepage: https://github.com/btwld/mix
 repository: https://github.com/btwld/mix/tree/main/packages/mix_chart
 
@@ -12,7 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
   fl_chart: ^1.2.0
-  mix: ^2.2.0-beta.0
+  mix: ^2.2.0-beta.5
   mix_annotations: ^2.2.0-beta.0
 
 dev_dependencies:
@@ -22,7 +22,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   mix_generator:
-    version: ^2.2.0-beta.0
+    version: ^2.2.0-beta.3
     path: ../mix_generator
 
 screenshots:

--- a/packages/mix_chart/test/publish_contract_test.dart
+++ b/packages/mix_chart/test/publish_contract_test.dart
@@ -10,16 +10,16 @@ void main() {
     expect(pubspec, contains(RegExp(r'^name: mix_chart$', multiLine: true)));
     expect(
       pubspec,
-      contains(RegExp(r'^version: 0\.0\.1-beta\.1$', multiLine: true)),
+      contains(RegExp(r'^version: 0\.0\.1-beta\.2$', multiLine: true)),
     );
-    expect(changelog, startsWith('## 0.0.1-beta.1\n'));
+    expect(changelog, startsWith('## 0.0.1-beta.2\n'));
     expect(
       pubspec,
       isNot(contains('publish_to: none')),
       reason: 'mix_chart is released by the repository publish workflow.',
     );
     expect(
-      RegExp(r'^  mix: \^2\.2\.0-beta\.0$', multiLine: true).hasMatch(pubspec),
+      RegExp(r'^  mix: \^2\.2\.0-beta\.5$', multiLine: true).hasMatch(pubspec),
       isTrue,
       reason: 'Published packages must use the hosted Mix dependency.',
     );

--- a/packages/mix_generator/CHANGELOG.md
+++ b/packages/mix_generator/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 2.2.0-beta.3
 
+ - **FEAT**: Emit a complete `$stylerFieldNames` inventory for generated
+   Stylers so schema tooling can validate field coverage directly from runtime
+   classes. `stylerFieldNames` is now reserved, with a targeted diagnostic,
+   and generated field-name literals safely escape `$` identifiers. Generated
+   output requires Mix 2.2.0-beta.5 or newer.
  - **FIX**: Preserve type parameters and bounds from uninstantiated generic
    targets in generated `@MixableSpec(target:)` `call()` methods, and reject
    instantiated or aliased generic targets instead of silently widening them in

--- a/packages/mix_generator/lib/src/core/builders/spec_styler_class_builder.dart
+++ b/packages/mix_generator/lib/src/core/builders/spec_styler_class_builder.dart
@@ -383,6 +383,18 @@ class SpecStylerClassBuilder {
     return fields.map((field) => field.name).toSet();
   }
 
+  void _validateStylerMetadataField(List<FieldModel> fields) {
+    for (final field in fields) {
+      if (field.name != stylerFieldMetadataName) continue;
+      fail(
+        specElement.getField(field.name) ?? specElement,
+        '`${field.name}` is reserved for generated Styler metadata. '
+        'Rename the Spec field.',
+        todo: 'Rename the Spec field.',
+      );
+    }
+  }
+
   bool _usesTransformOwnerMixin(List<_OwnerMixinReference> mixins) {
     return mixins.any((mixin) => mixin.name == 'TransformStyleMixin');
   }
@@ -1144,6 +1156,7 @@ class SpecStylerClassBuilder {
       specName,
       visibleFrom: _emissionLibrary,
     );
+    _validateStylerMetadataField(fields);
     final mixins = _collectOwnerMixins(fields);
     final mixinNames = mixins.map((m) => '${m.name}<$stylerName>').toList();
     final mixinClause = mixinNames.isEmpty
@@ -1151,7 +1164,8 @@ class SpecStylerClassBuilder {
         : ' with ${mixinNames.join(', ')}';
     final buffer = StringBuffer();
     buffer.writeln(
-      'class $stylerName extends MixStyler<$stylerName, $specName>$mixinClause {',
+      'class $stylerName extends MixStyler<$stylerName, $specName>$mixinClause '
+      'implements StylerFieldMetadata {',
     );
 
     for (final field in fields) {

--- a/packages/mix_generator/lib/src/core/builders/styler_mixin_builder.dart
+++ b/packages/mix_generator/lib/src/core/builders/styler_mixin_builder.dart
@@ -14,6 +14,12 @@ const stylerFieldMetadataName = 'stylerFieldNames';
 /// Getter reserved for generated Styler metadata.
 const stylerFieldMetadataGetter = r'$stylerFieldNames';
 
+/// Source names of the fields inherited from `Style<T>` by every Styler.
+///
+/// The order is shared by generated `props` and field metadata. Legacy field
+/// extraction also uses this list to exclude the inherited storage fields.
+const stylerBaseFieldNames = ['animation', 'modifier', 'variants'];
+
 String _dartStringLiteral(String value) {
   final escaped = value
       .replaceAll(r'\', r'\\')
@@ -197,7 +203,9 @@ class StylerMixinBuilder {
   String _buildProps() {
     return _fieldEmitter().multilineProps(
       propCode: (field) => field.declaredName,
-      trailingProps: const [r'$animation', r'$modifier', r'$variants'],
+      trailingProps: [
+        for (final fieldName in stylerBaseFieldNames) '\$$fieldName',
+      ],
     );
   }
 
@@ -210,11 +218,11 @@ class StylerMixinBuilder {
       buffer.writeln('    ${_dartStringLiteral(field.name)},');
     }
 
-    buffer
-      ..writeln("    'animation',")
-      ..writeln("    'modifier',")
-      ..writeln("    'variants',")
-      ..writeln('  };');
+    for (final fieldName in stylerBaseFieldNames) {
+      buffer.writeln('    ${_dartStringLiteral(fieldName)},');
+    }
+
+    buffer.writeln('  };');
 
     return buffer.toString();
   }

--- a/packages/mix_generator/lib/src/core/builders/styler_mixin_builder.dart
+++ b/packages/mix_generator/lib/src/core/builders/styler_mixin_builder.dart
@@ -12,7 +12,7 @@ import '../models/styler_field_model.dart';
 const stylerFieldMetadataName = 'stylerFieldNames';
 
 /// Getter reserved for generated Styler metadata.
-const stylerFieldMetadataGetter = r'$stylerFieldNames';
+const stylerFieldMetadataGetter = '\$$stylerFieldMetadataName';
 
 /// Source names of the fields inherited from `Style<T>` by every Styler.
 ///

--- a/packages/mix_generator/lib/src/core/builders/styler_mixin_builder.dart
+++ b/packages/mix_generator/lib/src/core/builders/styler_mixin_builder.dart
@@ -1,12 +1,29 @@
 /// Builder for generated `_$XStylerMixin` code.
 ///
-/// Emits abstract getters, setters, base methods, `merge`, `resolve`,
-/// `debugFillProperties`, and `props` members.
+/// Emits field metadata, abstract getters, setters, base methods, `merge`,
+/// `resolve`, `debugFillProperties`, and `props` members.
 library;
 
 import '../models/annotation_config.dart';
 import '../helpers/field_emitter.dart';
 import '../models/styler_field_model.dart';
+
+/// Source-field name reserved for generated Styler metadata.
+const stylerFieldMetadataName = 'stylerFieldNames';
+
+/// Getter reserved for generated Styler metadata.
+const stylerFieldMetadataGetter = r'$stylerFieldNames';
+
+String _dartStringLiteral(String value) {
+  final escaped = value
+      .replaceAll(r'\', r'\\')
+      .replaceAll("'", r"\'")
+      .replaceAll(r'$', r'\$')
+      .replaceAll('\r', r'\r')
+      .replaceAll('\n', r'\n');
+
+  return "'$escaped'";
+}
 
 /// Builds the `_$XStylerMixin` for a Styler class.
 class StylerMixinBuilder {
@@ -170,7 +187,9 @@ class StylerMixinBuilder {
     return _fieldEmitter().debugFillProperties(
       callSuper: true,
       propertyCode: (field) {
-        return "DiagnosticsProperty('${field.displayName}', ${field.declaredName})";
+        return 'DiagnosticsProperty('
+            '${_dartStringLiteral(field.displayName)}, '
+            '${field.declaredName})';
       },
     );
   }
@@ -182,12 +201,32 @@ class StylerMixinBuilder {
     );
   }
 
+  String _buildFieldNames() {
+    final buffer = StringBuffer()
+      ..writeln('  @override')
+      ..writeln('  Set<String> get $stylerFieldMetadataGetter => const {');
+
+    for (final field in fields) {
+      buffer.writeln('    ${_dartStringLiteral(field.name)},');
+    }
+
+    buffer
+      ..writeln("    'animation',")
+      ..writeln("    'modifier',")
+      ..writeln("    'variants',")
+      ..writeln('  };');
+
+    return buffer.toString();
+  }
+
   /// The mixin name.
   String get mixinName => '_\$${stylerName}Mixin';
 
   /// Builds styler members without a surrounding mixin declaration.
   String buildMembers({Set<String> methodOverrides = const {}}) {
     final buffer = StringBuffer();
+
+    buffer.writeln(_buildFieldNames());
 
     if (config.generateSetters) {
       buffer.writeln(_buildSetters(methodOverrides: methodOverrides));
@@ -224,7 +263,10 @@ class StylerMixinBuilder {
   String build() {
     final buffer = StringBuffer();
 
-    buffer.writeln('mixin $mixinName on Style<$specName>, Diagnosticable {');
+    buffer.writeln(
+      'mixin $mixinName on Style<$specName>, Diagnosticable '
+      'implements StylerFieldMetadata {',
+    );
 
     buffer.writeln(_buildAbstractGetters());
 

--- a/packages/mix_generator/lib/src/styler_generator.dart
+++ b/packages/mix_generator/lib/src/styler_generator.dart
@@ -70,7 +70,7 @@ class StylerGenerator extends GeneratorForAnnotation<MixableStyler> {
 
   bool _isBaseField(String name) {
     // Base fields come from `Style<T>` and are handled separately.
-    return const {r'$variants', r'$modifier', r'$animation'}.contains(name);
+    return stylerBaseFieldNames.any((fieldName) => name == '\$$fieldName');
   }
 
   MixableStylerAnnotationConfig _extractAnnotationConfig(

--- a/packages/mix_generator/lib/src/styler_generator.dart
+++ b/packages/mix_generator/lib/src/styler_generator.dart
@@ -49,13 +49,23 @@ class StylerGenerator extends GeneratorForAnnotation<MixableStyler> {
     ClassElement classElement,
     String stylerName,
   ) {
-    return classElement.fields
+    for (final member in [...classElement.fields, ...classElement.methods]) {
+      if (member.name != stylerFieldMetadataGetter) continue;
+      fail(
+        member,
+        '`$stylerFieldMetadataGetter` is reserved for generated Styler metadata. '
+        'Rename the Styler member.',
+        todo: 'Rename the Styler member.',
+      );
+    }
+
+    final fields = classElement.fields
         .where((f) => f.name?.startsWith(r'$') ?? false)
-        .where((f) => !_isBaseField(f.name!))
-        .map((field) {
-          return StylerFieldModel.fromElement(field, stylerName: stylerName);
-        })
-        .toList();
+        .where((f) => !_isBaseField(f.name!));
+
+    return fields.map((field) {
+      return StylerFieldModel.fromElement(field, stylerName: stylerName);
+    }).toList();
   }
 
   bool _isBaseField(String name) {

--- a/packages/mix_generator/test/core/builders/styler_mixin_builder_test.dart
+++ b/packages/mix_generator/test/core/builders/styler_mixin_builder_test.dart
@@ -175,17 +175,7 @@ void main() {
         final builder = StylerMixinBuilder(
           stylerName: 'BoxStyler',
           specName: 'BoxSpec',
-          fields: [
-            StylerFieldModel(
-              name: 'gap',
-              declaredName: r'$gap',
-              fieldTypeCode: 'Prop<double>?',
-              isRawList: false,
-              effectivePublicParamType: 'double',
-              generateSetter: true,
-              setterName: 'gap',
-            ),
-          ],
+          fields: const [metadataField],
           config: defaultConfig,
         );
         final code = builder.build();

--- a/packages/mix_generator/test/core/builders/styler_mixin_builder_test.dart
+++ b/packages/mix_generator/test/core/builders/styler_mixin_builder_test.dart
@@ -6,6 +6,15 @@ import 'package:test/test.dart';
 
 void main() {
   const defaultConfig = MixableStylerAnnotationConfig();
+  const metadataField = StylerFieldModel(
+    name: 'gap',
+    declaredName: r'$gap',
+    fieldTypeCode: 'Prop<double>?',
+    isRawList: false,
+    effectivePublicParamType: 'double',
+    generateSetter: true,
+    setterName: 'gap',
+  );
 
   group('StylerMixinBuilder', () {
     group('mixinName', () {
@@ -42,7 +51,10 @@ void main() {
 
         expect(
           code,
-          contains('mixin _\$BoxStylerMixin on Style<BoxSpec>, Diagnosticable'),
+          contains(
+            'mixin _\$BoxStylerMixin on Style<BoxSpec>, Diagnosticable '
+            'implements StylerFieldMetadata',
+          ),
         );
       });
 
@@ -157,6 +169,62 @@ void main() {
 
         expect(code, contains('@override'));
         expect(code, contains('List<Object?> get props =>'));
+      });
+
+      test('generates the complete styler field-name inventory', () {
+        final builder = StylerMixinBuilder(
+          stylerName: 'BoxStyler',
+          specName: 'BoxSpec',
+          fields: [
+            StylerFieldModel(
+              name: 'gap',
+              declaredName: r'$gap',
+              fieldTypeCode: 'Prop<double>?',
+              isRawList: false,
+              effectivePublicParamType: 'double',
+              generateSetter: true,
+              setterName: 'gap',
+            ),
+          ],
+          config: defaultConfig,
+        );
+        final code = builder.build();
+
+        expect(
+          code,
+          contains(r'''Set<String> get $stylerFieldNames => const {
+    'gap',
+    'animation',
+    'modifier',
+    'variants',
+  };'''),
+        );
+      });
+
+      test(r'escapes $ in generated styler field-name literals', () {
+        final builder = StylerMixinBuilder(
+          stylerName: 'PriceStyler',
+          specName: 'PriceSpec',
+          fields: [
+            StylerFieldModel(
+              name: r'price$usd',
+              declaredName: r'$price$usd',
+              fieldTypeCode: 'Prop<double>?',
+              isRawList: false,
+              effectivePublicParamType: 'double',
+              generateSetter: true,
+              setterName: r'price$usd',
+            ),
+          ],
+          config: defaultConfig,
+        );
+        final code = builder.build();
+
+        expect(code, contains(r"'price\$usd',"));
+        expect(
+          code,
+          contains(r"DiagnosticsProperty('price\$usd', $price$usd)"),
+        );
       });
 
       test('emits optional call method before merge', () {
@@ -457,7 +525,7 @@ void main() {
         final builder = StylerMixinBuilder(
           stylerName: 'BoxStyler',
           specName: 'BoxSpec',
-          fields: [],
+          fields: const [metadataField],
           config: const MixableStylerAnnotationConfig(
             methods: GeneratedStylerMethods.skipProps,
           ),
@@ -465,16 +533,18 @@ void main() {
         final code = builder.build();
 
         expect(code, isNot(contains('List<Object?> get props =>')));
+        expect(code, contains(r'Set<String> get $stylerFieldNames'));
+        expect(code, contains("'gap',"));
         expect(code, contains('BoxStyler merge('));
         expect(code, contains('StyleSpec<BoxSpec> resolve('));
         expect(code, contains('void debugFillProperties('));
       });
 
-      test('generates nothing when all flags disabled', () {
+      test('generates only field metadata when all flags are disabled', () {
         final builder = StylerMixinBuilder(
           stylerName: 'BoxStyler',
           specName: 'BoxSpec',
-          fields: [],
+          fields: const [metadataField],
           config: const MixableStylerAnnotationConfig(
             methods: GeneratedStylerMethods.none,
           ),
@@ -485,6 +555,8 @@ void main() {
           code,
           contains('mixin _\$BoxStylerMixin on Style<BoxSpec>, Diagnosticable'),
         );
+        expect(code, contains(r'Set<String> get $stylerFieldNames'));
+        expect(code, contains("'gap',"));
         expect(code, isNot(contains('BoxStyler merge(')));
         expect(code, isNot(contains('StyleSpec<BoxSpec> resolve(')));
         expect(code, isNot(contains('void debugFillProperties(')));

--- a/packages/mix_generator/test/integration/generator_smoke_test.dart
+++ b/packages/mix_generator/test/integration/generator_smoke_test.dart
@@ -71,6 +71,10 @@ import '../variants/variant.dart';
 import 'spec.dart';
 import 'style_spec.dart';
 
+abstract interface class StylerFieldMetadata {
+  Set<String> get $stylerFieldNames;
+}
+
 abstract class Style<S extends Spec<S>> {
   final List<VariantStyle<S>>? $variants;
   final WidgetModifierConfig? $modifier;

--- a/packages/mix_generator/test/integration/generator_validation_test.dart
+++ b/packages/mix_generator/test/integration/generator_validation_test.dart
@@ -1,4 +1,5 @@
 import 'package:build_test/build_test.dart';
+import 'package:logging/logging.dart';
 import 'package:mix_generator/mix_generator.dart';
 import 'package:source_gen_test/source_gen_test.dart';
 import 'package:test/test.dart';
@@ -24,6 +25,25 @@ Future<String> _expectMixWidgetValidationError(
   expect(result.succeeded, isFalse);
 
   return result.errors.join('\n');
+}
+
+Future<String> _expectStylerValidationError(String libSource) async {
+  final logs = <LogRecord>[];
+  await testBuilder(
+    partBuilder(const StylerGenerator()),
+    {
+      ...mixAnnotationsSources,
+      'mix|lib/src/core/style.dart': styleStub,
+      'mix_generator|lib/styler_validation.dart': libSource,
+    },
+    generateFor: {'mix_generator|lib/styler_validation.dart'},
+    onLog: logs.add,
+  );
+
+  return logs
+      .where((record) => record.level == Level.SEVERE)
+      .map((record) => record.message)
+      .join('\n');
 }
 
 void main() {
@@ -121,6 +141,68 @@ class NotAStyle {}
         );
       },
     );
+
+    test('StylerGenerator rejects a getter reserved for metadata', () async {
+      const libSource = r'''
+library styler_validation;
+
+import 'package:mix_annotations/mix_annotations.dart';
+import 'package:mix/src/core/style.dart';
+
+part 'styler_validation.g.dart';
+
+@MixableStyler()
+class ReservedStyler extends Style<Object> {
+  Object? get $stylerFieldNames => null;
+
+  const ReservedStyler()
+    : super(variants: null, modifier: null, animation: null);
+}
+''';
+
+      final errors = await _expectStylerValidationError(libSource);
+
+      expect(
+        errors,
+        allOf(
+          contains(
+            r'`$stylerFieldNames` is reserved for generated Styler metadata',
+          ),
+          contains('Rename the Styler member'),
+        ),
+      );
+    });
+
+    test('StylerGenerator rejects a method reserved for metadata', () async {
+      const libSource = r'''
+library styler_validation;
+
+import 'package:mix_annotations/mix_annotations.dart';
+import 'package:mix/src/core/style.dart';
+
+part 'styler_validation.g.dart';
+
+@MixableStyler()
+class ReservedStyler extends Style<Object> {
+  const ReservedStyler()
+    : super(variants: null, modifier: null, animation: null);
+
+  Object? $stylerFieldNames() => null;
+}
+''';
+
+      final errors = await _expectStylerValidationError(libSource);
+
+      expect(
+        errors,
+        allOf(
+          contains(
+            r'`$stylerFieldNames` is reserved for generated Styler metadata',
+          ),
+          contains('Rename the Styler member'),
+        ),
+      );
+    });
 
     test('MixWidgetGenerator rejects annotation on a class', () async {
       const libSource = r'''

--- a/packages/mix_generator/test/integration/mix_widget_spec_styler_test.dart
+++ b/packages/mix_generator/test/integration/mix_widget_spec_styler_test.dart
@@ -31,6 +31,10 @@ const _mixStub = r'''
     const Spec();
   }
 
+  abstract interface class StylerFieldMetadata {
+    Set<String> get $stylerFieldNames;
+  }
+
   abstract class Style<S extends Spec<S>> extends Mix<StyleSpec<S>> {
     final List<VariantStyle<S>>? $variants;
     final WidgetModifierConfig? $modifier;

--- a/packages/mix_generator/test/integration/spec_styler_generator_smoke_test.dart
+++ b/packages/mix_generator/test/integration/spec_styler_generator_smoke_test.dart
@@ -52,6 +52,10 @@ const _setterTypeMixSources = {
       const Spec();
     }
 
+    abstract interface class StylerFieldMetadata {
+      Set<String> get \$stylerFieldNames;
+    }
+
     abstract class Style<S extends Spec<S>> extends Mix<StyleSpec<S>> {
       final List<VariantStyle<S>>? \$variants;
       final WidgetModifierConfig? \$modifier;
@@ -138,6 +142,10 @@ const _mixStub = '''
 
   abstract class Spec<T extends Spec<T>> {
     const Spec();
+  }
+
+  abstract interface class StylerFieldMetadata {
+    Set<String> get \$stylerFieldNames;
   }
 
   abstract class Style<S extends Spec<S>> extends Mix<StyleSpec<S>> {
@@ -552,11 +560,45 @@ void main() {
         {...mixAnnotationsSources, ..._mixSources, 'mix|lib/spike.dart': input},
         outputs: {
           'mix|lib/spike.g.dart': decodedMatches(
-            contains(
-              'class TrivialStyler extends MixStyler<TrivialStyler, TrivialSpec>',
+            allOf(
+              contains(
+                'class TrivialStyler extends '
+                'MixStyler<TrivialStyler, TrivialSpec>',
+              ),
+              contains('implements StylerFieldMetadata'),
             ),
           ),
         },
+      );
+    });
+
+    test('rejects a spec field reserved for styler metadata', () async {
+      const input = '''
+        library reserved_styler_metadata;
+        import 'package:mix_annotations/mix_annotations.dart';
+        part 'reserved_styler_metadata.g.dart';
+
+        @MixableSpec()
+        final class ReservedSpec {
+          final int? stylerFieldNames;
+          const ReservedSpec({this.stylerFieldNames});
+        }
+      ''';
+
+      final errors = await _expectSpecStylerValidationError({
+        ...mixAnnotationsSources,
+        ..._mixSources,
+        'mix|lib/reserved_styler_metadata.dart': input,
+      }, inputAsset: 'mix|lib/reserved_styler_metadata.dart');
+
+      expect(
+        errors,
+        allOf(
+          contains(
+            '`stylerFieldNames` is reserved for generated Styler metadata',
+          ),
+          contains('Rename the Spec field'),
+        ),
       );
     });
 


### PR DESCRIPTION
#### Related issue

Related to #1026.

### Description

Expose a generated, runtime-safe inventory of Styler source fields so protocol
adapters and tooling can validate complete field coverage without maintaining a
second handwritten field manifest.

The capability lives in `mix`, while source discovery remains in
`mix_generator`; consumers do not acquire a runtime dependency on the
generator.

### Changes

- Add the `StylerFieldMetadata` capability to `mix`.
- Emit const `$stylerFieldNames` metadata for generated Styler classes and
  legacy `@MixableStyler` mixins.
- Reserve metadata member names and report source-located generator errors for
  collisions.
- Keep handwritten `GridBoxStyler` aligned with the generated contract.
- Centralize the inherited `animation`, `modifier`, and `variants` field names
  across generated metadata, `props`, and legacy extraction.
- Derive the generated metadata getter from its reserved source name so both
  validation and emission share one spelling.
- Update generated Mix and Mix Chart output, package versions, changelogs, and
  conformance coverage.

**Review Checklist**

- [x] **Testing**: `melos run gen:build` and `melos run ci` pass.
- [x] **Breaking Changes**: No. The metadata interface is additive.
- [x] **Documentation Updates**: Public Dartdoc and package changelogs are updated.
- [x] **Website Updates**: Not required for generator/runtime metadata.

### Additional Information (optional)

`melos run analyze:dart` passes across all packages. The repository-wide DCM
stage continues to report the existing unrelated findings in untouched
`mix_annotations` (1) and `mix_generator` (12) files.
