### PR TITLE
refactor(mix_winds): project layout insets from translated groups

### DIFF
--- a/packages/mix_winds/CHANGELOG.md
+++ b/packages/mix_winds/CHANGELOG.md
@@ -4,7 +4,12 @@
   read-only runtime layout inspection.
 - Match zero-viewport padding and border activation to Mix, and share responsive
   widths through nested Tw flex scopes so reserved and applied margins agree.
-- Derive layout inset merge order from the actual emitted style groups.
+- Derive layout inset merge order from the actual emitted style groups, and
+  project the plan's padding and border widths from those groups so the plan
+  cannot disagree with the rendered style.
+- Widget compilation keeps external margin out of box and flex Stylers; the
+  layout plan owns it, so semantic widgets no longer strip margin from every
+  resolved spec. Direct `TwParser` compilation still retains margin.
 - Preserve intrinsic measurement for text, headings, spans, and icons with static
   margins or padding, and for responsive margins when a viewport or enclosing
   Tw flex scope supplies the width.

--- a/packages/mix_winds/lib/src/translate/tw_translator.dart
+++ b/packages/mix_winds/lib/src/translate/tw_translator.dart
@@ -44,7 +44,11 @@ final class _FailedCandidate {
 final class _CandidateProgram {
   final List<_CompiledCandidate> candidates;
   final List<_FailedCandidate> failures;
-  final styleGroupPaths = <TwTarget, List<_VariantPath>>{};
+
+  /// Style groups produced by the last translation for each target, in the
+  /// Styler's merge order. The layout plan projects padding and border from
+  /// these so it can never disagree with the emitted style.
+  final styleGroups = <TwTarget, Map<_VariantPath, _GroupContext>>{};
   _CandidateProgram({
     required Iterable<_CompiledCandidate> candidates,
     required Iterable<_FailedCandidate> failures,
@@ -367,8 +371,7 @@ final class TwTranslator {
       if (_isLayoutOwnedCandidate(compiled, target)) continue;
       if (_reportBlockingRoute(token, route)) continue;
       if (_usesExternalMargins || target == .text) {
-        final unsupportedMargin = _reportExternalMarginVariant(candidate);
-        if (unsupportedMargin && target == .text) continue;
+        if (_reportExternalMarginVariant(candidate)) continue;
       }
       if (route.kind == .widgetLayer) {
         if (!_isSupportedWidgetLayerUtility(candidate.utility)) {
@@ -433,10 +436,7 @@ final class TwTranslator {
       }
     }
 
-    program.styleGroupPaths[target] = List.unmodifiable([
-      _VariantPath.base,
-      ...groups.keys.where((path) => path != .base),
-    ]);
+    program.styleGroups[target] = groups;
 
     return groups;
   }
@@ -1141,12 +1141,20 @@ final class TwTranslator {
     return target == .flexBox || (root != 'gap-x' && root != 'gap-y');
   }
 
+  /// Margin utilities the emitted Styler must not carry.
+  ///
+  /// Text Stylers never style margin. Widget compilation applies box and flex
+  /// margin outside the styled border box through the layout plan, so those
+  /// Stylers omit it as well. Direct `TwParser` compilation keeps margin
+  /// because Mix can apply it portably.
   bool _isLayoutOwnedCandidate(_CompiledCandidate compiled, TwTarget target) {
-    final inset = compiled.layoutInput?.inset;
+    // Only breakpoint-scoped positive margins reach the plan. Other margin
+    // variants fall through so the compiler can report them.
+    if (compiled.layoutInput?.inset?.kind != .margin) return false;
 
     return switch (target) {
-      .text => inset?.kind == .margin,
-      .box || .flexBox => false,
+      .text => true,
+      .box || .flexBox => _usesExternalMargins,
     };
   }
 
@@ -1819,26 +1827,17 @@ final class TwTranslator {
         : TwLayoutFlexItemDeclaration(selfAlignment: alignment);
   }
 
+  /// Widget-owned external margin. Padding and border widths are projected
+  /// from the translated style groups instead, see [_addStyleGroupInsets].
   TwLayoutInsetDeclaration? _layoutInset(TailwindUtility utility) {
     if (tailwindUtilityNegative(utility)) return null;
     final root = tailwindUtilityRoot(utility);
-    final spacingSides = _layoutSpacingSides(root);
-    if (spacingSides != null) {
-      final value = _spaceLengthForUtility(utility);
-      final kind = root.startsWith('m')
-          ? TwLayoutInsetKind.margin
-          : TwLayoutInsetKind.padding;
-      if (value == null || (kind == .margin && value < 0)) return null;
+    if (!root.startsWith('m')) return null;
+    final sides = _layoutSpacingSides(root);
+    final value = _spaceLengthForUtility(utility);
+    if (sides == null || value == null || value < 0) return null;
 
-      return TwLayoutInsetDeclaration(
-        kind: kind,
-        sides: spacingSides,
-        value: value,
-      );
-    }
-
-    // Border widths are collected per style group after base inheritance.
-    return null;
+    return TwLayoutInsetDeclaration(kind: .margin, sides: sides, value: value);
   }
 
   TwLayoutLogicalInsetDeclaration? _layoutLogicalMargin(
@@ -1875,88 +1874,92 @@ final class TwTranslator {
     _CandidateProgram program,
     TwTarget? target,
   ) {
-    // Icons have no variant style groups.
-    final paths = target == null
-        ? const [_VariantPath.base]
-        : program.styleGroupPaths[target]!;
-    final styleGroups = {
-      for (var index = 0; index < paths.length; index++) paths[index]: index,
-    };
     final builder = TwLayoutPlanBuilder();
     for (final compiled in program.candidates) {
       if (compiled.layoutInput case final input?) {
-        builder.add(
-          input,
-          styleGroupOrder: styleGroups[compiled.variantPath] ?? 0,
-        );
+        builder.add(input);
       }
     }
 
-    _addLayoutBorders(builder, program, styleGroups);
+    // Icons have no variant style groups.
+    if (target != null) {
+      _addStyleGroupInsets(builder, program.styleGroups[target]!);
+    }
 
     return builder.build();
   }
 
-  void _addLayoutBorders(
+  /// Projects padding and border widths from the translated style groups.
+  ///
+  /// Groups are visited in the Styler's merge order: base first, then variant
+  /// groups as they were introduced. Only breakpoint-scoped groups reach the
+  /// plan; the plan cannot evaluate interactive or contextual variants.
+  void _addStyleGroupInsets(
     TwLayoutPlanBuilder builder,
-    _CandidateProgram program,
-    Map<_VariantPath, int> styleGroups,
+    Map<_VariantPath, _GroupContext> groups,
   ) {
-    final borders = <_VariantPath, (BorderAccum, double)>{};
-    for (final compiled in program.candidates) {
-      final utility = compiled.candidate.utility;
-      final root = tailwindUtilityRoot(utility);
-      final path = compiled.variantPath;
-      if (compiled.route.kind != .style ||
-          path == null ||
-          !styleGroups.containsKey(path) ||
-          !root.startsWith('border')) {
-        continue;
-      }
-      final minWidth = _layoutBreakpointMinWidth(compiled.candidate.variants);
-      if (minWidth == null) continue;
-      final (border, _) = borders.putIfAbsent(
-        path,
-        () => (BorderAccum(), minWidth),
-      );
-      _applyBorder(
-        border,
-        utility.raw,
-        root,
-        tailwindUtilityValue(utility),
-        tailwindUtilityModifier(utility),
-      );
-    }
+    final paths = [
+      _VariantPath.base,
+      ...groups.keys.where((path) => path != .base),
+    ];
+    for (final (order, path) in paths.indexed) {
+      final group = groups[path];
+      final minWidth = _breakpointMinWidthOfPath(path);
+      if (group == null || minWidth == null) continue;
 
-    final base = borders[_VariantPath.base]?.$1;
-    for (final entry in borders.entries) {
-      final (border, minWidth) = entry.value;
-      if (!border.hasStructure) continue;
-      if (entry.key != .base && base != null) {
-        border.inheritUnsetFrom(base);
+      void addInset(
+        TwLayoutInsetKind kind,
+        TwLayoutInsetSides sides,
+        double value,
+      ) {
+        builder.add(
+          TwLayoutUtilityInput(
+            breakpointMinWidth: minWidth,
+            inset: TwLayoutInsetDeclaration(
+              kind: kind,
+              sides: sides,
+              value: value,
+            ),
+          ),
+          styleGroupOrder: order,
+        );
       }
-      // Mirror BorderAccum.toMix: a colored side without an explicit or
-      // inherited width has zero width. Unspecified sides remain absent.
-      for (final (side, width, color) in [
+
+      final padding = group.padding;
+      for (final (sides, value) in [
+        (TwLayoutInsetSides.left, padding.left),
+        (TwLayoutInsetSides.top, padding.top),
+        (TwLayoutInsetSides.right, padding.right),
+        (TwLayoutInsetSides.bottom, padding.bottom),
+      ]) {
+        if (value != null) addInset(.padding, sides, value);
+      }
+
+      // Match BorderAccum.toMix: a colored side without an explicit or
+      // inherited width renders at zero width; unspecified sides are absent.
+      final border = group.border;
+      if (!border.hasStructure) continue;
+      for (final (sides, width, color) in [
         (TwLayoutInsetSides.left, border.leftWidth, border.leftColor),
         (TwLayoutInsetSides.top, border.topWidth, border.topColor),
         (TwLayoutInsetSides.right, border.rightWidth, border.rightColor),
         (TwLayoutInsetSides.bottom, border.bottomWidth, border.bottomColor),
       ]) {
         if (width == null && color == null) continue;
-        builder.add(
-          TwLayoutUtilityInput(
-            breakpointMinWidth: minWidth,
-            inset: TwLayoutInsetDeclaration(
-              kind: .border,
-              sides: side,
-              value: width ?? 0,
-            ),
-          ),
-          styleGroupOrder: styleGroups[entry.key]!,
-        );
+        addInset(.border, sides, width ?? 0);
       }
     }
+  }
+
+  double? _breakpointMinWidthOfPath(_VariantPath path) {
+    var minWidth = 0.0;
+    for (final part in path.parts) {
+      final breakpoint = part.breakpoint;
+      if (part.kind != .breakpoint || breakpoint == null) return null;
+      if (breakpoint > minWidth) minWidth = breakpoint;
+    }
+
+    return minWidth;
   }
 
   TwCompiledLayoutPlan _boxLayoutPlan(TwCompiledLayoutPlan plan) => .new(

--- a/packages/mix_winds/lib/src/tw_widget.dart
+++ b/packages/mix_winds/lib/src/tw_widget.dart
@@ -9,48 +9,6 @@ import 'tw_layout_plan.dart';
 import 'tw_types.dart';
 
 // =============================================================================
-// CSS Semantic Margin Helpers
-// =============================================================================
-
-/// Creates a new [BoxSpec] with margin set to null.
-///
-/// Used to strip margin from a spec so it can be applied externally
-/// for CSS semantic hit-testing (margin outside interactive area).
-BoxSpec _boxSpecWithoutMargin(BoxSpec spec) {
-  return BoxSpec(
-    alignment: spec.alignment,
-    padding: spec.padding,
-    margin: null,
-    constraints: spec.constraints,
-    decoration: spec.decoration,
-    foregroundDecoration: spec.foregroundDecoration,
-    transform: spec.transform,
-    transformAlignment: spec.transformAlignment,
-    clipBehavior: spec.clipBehavior,
-  );
-}
-
-/// Creates a new [StyleSpec<BoxSpec>] with margin stripped from the inner spec.
-///
-/// Preserves animation and widgetModifiers from the original.
-StyleSpec<BoxSpec> _styleSpecWithoutMargin(StyleSpec<BoxSpec> styleSpec) {
-  return StyleSpec(
-    spec: _boxSpecWithoutMargin(styleSpec.spec),
-    animation: styleSpec.animation,
-    widgetModifiers: styleSpec.widgetModifiers,
-  );
-}
-
-/// Creates a new [FlexBoxSpec] with margin stripped from the box spec.
-///
-/// Preserves flex spec and other box properties.
-FlexBoxSpec _flexBoxSpecWithoutMargin(FlexBoxSpec spec) {
-  if (spec.box == null) return spec;
-
-  return FlexBoxSpec(box: _styleSpecWithoutMargin(spec.box!), flex: spec.flex);
-}
-
-// =============================================================================
 // Flex Scope (boundedness propagation)
 // =============================================================================
 
@@ -142,16 +100,13 @@ class _CssSemanticBox extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     // Build inner content with StyleBuilder (handles variants/animations).
-    // Margin is stripped because the semantic plan owns its outer placement.
+    // The compiler keeps margin out of widget Stylers; the plan owns it.
     Widget inner = StyleBuilder<BoxSpec>(
       style: style,
-      builder: (context, spec) {
-        // Use Box widget with margin stripped - margin is applied externally
-        return Box(
-          styleSpec: _styleSpecWithoutMargin(StyleSpec(spec: spec)),
-          child: child,
-        );
-      },
+      builder: (context, spec) => Box(
+        styleSpec: StyleSpec(spec: spec),
+        child: child,
+      ),
     );
 
     if (wrapBorderBox case final wrap?) {
@@ -196,24 +151,22 @@ class _CssSemanticFlexBox extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     // Build inner content with StyleBuilder (handles variants/animations).
-    // Margin is stripped because the semantic plan owns its outer placement.
+    // The compiler keeps margin out of widget Stylers; the plan owns it.
     Widget inner = StyleBuilder<FlexBoxSpec>(
       style: style,
       builder: (context, spec) {
-        // Use FlexBox widget with margin stripped - margin is applied externally
-        final stripped = _flexBoxSpecWithoutMargin(spec);
         final alignments = selfAlignments;
         final items = zeroBasisItems;
         if (alignments == null && items == null) {
           return FlexBox(
-            styleSpec: StyleSpec(spec: stripped),
+            styleSpec: StyleSpec(spec: spec),
             children: children,
           );
         }
 
         // FlexBox is a Box wrapping a Flex, so rebuild that composition when
         // Tailwind needs per-child alignment or content-box flex sizing.
-        final flexSpec = stripped.flex?.spec;
+        final flexSpec = spec.flex?.spec;
         final Widget flex = _TailwindFlex(
           direction: flexSpec?.direction ?? .horizontal,
           mainAxisAlignment: flexSpec?.mainAxisAlignment ?? .start,
@@ -229,7 +182,7 @@ class _CssSemanticFlexBox extends StatelessWidget {
           children: children,
         );
 
-        final box = stripped.box;
+        final box = spec.box;
 
         return box == null ? flex : Box(styleSpec: box, child: flex);
       },

--- a/packages/mix_winds/test/tw_compilation_test.dart
+++ b/packages/mix_winds/test/tw_compilation_test.dart
@@ -231,6 +231,45 @@ void main() {
       expect(compilation.requiresWidgetRuntime, isFalse);
     });
 
+    testWidgets('widget stylers leave margin to the layout plan', (
+      tester,
+    ) async {
+      final translator = TwTranslator(config: TwConfig.standard());
+      final box = translator.compileForWidget('m-4 md:m-8 p-2', .boxOrFlex);
+      final flex = translator.compileForWidget(
+        'flex m-4 md:m-8 p-2',
+        .boxOrFlex,
+      );
+      final portable = TwParser().compileBox('m-4 md:m-8 p-2');
+
+      expect(box.diagnostics, isEmpty);
+      expect(flex.diagnostics, isEmpty);
+      expect(box.layoutPlan.isEmpty, isFalse);
+      expect(flex.layoutPlan.isEmpty, isFalse);
+
+      await tester.pumpWidget(
+        MediaQuery(
+          data: const MediaQueryData(size: Size(1024, 768)),
+          child: Builder(
+            builder: (context) {
+              final boxSpec = box.boxStyler!.build(context).spec;
+              final flexSpec = flex.flexStyler!.build(context).spec;
+              final portableSpec = portable.styler.build(context).spec;
+
+              expect(boxSpec.margin, isNull);
+              expect(boxSpec.padding, const EdgeInsets.all(8));
+              expect(flexSpec.box?.spec.margin, isNull);
+              expect(flexSpec.box?.spec.padding, const EdgeInsets.all(8));
+              expect(portableSpec.margin, const EdgeInsets.all(32));
+
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+      expect(tester.takeException(), isNull);
+    });
+
     test('internal widget seam infers targets without exposing candidates', () {
       final translator = TwTranslator(config: TwConfig.standard());
       final element = translator.compileForWidget(

--- a/packages/mix_winds/test/tw_layout_plan_test.dart
+++ b/packages/mix_winds/test/tw_layout_plan_test.dart
@@ -172,6 +172,7 @@ void main() {
                   plan.padding.select(800)!.mainExtent(.horizontal),
                   padding.horizontal,
                 );
+
                 return const SizedBox();
               },
             ),
@@ -179,6 +180,73 @@ void main() {
         ),
       );
       expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('plan padding and border project the emitted box groups', (
+      tester,
+    ) async {
+      for (final classes in [
+        'p-4 px-2 md:p-8 lg:pl-1',
+        'border-blue-500 md:border-4 lg:border-l-2',
+        'border-2 md:border-x-4 md:border-red-500 lg:border-t-0',
+        'hover:p-6 md:p-3 dark:border-4 md:border-2',
+      ]) {
+        final compilation = TwTranslator(
+          config: TwConfig.standard(),
+        ).compileForWidget(classes, .boxOrFlex);
+        final plan = compilation.parentLayoutPlan;
+        for (final width in [600.0, 800.0, 1200.0]) {
+          await tester.pumpWidget(
+            MediaQuery(
+              data: MediaQueryData(size: Size(width, 600)),
+              child: Directionality(
+                textDirection: .ltr,
+                child: Builder(
+                  builder: (context) {
+                    final spec = compilation.boxStyler!.build(context).spec;
+                    final padding = spec.padding?.resolve(.ltr) ?? .zero;
+                    final border =
+                        (spec.decoration as BoxDecoration?)?.border as Border?;
+                    final planPadding =
+                        plan.padding.select(width) ?? const TwInsets();
+                    final planBorder =
+                        plan.border.select(width) ?? const TwInsets();
+                    final reason = '$classes at $width';
+
+                    expect(planPadding.left, padding.left, reason: reason);
+                    expect(planPadding.top, padding.top, reason: reason);
+                    expect(planPadding.right, padding.right, reason: reason);
+                    expect(planPadding.bottom, padding.bottom, reason: reason);
+                    expect(
+                      planBorder.left,
+                      border?.left.width ?? 0,
+                      reason: reason,
+                    );
+                    expect(
+                      planBorder.top,
+                      border?.top.width ?? 0,
+                      reason: reason,
+                    );
+                    expect(
+                      planBorder.right,
+                      border?.right.width ?? 0,
+                      reason: reason,
+                    );
+                    expect(
+                      planBorder.bottom,
+                      border?.bottom.width ?? 0,
+                      reason: reason,
+                    );
+
+                    return const SizedBox();
+                  },
+                ),
+              ),
+            ),
+          );
+          expect(tester.takeException(), isNull, reason: '$classes at $width');
+        }
+      }
     });
 
     testWidgets('dropped text margin cannot establish variant merge order', (
@@ -202,6 +270,7 @@ void main() {
                   compilation.textStyler!.build(context).spec,
                   withoutMargin.styler.build(context).spec,
                 );
+
                 return const SizedBox();
               },
             ),


### PR DESCRIPTION
Stacked on #1037. Merge that first; this PR only contains the one commit on top.

## Summary
- The layout plan's padding and border tables were derived a second time from candidates, re-running the border parser and base inheritance beside the translator with a separate inheritance condition. The translator now records each target's translated style groups on the candidate program, and the plan projects padding and border widths from those groups in merge order. The plan can only reflect what the Styler emits, and the "mirror BorderAccum" path is gone.
- Widget compilation keeps external margin out of box and flex Stylers, since the plan already owns it. The semantic box widgets no longer strip margin from every resolved spec, which removes three spec-copy helpers and one copy per build. Direct `TwParser` compilation still retains margin so portable Stylers are unchanged. Unsupported margin variants on widgets are still reported and now also omitted from the Styler instead of being stripped at render.

## Validation
- `melos run ci && melos run analyze` — passed (4,677 tests; schema inventories, Dart analysis, and DCM clean)
- `flutter test` in `packages/mix_winds` — 823 passed, including two new tests: plan padding and border equal the built spec's values across breakpoints for four class strings (color-only base border, side overrides, interactive and contextual variants), and widget Stylers resolve with no margin while the portable Styler keeps it. The margin test fails when the compiler rule is reverted.
- Archived before/after layout probes from the #1037 review — all pass with identical measurements.
