### PR TITLE
fix(mix_winds): resolve release tests against hosted Mix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,12 +79,9 @@ jobs:
         working-directory: packages/mix_winds
     steps:
       - uses: actions/checkout@v4
-      - uses: kuhnroyal/flutter-fvm-config-action@v2
-        id: fvm-config-action
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
-          channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          channel: stable
       # Match release installation before Melos creates local overrides.
       - name: Resolve hosted release dependencies
         run: flutter pub get

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,12 +61,41 @@ jobs:
           dart pub global activate melos 6.3.3
           melos bootstrap
       # DCM requires CI credentials; this job still runs all Dart analysis.
+      - name: Generate code
+        run: melos run gen:build
       - name: Verify schema inventories
         run: melos run schema:inventory
       - name: Analyze
         run: melos run analyze:dart
       - name: Test
         run: melos run ci
+
+  winds-release:
+    name: Winds / Release dependency check
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: packages/mix_winds
+    steps:
+      - uses: actions/checkout@v4
+      - uses: kuhnroyal/flutter-fvm-config-action@v2
+        id: fvm-config-action
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
+          channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+      # Match release installation before Melos creates local overrides.
+      - name: Resolve hosted release dependencies
+        run: flutter pub get
+      - name: Analyze against published Mix
+        run: flutter analyze
+      - name: Test against published Mix
+        run: flutter test
+      - name: Restore files modified by Flutter tooling
+        run: git restore -- .
+      - name: Validate publish archive
+        run: dart pub publish --dry-run
 
   protocol-schema:
     name: Protocol Schema / Ajv check

--- a/packages/mix_chart_protocol/pubspec.yaml
+++ b/packages/mix_chart_protocol/pubspec.yaml
@@ -11,8 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  mix:
-    path: ../mix
+  mix: ^2.2.0-beta.5
   mix_chart:
     path: ../mix_chart
   mix_protocol:

--- a/packages/mix_protocol/pubspec.yaml
+++ b/packages/mix_protocol/pubspec.yaml
@@ -12,8 +12,7 @@ dependencies:
   ack: ^1.2.0
   flutter:
     sdk: flutter
-  mix:
-    path: ../mix
+  mix: ^2.2.0-beta.5
 
 dev_dependencies:
   analyzer: '>=9.0.0 <11.0.0'


### PR DESCRIPTION
#### Related issue

Failed alpha publication: https://github.com/conceptadev/mix/actions/runs/34414519049

### Description

The Winds release failed before tests because Winds required hosted Mix while its protocol test dependency required path-based Mix. Both protocol packages now use `mix: ^2.2.0-beta.5`, the latest published prerelease and the constraint already used by Winds and Chart. Melos continues to supply local overrides during repository development.

### Changes

- Align protocol Mix dependencies on the hosted release constraint.
- Add a clean-checkout Winds release check, without Melos overrides, using the publishing Flutter channel: dependency installation, analysis, tests, and publish dry run.
- Run code generation before the existing monorepo analysis and tests.

**Review Checklist**

- [x] **Testing**: All seven PR checks passed. CI completed monorepo generation, schema inventories, Dart analysis, and the full test suite. The separate release check passed hosted dependency installation, analysis, tests, and a publish dry run with 0 warnings. Local clean-snapshot dependency resolution also passed for Winds and chart protocol. Local full validation was limited by disk space; DCM reported missing presets in the local protocol configuration.
- [x] **Breaking Changes**: No public API changes or version bumps.
- [x] **Documentation Updates**: No consumer documentation changes required.
- [x] **Website Updates**: No website changes required.

### Additional Information (optional)

`mix_winds 0.1.0-alpha.0` has not been published. After merge, the release must use the corrected commit; rerunning the existing tag unchanged would reproduce the failure.
