### PR TITLE
ci: remove redundant melos action dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,10 +54,11 @@ jobs:
         run: |
           dart pub global activate melos 6.3.3
           melos bootstrap
+      # DCM requires CI credentials; this job still runs all Dart analysis.
+      - name: Verify schema inventories
+        run: melos run schema:inventory
       - name: Analyze
-        run: |
-          melos run schema:inventory
-          melos run analyze:dart
+        run: melos run analyze:dart
       - name: Test
         run: melos run ci
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,17 +38,28 @@ jobs:
         run: melos run format:check
 
   test:
-    name: Test
-    uses: btwld/dart-actions/.github/workflows/ci.yml@9075ce1232ec77b8747953f2ff4a349190e5a805
-    secrets:
-      token: ${{ secrets.GITHUB_TOKEN }}
-    with:
-      flutter-version: 'stable'
-      # DCM requires CI credentials; the reusable workflow still runs Dart analysis.
-      run-dcm: false
-      melos-commands: |
-        melos run schema:inventory
-        melos run analyze:dart
+    name: Test / Run tests for all packages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: kuhnroyal/flutter-fvm-config-action@v2
+        id: fvm-config-action
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
+          channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+      - name: Setup Melos
+        run: |
+          dart pub global activate melos 6.3.3
+          melos bootstrap
+      - name: Analyze
+        run: |
+          melos run schema:inventory
+          melos run analyze:dart
+      - name: Test
+        run: melos run ci
 
   showcase-tool:
     name: Showcase Tool Tests


### PR DESCRIPTION
#### Related issue

Follow-up CI reliability fix discovered while validating #1027.

### Description

Remove the test job's dependency on `bluefireteam/melos-action`. GitHub failed
to download that action from codeload with HTTP 429/503 on three consecutive
attempts, so the required test check never reached checkout or project code.

### Changes

- Inline the small reusable test job using the same `.fvmrc`-driven Flutter
  setup already used by the format job.
- Install the repository's pinned Melos 6.3.3 release and bootstrap with shell
  commands instead of a third-party setup action.
- Preserve the required `Test / Run tests for all packages` check name and the
  existing inventory, Dart analysis, and full test commands.
- Remove the redundant analyzer action; `melos run analyze:dart` already checks
  every workspace package.

**Review Checklist**

- [x] **Testing**: YAML parsing and `git diff --check` pass. PR CI completed the
  schema inventories, Dart analysis, and full repository test suite through the
  new inline job.
- [x] **Breaking Changes**: No product or package behavior changes.
- [x] **Documentation Updates**: Not required for an internal workflow repair.
- [x] **Website Updates**: Not required.

### Additional Information (optional)

The previous reusable workflow also selected moving `stable`; the inline job
uses the repository's committed FVM version, matching the format job and local
development setup.
