### PR TITLE
fix(mix_winds): require mix 2.2.0-beta.5

### DIFF
--- a/packages/mix_winds/CHANGELOG.md
+++ b/packages/mix_winds/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.1.0-alpha.0
 
+- Requires `mix` 2.2.0-beta.5 or later. The package uses focus-visible
+  variants, semantics roles, and gradient transforms that were added after
+  2.1.0, so the previous `^2.1.0` constraint could not resolve a working
+  build.
 - Export `TwCompilation` and `TwLayoutPlan` for typed compilation results and
   read-only runtime layout inspection.
 - Match zero-viewport padding and border activation to Mix, and share responsive

--- a/packages/mix_winds/pubspec.yaml
+++ b/packages/mix_winds/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  mix: ^2.1.0
+  mix: ^2.2.0-beta.5
 
 dev_dependencies:
   dart_code_metrics_presets: ^2.24.0

--- a/packages/mix_winds/test/publish_contract_test.dart
+++ b/packages/mix_winds/test/publish_contract_test.dart
@@ -12,9 +12,16 @@ void main() {
       reason: 'mix_winds is released by the repository publish workflow.',
     );
     expect(
-      RegExp(r'^  mix: \^2\.1\.0$', multiLine: true).hasMatch(pubspec),
+      RegExp(
+        r'^  mix: \^2\.\d+\.\d+(-[0-9A-Za-z.]+)?$',
+        multiLine: true,
+      ).hasMatch(pubspec),
       isTrue,
-      reason: 'Published packages must use the hosted Mix dependency.',
+      reason:
+          'Published packages must use a hosted caret Mix constraint. Keep '
+          'its minimum at the first Mix version that has every API this '
+          'library uses; verify by resolving lib/ against pub.dev without '
+          'pubspec_overrides.yaml.',
     );
   });
 }


### PR DESCRIPTION
## Summary
- `mix_winds` declared `mix: ^2.1.0` but uses `onFocusVisible`, `semanticsRole`, and gradient transforms that landed in the 2.2.0 betas. Resolving the library against hosted 2.1.0 fails with nine compile errors, so no consumer could have built against the published constraint. The monorepo never noticed because melos overrides `mix` with the path checkout at 2.2.0-beta.5.
- Bumps the constraint to `^2.2.0-beta.5`, which is published, and records the requirement in the 0.1.0-alpha.0 changelog entry.

## Validation
- Copied `lib/` and `pubspec.yaml` to a clean directory with no overrides and no dev dependencies, resolved `mix 2.2.0-beta.5` from pub.dev, and ran `flutter analyze` — no issues. The same procedure against 2.1.0 reports nine errors.
- `flutter pub publish --dry-run` — 0 warnings once committed; the two remaining hints are the expected monorepo `pubspec_overrides.yaml` notice.
