### PR TITLE
chore(mix_generator): clear the DCM backlog in mix_generator and mix_annotations

### DIFF
--- a/packages/mix_annotations/lib/src/annotations.dart
+++ b/packages/mix_annotations/lib/src/annotations.dart
@@ -225,6 +225,9 @@ class MixWidget {
   /// Styler `call()` method. The constructor must expose a compatible named
   /// `style` parameter. `style` and `styleSpec` are supplied or omitted by the
   /// generator and never become wrapper fields.
+  // A constructor tear-off's signature differs per annotation, so no explicit
+  // function type fits; the generator narrows it via `toFunctionValue()`.
+  // ignore: prefer-explicit-function-type
   final Function? target;
 
   /// Selection of non-`key` styler `call()` value parameters exposed by the

--- a/packages/mix_generator/lib/src/core/builders/mix_widget_builder.dart
+++ b/packages/mix_generator/lib/src/core/builders/mix_widget_builder.dart
@@ -118,9 +118,12 @@ class MixWidgetBuilder {
         ? '${model.factoryReference}(${_factoryArgs()})'
         : model.factoryReference;
 
-    if (model.hasDirectTarget) {
-      _writeDirectTargetBuild(buffer, invocation);
+    // Bind the target type here so the emitter takes it non-null: interpolating
+    // a null reference would silently emit `null(...)` as the widget name.
+    if (model.targetTypeReference case final targetTypeReference?) {
+      _writeDirectTargetBuild(buffer, invocation, targetTypeReference);
       buffer.writeln('  }');
+
       return;
     }
 
@@ -140,12 +143,17 @@ class MixWidgetBuilder {
     buffer.writeln('  }');
   }
 
-  void _writeDirectTargetBuild(StringBuffer buffer, String styleInvocation) {
-    final constructorSuffix = model.targetConstructorName == null
+  void _writeDirectTargetBuild(
+    StringBuffer buffer,
+    String styleInvocation,
+    String targetTypeReference,
+  ) {
+    final constructorName = model.targetConstructorName;
+    final constructorSuffix = constructorName == null
         ? ''
-        : '.${model.targetConstructorName}';
+        : '.$constructorName';
     final target =
-        '${model.targetTypeReference}${model.typeParameterInvocation}'
+        '$targetTypeReference${model.typeParameterInvocation}'
         '$constructorSuffix';
     final args = [
       for (final p in model.callParams.where((p) => p.isPositional))

--- a/packages/mix_generator/lib/src/core/models/mix_widget_model.dart
+++ b/packages/mix_generator/lib/src/core/models/mix_widget_model.dart
@@ -156,6 +156,7 @@ class MixWidgetModel {
   /// all positional params first, then named params.
   List<WidgetCallParam> get allParams {
     final seen = <String>{};
+
     return [
       for (final parameter in [...factoryParams, ...callParams])
         if (seen.add(parameter.name)) parameter,
@@ -168,7 +169,4 @@ class MixWidgetModel {
 
   /// Type argument suffix for forwarding to the styler `call()` method.
   String get typeParameterInvocation => _typeParameterSuffix((p) => p.name);
-
-  /// Whether `build()` instantiates a plain target widget directly.
-  bool get hasDirectTarget => targetTypeReference != null;
 }

--- a/packages/mix_generator/lib/src/mix_widget_generator.dart
+++ b/packages/mix_generator/lib/src/mix_widget_generator.dart
@@ -375,6 +375,7 @@ class MixWidgetGenerator extends GeneratorForAnnotation<MixWidget> {
     }
 
     final constructorName = constructor.name;
+
     return _CallSource(
       call: constructor,
       baseExcluded: stylerBackedTargetParams,
@@ -406,6 +407,10 @@ class MixWidgetGenerator extends GeneratorForAnnotation<MixWidget> {
     if (writtenStylerName == null) return false;
     final spec = _findGeneratedStylerSpec(library, writtenStylerName);
     if (spec == null) return false;
+    // Both remaining checks match the spec by name, so an unnamed element can
+    // never be the recipe's spec.
+    final specName = spec.name;
+    if (specName == null) return false;
 
     // A target can itself refer to a same-build generated Styler, in which
     // case analyzer reports InvalidType until the shared part is written.
@@ -416,15 +421,16 @@ class MixWidgetGenerator extends GeneratorForAnnotation<MixWidget> {
       // Some build-test consumers re-export a lightweight Style stub from a
       // barrel rather than its canonical library. Preserve semantic matching
       // for that test shape without weakening non-Style targets.
-      return targetStyleType.getDisplayString() == 'Style<${spec.name}>';
+      return targetStyleType.getDisplayString() == 'Style<$specName>';
     }
     if (acceptedStyle.typeArguments.isEmpty) {
       return false;
     }
 
     final acceptedSpec = acceptedStyle.typeArguments.first;
+
     return acceptedSpec is InterfaceType &&
-        acceptedSpec.element.name == spec.name &&
+        acceptedSpec.element.name == specName &&
         acceptedSpec.element.library.uri == spec.library.uri;
   }
 
@@ -825,12 +831,12 @@ class MixWidgetGenerator extends GeneratorForAnnotation<MixWidget> {
     required _WidgetParameterSelection factoryParameters,
   }) {
     final selectedParameters = <FormalParameterElement>[];
-    final availableNames = {
-      for (final parameter in function.formalParameters)
-        if (parameter.name case final String name) name,
-    };
 
     if (!factoryParameters.includesAll) {
+      final availableNames = {
+        for (final parameter in function.formalParameters)
+          if (parameter.name case final String name) name,
+      };
       for (final name in factoryParameters.names) {
         if (!availableNames.contains(name)) {
           fail(
@@ -850,12 +856,15 @@ class MixWidgetGenerator extends GeneratorForAnnotation<MixWidget> {
           (name != null && factoryParameters.names.contains(name));
       if (!selected) {
         if (parameter.isRequired) {
+          // A wildcard parameter has no name to select, so report the
+          // analyzer's rendering rather than interpolating a null.
+          final label = name ?? parameter.displayName;
           fail(
             function,
             '$_annotationLabel factoryParameters must include required '
-            'factory parameter `$name`.',
+            'factory parameter `$label`.',
             todo:
-                'Add `$name` to `factoryParameters: .only({...})` or use '
+                'Add `$label` to `factoryParameters: .only({...})` or use '
                 '`factoryParameters: .all()`.',
           );
         }
@@ -1126,6 +1135,31 @@ class MixWidgetGenerator extends GeneratorForAnnotation<MixWidget> {
     return annotationType.name.lexeme;
   }
 
+  ConstructorElement? _targetConstructorFor(
+    Element anchor,
+    ConstantReader annotation,
+  ) {
+    final target = annotation.peek('target');
+    if (target == null || target.isNull) return null;
+
+    final constructor = target.objectValue.toFunctionValue();
+    if (constructor is! ConstructorElement) {
+      fail(
+        anchor,
+        '$_annotationLabel(target:) must be a constructor tear-off '
+        '(e.g., RemixButton.new).',
+      );
+    }
+    validateGenericTargetTearOff(
+      target: target,
+      constructor: constructor,
+      anchor: anchor,
+      annotationLabel: '@MixWidget(target:)',
+    );
+
+    return constructor;
+  }
+
   @override
   Future<String> generateForAnnotatedElement(
     Element element,
@@ -1166,31 +1200,6 @@ class MixWidgetGenerator extends GeneratorForAnnotation<MixWidget> {
     };
 
     return MixWidgetBuilder(model).build();
-  }
-
-  ConstructorElement? _targetConstructorFor(
-    Element anchor,
-    ConstantReader annotation,
-  ) {
-    final target = annotation.peek('target');
-    if (target == null || target.isNull) return null;
-
-    final constructor = target.objectValue.toFunctionValue();
-    if (constructor is! ConstructorElement) {
-      fail(
-        anchor,
-        '$_annotationLabel(target:) must be a constructor tear-off '
-        '(e.g., RemixButton.new).',
-      );
-    }
-    validateGenericTargetTearOff(
-      target: target,
-      constructor: constructor,
-      anchor: anchor,
-      annotationLabel: '@MixWidget(target:)',
-    );
-
-    return constructor;
   }
 }
 


### PR DESCRIPTION
## What

`melos run analyze` failed on `mix_generator` (10 issues) and `mix_annotations` (1). This clears both, so `melos run analyze` passes across the workspace for the first time.

Split out of #1031, which is unrelated grid work — these files aren't touched there.

## Why it accumulated

CI never runs DCM. `.github/workflows/test.yml` runs `format:check`, `schema:inventory`, `analyze:dart`, and `ci`, with a comment explaining the omission: *"DCM requires CI credentials."* So `melos run analyze:dcm` only ever runs on someone's laptop, and there are no git hooks in the repo. Worth a follow-up decision — see below.

For the record, the rest of the local-lint surface was already clean: `dart format --set-exit-if-changed` reports 0 changed files across all 11 packages plus `scripts`, and `dart fix --dry-run` reports "Nothing to fix!" in every package. This is DCM-only.

## Mechanical (via `dcm fix`)

Four `missing blank line before return`, one `member-ordering`.

## Judgement calls

**`MixWidgetBuilder` interpolated a nullable `targetTypeReference` into the generated widget name.** Guarded by `hasDirectTarget`, so it couldn't actually be null — but nothing made that checkable, and a null would have emitted `null(...)` as a widget name in generated code. Now bound at the call site with a pattern match and passed in non-null. `hasDirectTarget` had no consumers left afterward, so it's removed rather than left dead.

**`_targetStyleAcceptsRecipe` interpolated a nullable `spec.name`** into a type string it then compares against. Both remaining checks match the spec by name, so an unnamed element can never match — hoisted the name and returned `false` when absent.

**The "must include required factory parameter" diagnostic** interpolated a nullable parameter name, so a wildcard (`_`) parameter would have produced ``parameter `null` ``. Falls back to the analyzer's `displayName`.

**`MixWidget.target` keeps `Function?`.** A constructor tear-off's signature differs per annotation, so no explicit function type fits, and `Object?` would drop the callable signal. `MixableSpec.target` already carried this exact ignore; `MixWidget.target` had simply been missed. Added with the rationale.

**`_extractFactoryParams`** built `availableNames` unconditionally though it's only read in the `!includesAll` branch — moved inside it.

## Verification

- `melos run gen:build` regenerates **every package byte-for-byte identically** — no behavior change, which is the point that matters for a generator refactor
- `melos run analyze` — SUCCESS (dart + DCM + schema inventory), previously FAILED
- `melos run ci` — all green (mix 2892, mix_winds 532, mix_protocol 391, mix_generator 377, mix_chart 52, mix_lint 37, + examples)
- `melos run format:check` — clean

No CHANGELOG entries: generated output is unchanged, so nothing here is user-visible.

## Follow-up worth deciding

These will drift back. With DCM intentionally out of CI, the only enforcement point is local, and the repo has no git hooks at all — no husky, no lefthook, no `core.hooksPath`. Options are DCM CI credentials, or a pre-commit/pre-push hook running `melos run analyze:dcm`. Happy to wire up whichever you prefer.