### PR TITLE
ci: stop apt from gating the showcase Chromium install

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,11 +84,29 @@ jobs:
           cache-dependency-path: packages/mix_winds/tool/visual-comparison/package-lock.json
       - name: Install Node dependencies
         run: npm ci
+      # Skips the download entirely on a hit. The browser only changes when the
+      # pinned Playwright version does, so the lockfile is the right key.
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: >-
+            playwright-${{ runner.os }}-${{
+              hashFiles('packages/mix_winds/tool/visual-comparison/package-lock.json')
+            }}
       - name: Install Chromium
-        # This download wedged for 20+ minutes on PR #1032 while every other
-        # step passed. A step bound fails on the actual culprit instead of
-        # letting the job time out with the cause buried.
+        # Deliberately no --with-deps. That flag shells out to apt-get, and the
+        # Azure Ubuntu mirror on GitHub's runners intermittently hangs there:
+        # it stalled this job for 21 minutes on PR #1032 and again to the
+        # 10-minute bound on PR #1031, while every other step passed. The
+        # ubuntu-24.04 image already ships Chromium's shared libraries, and
+        # Playwright is pinned well past 1.45, which is where 24.04 support
+        # landed. If a future image drops a library, this fails fast with a
+        # missing-library error naming it -- add just that package rather than
+        # putting all of apt back on the critical path.
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         timeout-minutes: 10
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install chromium
       - name: Run showcase tool tests
         run: npm test


### PR DESCRIPTION
## Root cause

`Showcase Tool Tests` has been intermittently hanging. The logs from PR #1031 pin it down precisely — it is not the browser download, it is `apt`.

`npx playwright install --with-deps chromium` shells out to `apt-get`, which then stops responding against the Azure Ubuntu mirror:

```
Installing dependencies...
Switching to root user to install dependencies...
Ign:2 http://azure.archive.ubuntu.com/ubuntu noble InRelease
Ign:3 http://azure.archive.ubuntu.com/ubuntu noble-updates InRelease
...
##[error]The action 'Install Chromium' has timed out after 10 minutes.
```

Nothing was logged for the 9.5 minutes between the last `InRelease` line and the timeout.

Evidence it is the mirror and not the diff or the download:

- It stalled **21 minutes** on #1032, then again to the 10-minute bound on #1031
- Every other step in the job passed both times
- The same job passed in **1m59s** and **2m13s** on other runs in the same hour
- Neither PR's diff touches anything this job reads

The step bound added in #1033 is doing its job here: it converted a six-hour hang into a labelled 10-minute failure that names the culprit. This PR removes the cause.

## Fix

**Drop `--with-deps`.** That flag exists to `apt-get install` Chromium's shared libraries. The `ubuntu-24.04` runner image already ships them, and Playwright is pinned to **1.57.0** here — well past **1.45**, where [Ubuntu 24.04 support landed](https://github.com/microsoft/playwright/issues/34342). This takes apt off the critical path entirely.

**Cache `~/.cache/ms-playwright`** keyed on the lockfile. The browser only changes when the pinned Playwright version does, so most runs skip the download entirely.

## Risk, and why it is the right trade

If a future runner image drops a library, Chromium fails to launch. That surfaces as a missing-library error **naming the library**, in seconds — and the fix is to `apt-get install` that one package, not to put all of apt back in front of every run. That is a strictly better failure mode than an unexplained hang. The reasoning is recorded in a comment on the step so it does not get "helpfully" reverted later.

Worth noting the job genuinely needs a browser: `test/visual-report.test.mjs` calls `chromium.launch()` to verify the generated report opens without console errors. So dropping the install altogether was not an option — only the apt half is unnecessary.

## Verification

Deliberately proven in CI rather than argued: this PR's first run has a **cache miss**, so it exercises the real `npx playwright install chromium` path without `--with-deps`. If the job goes green, the removal is confirmed on the actual runner image.