### PR TITLE
ci: bound every workflow job with an explicit timeout

### DIFF
--- a/.github/workflows/add_label.yml
+++ b/.github/workflows/add_label.yml
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   apply-label:
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v9

--- a/.github/workflows/add_to_ai_initiatives_board.yml
+++ b/.github/workflows/add_to_ai_initiatives_board.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   add-to-project:
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
       - uses: actions/add-to-project@v1.0.2

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -22,6 +22,7 @@ on:
 
 jobs:
   version:
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,10 @@ jobs:
   format:
     name: Format Check
     runs-on: ubuntu-latest
+    # Observed ~1m30s. Every job here sets a bound because the GitHub default
+    # is 360 minutes, so a wedged step burns runner time for six hours and
+    # blocks the PR with a check that never resolves.
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: kuhnroyal/flutter-fvm-config-action@v2
@@ -42,6 +46,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    # Observed ~6m for the full workspace suite.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: kuhnroyal/flutter-fvm-config-action@v2
@@ -65,6 +71,7 @@ jobs:
   showcase-tool:
     name: Showcase Tool Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     defaults:
       run:
         working-directory: packages/mix_winds/tool/visual-comparison
@@ -78,6 +85,10 @@ jobs:
       - name: Install Node dependencies
         run: npm ci
       - name: Install Chromium
+        # This download wedged for 20+ minutes on PR #1032 while every other
+        # step passed. A step bound fails on the actual culprit instead of
+        # letting the job time out with the cause buried.
+        timeout-minutes: 10
         run: npx playwright install --with-deps chromium
       - name: Run showcase tool tests
         run: npm test

--- a/.github/workflows/title_validation.yml
+++ b/.github/workflows/title_validation.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   main:
+    timeout-minutes: 5
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/widgetbook.yml
+++ b/.github/workflows/widgetbook.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   disabled:
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
       - name: Notice


### PR DESCRIPTION
## Why

No job in any workflow set `timeout-minutes`, so every one inherited GitHub's **360-minute** default.

That bit us on #1032. The `Showcase Tool Tests` job wedged inside `npx playwright install --with-deps chromium` and sat in that single step for 20+ minutes while every other check passed. The PR was left with a check that would not have resolved for six hours, burning runner minutes the entire time, on a diff that touches only `mix_generator` and `mix_annotations` and has no path into that job.

## What

Each job now carries a bound sized from observed runtime plus headroom:

| Workflow | Job | Timeout | Observed |
|---|---|---|---|
| test.yml | `format` | 15m | ~1m30s |
| test.yml | `test` | 30m | ~6m |
| test.yml | `showcase-tool` | 20m | — |
| changelog.yml | `version` | 20m | — |
| widgetbook.yml | `disabled` | 10m | — |
| title_validation.yml | `main` | 5m | ~3s |
| add_label.yml | `apply-label` | 5m | ~7s |
| add_to_ai_initiatives_board.yml | `add-to-project` | 5m | — |

The Chromium install also gets its own **10-minute step bound**. A step-level timeout fails on the actual culprit instead of letting the job expire with the cause buried in a log; a Chromium download that takes more than 10 minutes is wedged by definition.

## Two things worth knowing

**`publish.yml` is deliberately untouched.** Its jobs call a reusable workflow via `uses:`, and `timeout-minutes` is not a valid key for that job shape — adding it is a workflow syntax error. Bounding those means changing `btwld/dart-actions`. I confirmed the file parses with no timeout on those jobs rather than leaving a broken key behind.

**There is no account- or org-level default timeout in GitHub Actions.** It's a [long-standing open request](https://github.com/orgs/community/discussions/14834). The only workaround people use is an org-level *variable* referenced from each job, which centralizes the number but still requires every job to opt in — so it doesn't prevent omission. Per-job `timeout-minutes` is the only thing that actually enforces a bound.

## Verification

Parsed every workflow and asserted that each runner job has a `timeout-minutes` and that no reusable-workflow job has one. All 15 jobs check out.

## Possible follow-up

Nothing stops a new workflow from landing without a bound. If you want that guaranteed, a small CI step that fails when any runner job lacks `timeout-minutes` would close it — happy to add it here or separately.