### PR TITLE
refactor(mix_winds): share one cumulative inset builder

### DIFF
--- a/packages/mix_winds/lib/src/tw_layout_plan.dart
+++ b/packages/mix_winds/lib/src/tw_layout_plan.dart
@@ -580,16 +580,15 @@ final class TwLayoutPlanBuilder {
       _ResponsiveDeclarationBuilder();
   final _ResponsiveDeclarationBuilder<TwFlexBehavior> _behavior =
       _ResponsiveDeclarationBuilder();
-  final _InsetsDeclarationBuilder _margin = _InsetsDeclarationBuilder();
+  final _margin = _insetsBuilder();
 
-  final _InsetsDeclarationBuilder _padding = _InsetsDeclarationBuilder(
-    mergeInStyleOrder: true,
+  final _padding = _insetsBuilder(mergeInStyleOrder: true);
+  final _border = _insetsBuilder(mergeInStyleOrder: true);
+  final _CumulativeInsetsBuilder<TwLogicalInsets, TwLayoutLogicalInsetSides>
+  _iconMargin = _CumulativeInsetsBuilder(
+    empty: const TwLogicalInsets(),
+    apply: _applyLogicalInsets,
   );
-  final _InsetsDeclarationBuilder _border = _InsetsDeclarationBuilder(
-    mergeInStyleOrder: true,
-  );
-  final _LogicalInsetsDeclarationBuilder _iconMargin =
-      _LogicalInsetsDeclarationBuilder();
   var _isFlexContainer = false;
 
   var _hasBaseFlex = false;
@@ -822,13 +821,13 @@ final class _ResponsiveDeclarationBuilder<T> {
   }
 }
 
-final class _InsetsDeclaration {
+final class _CumulativeInsetsDeclaration<S> {
   final double value;
-  final TwLayoutInsetSides sides;
+  final S sides;
   final double minWidth;
   final int order;
   final int styleGroupOrder;
-  const _InsetsDeclaration({
+  const _CumulativeInsetsDeclaration({
     required this.value,
     required this.sides,
     required this.minWidth,
@@ -837,22 +836,36 @@ final class _InsetsDeclaration {
   });
 }
 
-final class _InsetsDeclarationBuilder {
+/// Builds a responsive value whose breakpoints accumulate rather than replace.
+///
+/// Every declaration active at a breakpoint is re-applied from [empty] in merge
+/// order, because a newly active breakpoint may precede another already active
+/// Styler variant. [apply] writes one declaration's sides onto the value under
+/// construction, which is what makes the two side vocabularies share this
+/// algorithm.
+final class _CumulativeInsetsBuilder<V, S> {
+  final V empty;
+
+  final V Function(V current, double value, S sides) apply;
   final bool mergeInStyleOrder;
 
-  final _declarations = <_InsetsDeclaration>[];
+  final _declarations = <_CumulativeInsetsDeclaration<S>>[];
 
-  _InsetsDeclarationBuilder({this.mergeInStyleOrder = false});
+  _CumulativeInsetsBuilder({
+    required this.empty,
+    required this.apply,
+    this.mergeInStyleOrder = false,
+  });
 
   void add(
     double value, {
-    required TwLayoutInsetSides sides,
+    required S sides,
     required double minWidth,
     required int order,
-    required int styleGroupOrder,
+    int styleGroupOrder = 0,
   }) {
     _declarations.add(
-      _InsetsDeclaration(
+      _CumulativeInsetsDeclaration(
         value: value,
         sides: sides,
         minWidth: minWidth,
@@ -862,7 +875,7 @@ final class _InsetsDeclarationBuilder {
     );
   }
 
-  TwResponsiveValue<TwInsets> build() {
+  TwResponsiveValue<V> build() {
     if (_declarations.isEmpty) return const TwResponsiveValue.empty();
     final declarations = _declarations.toList()
       ..sort((left, right) {
@@ -874,14 +887,12 @@ final class _InsetsDeclarationBuilder {
       });
     final widths = _declarations.map((entry) => entry.minWidth).toSet().toList()
       ..sort();
-    final entries = <TwResponsiveEntry<TwInsets>>[];
+    final entries = <TwResponsiveEntry<V>>[];
     for (final width in widths) {
-      var current = const TwInsets();
-      // Re-evaluate active declarations in merge order: a newly active
-      // breakpoint may precede another active Styler variant.
+      var current = empty;
       for (final declaration in declarations) {
         if (declaration.minWidth > width) continue;
-        current = _applyInsets(current, declaration.value, declaration.sides);
+        current = apply(current, declaration.value, declaration.sides);
       }
       entries.add(TwResponsiveEntry(minWidth: width, value: current));
     }
@@ -907,65 +918,22 @@ TwInsets _applyInsets(
   );
 }
 
-final class _LogicalInsetsDeclaration {
-  final double value;
+TwLogicalInsets _applyLogicalInsets(
+  TwLogicalInsets current,
+  double value,
+  TwLayoutLogicalInsetSides sides,
+) => current.withSides(
+  value: value,
+  start: sides == .start,
+  end: sides == .end,
+  left: sides == .left,
+  right: sides == .right,
+);
 
-  final TwLayoutLogicalInsetSides sides;
-  final double minWidth;
-  final int order;
-  const _LogicalInsetsDeclaration({
-    required this.value,
-    required this.sides,
-    required this.minWidth,
-    required this.order,
-  });
-}
-
-final class _LogicalInsetsDeclarationBuilder {
-  final _declarations = <_LogicalInsetsDeclaration>[];
-
-  void add(
-    double value, {
-    required TwLayoutLogicalInsetSides sides,
-    required double minWidth,
-    required int order,
-  }) {
-    _declarations.add(
-      _LogicalInsetsDeclaration(
-        value: value,
-        sides: sides,
-        minWidth: minWidth,
-        order: order,
-      ),
-    );
-  }
-
-  TwResponsiveValue<TwLogicalInsets> build() {
-    if (_declarations.isEmpty) return const TwResponsiveValue.empty();
-    final byWidth = <double, List<_LogicalInsetsDeclaration>>{};
-    for (final declaration in _declarations) {
-      byWidth.putIfAbsent(declaration.minWidth, () => []).add(declaration);
-    }
-
-    var current = const TwLogicalInsets();
-    final entries = <TwResponsiveEntry<TwLogicalInsets>>[];
-    final widths = byWidth.keys.toList()..sort();
-    for (final width in widths) {
-      final declarations = byWidth[width]!
-        ..sort((left, right) => left.order.compareTo(right.order));
-      for (final declaration in declarations) {
-        final sides = declaration.sides;
-        current = current.withSides(
-          value: declaration.value,
-          start: sides == .start,
-          end: sides == .end,
-          left: sides == .left,
-          right: sides == .right,
-        );
-      }
-      entries.add(TwResponsiveEntry(minWidth: width, value: current));
-    }
-
-    return TwResponsiveValue(entries);
-  }
-}
+_CumulativeInsetsBuilder<TwInsets, TwLayoutInsetSides> _insetsBuilder({
+  bool mergeInStyleOrder = false,
+}) => .new(
+  empty: const TwInsets(),
+  apply: _applyInsets,
+  mergeInStyleOrder: mergeInStyleOrder,
+);


### PR DESCRIPTION
#### Related issue

None. This is consolidation item C4 from the follow-up list that #1037 / #1038 left open.

### Description

`tw_layout_plan.dart` had two builders producing a responsive inset value, and after #1038 they no longer even agreed on how:

- `_InsetsDeclarationBuilder` (margin, padding, border) sorted every declaration once, then rebuilt each breakpoint entry from an empty `TwInsets` by re-applying all declarations active at that width. #1038 needed that because a newly active breakpoint can precede an already active Styler variant in merge order.
- `_LogicalInsetsDeclarationBuilder` (icon logical margin) grouped declarations by width and carried one `TwLogicalInsets` forward across breakpoints.

Both side vocabularies overwrite named sides and nothing else, so applying every active declaration in `(minWidth, order)` order from empty produces exactly the entries the accumulating loop produced. The two forms were the same function written twice.

This collapses them into one `_CumulativeInsetsBuilder<V, S>` parameterised by the empty value and an `apply` callback. Net 32 lines removed from the file.

### Changes

- Replace `_InsetsDeclaration` / `_InsetsDeclarationBuilder` and `_LogicalInsetsDeclaration` / `_LogicalInsetsDeclarationBuilder` with `_CumulativeInsetsDeclaration<S>` and `_CumulativeInsetsBuilder<V, S>`.
- Add `_applyLogicalInsets` next to the existing `_applyInsets` so each side vocabulary contributes only its own write rule.
- Keep the style-group merge order for padding and border through a small `_insetsBuilder` factory; external margin and icon logical margin keep the mobile-first `minWidth` cascade.

**Review Checklist**

- [x] **Testing**: `mix_winds` 824 tests and the example's 33 pass; `flutter analyze` and `dcm analyze --fatal-style --fatal-warnings` clean on `mix_winds`. The behavior I changed for icon margins is the cross-breakpoint accumulation, and `tw_layout_plan_test.dart`'s `tracks icon logical and box physical margins independently` already pins it: `ms-2 me-1 ml-4 hover:me-8 md:mr-6` must still report `start: 8, end: 4, left: 16` alongside the new `right: 24` at 800.
- [x] **Breaking Changes**: No. Both builders are private to `tw_layout_plan.dart`; the public `TwLayoutPlan` view and every `TwResponsiveValue` it exposes are unchanged.
- [x] **Documentation Updates**: Not applicable, no public surface changed.
- [x] **Website Updates**: Not applicable.

### Additional Information (optional)

Stacked on #1042. GitHub will retarget this to `main` when that one merges and its branch is deleted; CI's test workflow only runs for PRs targeting `main` or `next`, so expect no test run here until then.

As with #1042 I ran the `mix_winds` package gate rather than the whole monorepo, for the same reasons: nothing outside the package depends on these internals, and the disk on this machine is nearly full. The schema fixture golden and `tool/gen_registry.dart --check` pass, so the checked-in artifacts are current.