### PR TITLE
ci: harden pull request label workflow

### DIFF
--- a/.github/workflows/add_label.yml
+++ b/.github/workflows/add_label.yml
@@ -16,20 +16,20 @@ jobs:
   apply-label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/github-script@v9
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-
-      - uses: actions/github-script@v7
-        env:
-          GH_TOKEN: ${{ secrets.ADD_LABEL_BOT_TOKEN }}
-        with:
+          retries: 3
           script: |
-            const { execSync } = require('child_process')
-            const { commits } = context.payload.pull_request
-            const rawFiles = execSync(`git diff --name-only origin/${{ github.base_ref }}`).toString()
-            const files = rawFiles.split('\n').filter(Boolean)
+            const changedFiles = await github.paginate(
+              github.rest.pulls.listFiles,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number,
+                per_page: 100,
+              },
+            )
+            const files = changedFiles.map(file => file.filename)
 
             console.log('##### Modified Files #####')
             console.log(files)
@@ -55,15 +55,12 @@ jobs:
             console.log(newLabels)
             console.log('##########################')
 
-            // Get existing labels
-            const existingLabels = await github.rest.issues.listLabelsOnIssue({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-            })
+            // The pull_request_target payload already contains the current
+            // labels, so avoid an unnecessary issue-label lookup.
+            const existingLabels = context.payload.pull_request.labels ?? []
 
-            const labelsToAdd = newLabels.filter(label => !existingLabels.data.some(existingLabel => existingLabel.name === label))
-            const labelsToRemove = existingLabels.data.filter(existingLabel => !newLabels.includes(existingLabel.name))
+            const labelsToAdd = newLabels.filter(label => !existingLabels.some(existingLabel => existingLabel.name === label))
+            const labelsToRemove = existingLabels.filter(existingLabel => !newLabels.includes(existingLabel.name))
 
             console.log('##### Labels to Add #####')
             console.log(labelsToAdd)


### PR DESCRIPTION
#### Related issue

Not tied to a product issue.

### Description

Make the pull-request label workflow independent of a local checkout and avoid
the issue-label lookup that failed with a transient stale-node HTTP 422 after
the repository move.

### Changes

- Read changed PR files through the paginated Pull Requests API.
- Reuse labels already present in the `pull_request_target` event payload.
- Remove the unnecessary checkout of the untrusted PR head and the unused bot
  token environment variable.
- Upgrade `actions/github-script` to the Node 24-based v9 release and retry
  transient API failures.

**Review Checklist**

- [x] **Testing**: YAML parsing, the changed-files REST request, and a fresh
  `pull_request_target` run on #1028 were verified.
- [x] **Breaking Changes**: No. Label selection and removal behavior is unchanged.
- [x] **Documentation Updates**: Not required for an internal workflow repair.
- [x] **Website Updates**: Not required.

### Additional Information (optional)

The failure occurred before label calculation completed because
`listLabelsOnIssue` returned HTTP 422 for PR #1027. The event payload already
contains the same label snapshot, so that request was redundant.

The workflow intentionally preserves its existing ownership of the complete PR
label set: labels not derived from changed package paths (or `repo`) are
removed.
