### PR TITLE
fix(mix_chart): preserve axis label text properties

### DIFF
--- a/packages/mix_chart/lib/src/backend/fl_chart/fl_chart_helpers.dart
+++ b/packages/mix_chart/lib/src/backend/fl_chart/fl_chart_helpers.dart
@@ -217,10 +217,19 @@ fl.AxisTitles _resolveAxisTitles({
   final commonLabel = common?.label;
   final specificLabel = specific?.label;
   final specificText = specificLabel?.spec;
+  // Axes can arrive as raw StyleSpecs, so compose resolved values here.
+  // Preserve partial strut overrides using Mix's existing typography merge.
+  final commonStrut = commonLabel?.spec.strutStyle;
+  final specificStrut = specificText?.strutStyle;
+  final strut = commonStrut == null || specificStrut == null
+      ? (specificStrut ?? commonStrut)
+      : StrutStyleMix.value(
+          commonStrut,
+        ).merge(StrutStyleMix.value(specificStrut)).resolve(context);
   final labelSpec = StyleSpec(
     spec: (commonLabel?.spec ?? const TextSpec()).copyWith(
       overflow: specificText?.overflow,
-      strutStyle: specificText?.strutStyle,
+      strutStyle: strut,
       textAlign: specificText?.textAlign,
       textScaler: specificText?.textScaler,
       maxLines: specificText?.maxLines,

--- a/packages/mix_chart/lib/src/backend/fl_chart/fl_chart_helpers.dart
+++ b/packages/mix_chart/lib/src/backend/fl_chart/fl_chart_helpers.dart
@@ -218,14 +218,31 @@ fl.AxisTitles _resolveAxisTitles({
   final specificLabel = specific?.label;
   final specificText = specificLabel?.spec;
   // Axes can arrive as raw StyleSpecs, so compose resolved values here.
-  // Preserve partial strut overrides using Mix's existing typography merge.
+  // Rebuild raw struts without reapplying package prefixes to qualified fonts.
+  // StrutStyleMix does not retain leadingDistribution or debugLabel.
   final commonStrut = commonLabel?.spec.strutStyle;
   final specificStrut = specificText?.strutStyle;
-  final strut = commonStrut == null || specificStrut == null
-      ? (specificStrut ?? commonStrut)
-      : StrutStyleMix.value(
-          commonStrut,
-        ).merge(StrutStyleMix.value(specificStrut)).resolve(context);
+  final strut = commonStrut == null
+      ? specificStrut
+      : specificStrut == null
+      ? commonStrut
+      : StrutStyle(
+          fontFamily: specificStrut.fontFamily ?? commonStrut.fontFamily,
+          fontFamilyFallback:
+              specificStrut.fontFamilyFallback ??
+              commonStrut.fontFamilyFallback,
+          fontSize: specificStrut.fontSize ?? commonStrut.fontSize,
+          height: specificStrut.height ?? commonStrut.height,
+          leadingDistribution:
+              specificStrut.leadingDistribution ??
+              commonStrut.leadingDistribution,
+          leading: specificStrut.leading ?? commonStrut.leading,
+          fontWeight: specificStrut.fontWeight ?? commonStrut.fontWeight,
+          fontStyle: specificStrut.fontStyle ?? commonStrut.fontStyle,
+          forceStrutHeight:
+              specificStrut.forceStrutHeight ?? commonStrut.forceStrutHeight,
+          debugLabel: specificStrut.debugLabel ?? commonStrut.debugLabel,
+        );
   final labelSpec = StyleSpec(
     spec: (commonLabel?.spec ?? const TextSpec()).copyWith(
       overflow: specificText?.overflow,

--- a/packages/mix_chart/lib/src/backend/fl_chart/fl_chart_helpers.dart
+++ b/packages/mix_chart/lib/src/backend/fl_chart/fl_chart_helpers.dart
@@ -214,6 +214,30 @@ fl.AxisTitles _resolveAxisTitles({
     fontSize: 11,
     height: 1.2,
   ).merge(common?.label?.spec.style).merge(specific?.label?.spec.style);
+  final commonLabel = common?.label;
+  final specificLabel = specific?.label;
+  final specificText = specificLabel?.spec;
+  final labelSpec = StyleSpec(
+    spec: (commonLabel?.spec ?? const TextSpec()).copyWith(
+      overflow: specificText?.overflow,
+      strutStyle: specificText?.strutStyle,
+      textAlign: specificText?.textAlign,
+      textScaler: specificText?.textScaler,
+      maxLines: specificText?.maxLines,
+      style: textStyle,
+      textWidthBasis: specificText?.textWidthBasis,
+      textHeightBehavior: specificText?.textHeightBehavior,
+      textDirection: specificText?.textDirection,
+      softWrap: specificText?.softWrap,
+      textDirectives: specificText?.textDirectives,
+      selectionColor: specificText?.selectionColor,
+      semanticsLabel: specificText?.semanticsLabel,
+      locale: specificText?.locale,
+    ),
+    animation: specificLabel?.animation ?? commonLabel?.animation,
+    widgetModifiers:
+        specificLabel?.widgetModifiers ?? commonLabel?.widgetModifiers,
+  );
   final labelSpace = pick(common?.labelSpace, specific?.labelSpace) ?? 8;
   final labelAngle = pick(common?.labelAngle, specific?.labelAngle) ?? 0;
   final fitInside = pick(common?.fitInside, specific?.fitInside) ?? false;
@@ -237,7 +261,7 @@ fl.AxisTitles _resolveAxisTitles({
         );
         final child =
             axis?.labelBuilder?.call(context, label) ??
-            Text(formatted, style: textStyle);
+            StyledText(formatted, styleSpec: labelSpec);
 
         return fl.SideTitleWidget(
           meta: meta,

--- a/packages/mix_chart/test/axis_text_forwarding_test.dart
+++ b/packages/mix_chart/test/axis_text_forwarding_test.dart
@@ -4,6 +4,64 @@ import 'package:mix/mix.dart';
 import 'package:mix_chart/mix_chart.dart';
 
 void main() {
+  testWidgets('raw axis specs preserve common strut fields', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SizedBox(
+          width: 400,
+          height: 250,
+          child: LineChart(
+            series: [
+              LineSeries(
+                id: 's',
+                label: 'S',
+                points: [
+                  ChartPoint(id: 'a', x: 0, y: 0),
+                  ChartPoint(id: 'b', x: 1, y: 1),
+                ],
+              ),
+            ],
+            xAxis: ChartAxis.numeric(
+              min: 0,
+              max: 1,
+              interval: 1,
+              labelFormatter: (_) => 'Raw',
+            ),
+            styleSpec: const StyleSpec(
+              spec: LineChartSpec(
+                axis: StyleSpec(
+                  spec: ChartAxisSpec(
+                    label: StyleSpec(
+                      spec: TextSpec(
+                        strutStyle: StrutStyle(fontSize: 16, height: 1.3),
+                        textAlign: TextAlign.end,
+                      ),
+                    ),
+                  ),
+                ),
+                xAxis: StyleSpec(
+                  spec: ChartAxisSpec(
+                    label: StyleSpec(
+                      spec: TextSpec(strutStyle: StrutStyle(height: 1.6)),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    final labels = tester.widgetList<Text>(find.text('Raw')).toList();
+    expect(labels, isNotEmpty);
+    for (final label in labels) {
+      expect(label.strutStyle!.fontSize, 16);
+      expect(label.strutStyle!.height, 1.6);
+      expect(label.textAlign, TextAlign.end);
+    }
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('specific axis modifier replaces common modifier metadata', (
     tester,
   ) async {
@@ -104,7 +162,10 @@ void main() {
               .uppercase(),
         );
         final specific = ChartAxisStyler().label(
-          TextStyler().fontSize(19).textAlign(TextAlign.center),
+          TextStyler()
+              .fontSize(19)
+              .textAlign(TextAlign.center)
+              .strutStyle(StrutStyleMix(height: 1.6)),
         );
         final axis = ChartAxis.numeric(
           min: 0,
@@ -159,7 +220,7 @@ void main() {
           expect(label.style!.decorationStyle, TextDecorationStyle.dashed);
           expect(label.style!.decorationThickness, 2);
           expect(label.strutStyle!.fontSize, 16);
-          expect(label.strutStyle!.height, 1.3);
+          expect(label.strutStyle!.height, 1.6);
           expect(label.style!.fontSize, 19);
           expect(label.style!.color, Colors.purple);
           expect(label.textAlign, TextAlign.center);

--- a/packages/mix_chart/test/axis_text_forwarding_test.dart
+++ b/packages/mix_chart/test/axis_text_forwarding_test.dart
@@ -33,7 +33,15 @@ void main() {
                   spec: ChartAxisSpec(
                     label: StyleSpec(
                       spec: TextSpec(
-                        strutStyle: StrutStyle(fontSize: 16, height: 1.3),
+                        strutStyle: StrutStyle(
+                          fontSize: 16,
+                          height: 1.3,
+                          leadingDistribution: TextLeadingDistribution.even,
+                          debugLabel: 'Common strut',
+                          fontFamily: 'Primary',
+                          fontFamilyFallback: ['Fallback'],
+                          package: 'axis_fonts',
+                        ),
                         textAlign: TextAlign.end,
                       ),
                     ),
@@ -57,6 +65,15 @@ void main() {
     for (final label in labels) {
       expect(label.strutStyle!.fontSize, 16);
       expect(label.strutStyle!.height, 1.6);
+      expect(
+        label.strutStyle!.leadingDistribution,
+        TextLeadingDistribution.even,
+      );
+      expect(label.strutStyle!.debugLabel, 'Common strut');
+      expect(label.strutStyle!.fontFamily, 'packages/axis_fonts/Primary');
+      expect(label.strutStyle!.fontFamilyFallback, [
+        'packages/axis_fonts/Fallback',
+      ]);
       expect(label.textAlign, TextAlign.end);
     }
     expect(tester.takeException(), isNull);

--- a/packages/mix_chart/test/axis_text_forwarding_test.dart
+++ b/packages/mix_chart/test/axis_text_forwarding_test.dart
@@ -1,0 +1,277 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mix/mix.dart';
+import 'package:mix_chart/mix_chart.dart';
+
+void main() {
+  testWidgets('specific axis modifier replaces common modifier metadata', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SizedBox(
+          width: 400,
+          height: 250,
+          child: LineChart(
+            series: [
+              LineSeries(
+                id: 's',
+                label: 'S',
+                points: [
+                  ChartPoint(id: 'a', x: 0, y: 0),
+                  ChartPoint(id: 'b', x: 1, y: 1),
+                ],
+              ),
+            ],
+            xAxis: ChartAxis.numeric(
+              min: 0,
+              max: 1,
+              interval: 1,
+              labelFormatter: (_) => 'Modified',
+            ),
+            style: LineChartStyler()
+                .axis(
+                  ChartAxisStyler().label(
+                    TextStyler().wrap(
+                      WidgetModifierConfig.modifiers([
+                        OpacityModifierMix(opacity: 0.2),
+                      ]),
+                    ),
+                  ),
+                )
+                .xAxis(
+                  ChartAxisStyler().label(
+                    TextStyler().wrap(
+                      WidgetModifierConfig.modifiers([
+                        OpacityModifierMix(opacity: 0.7),
+                      ]),
+                    ),
+                  ),
+                ),
+          ),
+        ),
+      ),
+    );
+    final labels = find.text('Modified');
+    expect(labels, findsWidgets);
+    for (final element in labels.evaluate()) {
+      final modifiers = <Opacity>[];
+      element.visitAncestorElements((ancestor) {
+        if (ancestor.widget case final Opacity opacity) modifiers.add(opacity);
+        return true;
+      });
+      expect(modifiers.map((w) => w.opacity), [0.7]);
+    }
+  });
+
+  for (final bar in [false, true]) {
+    testWidgets(
+      '${bar ? 'bar' : 'line'} preserves common fields and specific overrides',
+      (tester) async {
+        final common = ChartAxisStyler().label(
+          TextStyler()
+              .style(
+                TextStyleMix(
+                  fontFamilyFallback: ['FallbackFont'],
+                  fontStyle: FontStyle.italic,
+                  fontWeight: FontWeight.w300,
+                  height: 1.4,
+                  letterSpacing: 0.8,
+                  wordSpacing: 1.5,
+                  decoration: TextDecoration.underline,
+                  decorationColor: Colors.green,
+                  decorationStyle: TextDecorationStyle.dashed,
+                  decorationThickness: 2,
+                ),
+              )
+              .strutStyle(StrutStyleMix(fontSize: 16, height: 1.3))
+              .fontFamily('CommonFont')
+              .fontSize(15)
+              .color(Colors.purple)
+              .textAlign(TextAlign.end)
+              .maxLines(2)
+              .softWrap(false)
+              .overflow(TextOverflow.fade)
+              .textDirection(TextDirection.rtl)
+              .textScaler(const TextScaler.linear(1.2))
+              .textWidthBasis(TextWidthBasis.longestLine)
+              .textHeightBehavior(
+                TextHeightBehaviorMix(applyHeightToFirstAscent: false),
+              )
+              .locale(const Locale('fr'))
+              .semanticsLabel('Accessible tick')
+              .selectionColor(Colors.orange)
+              .uppercase(),
+        );
+        final specific = ChartAxisStyler().label(
+          TextStyler().fontSize(19).textAlign(TextAlign.center),
+        );
+        final axis = ChartAxis.numeric(
+          min: 0,
+          max: 1,
+          interval: 1,
+          labelFormatter: (_) => 'audit',
+        );
+        final chart = bar
+            ? BarChart(
+                groups: [
+                  BarGroup(
+                    id: 'a',
+                    label: 'A',
+                    bars: [BarValue(id: 'v', label: 'V', toY: 1)],
+                  ),
+                ],
+                xAxis: axis,
+                style: BarChartStyler().axis(common).xAxis(specific),
+              )
+            : LineChart(
+                series: [
+                  LineSeries(
+                    id: 's',
+                    label: 'S',
+                    points: [
+                      ChartPoint(id: 'a', x: 0, y: 0),
+                      ChartPoint(id: 'b', x: 1, y: 1),
+                    ],
+                  ),
+                ],
+                xAxis: axis,
+                style: LineChartStyler().axis(common).xAxis(specific),
+              );
+        await tester.pumpWidget(
+          MaterialApp(home: SizedBox(width: 400, height: 250, child: chart)),
+        );
+        final labels = tester
+            .widgetList<Text>(find.byType(Text))
+            .where((w) => w.data == 'AUDIT')
+            .toList();
+        expect(labels, isNotEmpty);
+        for (final label in labels) {
+          expect(label.style!.fontFamily, 'CommonFont');
+          expect(label.style!.fontFamilyFallback, ['FallbackFont']);
+          expect(label.style!.fontStyle, FontStyle.italic);
+          expect(label.style!.fontWeight, FontWeight.w300);
+          expect(label.style!.height, 1.4);
+          expect(label.style!.letterSpacing, 0.8);
+          expect(label.style!.wordSpacing, 1.5);
+          expect(label.style!.decoration, TextDecoration.underline);
+          expect(label.style!.decorationColor, Colors.green);
+          expect(label.style!.decorationStyle, TextDecorationStyle.dashed);
+          expect(label.style!.decorationThickness, 2);
+          expect(label.strutStyle!.fontSize, 16);
+          expect(label.strutStyle!.height, 1.3);
+          expect(label.style!.fontSize, 19);
+          expect(label.style!.color, Colors.purple);
+          expect(label.textAlign, TextAlign.center);
+          expect(label.maxLines, 2);
+          expect(label.softWrap, false);
+          expect(label.overflow, TextOverflow.fade);
+          expect(label.textDirection, TextDirection.rtl);
+          expect(label.textScaler!.scale(10), 12);
+          expect(label.textWidthBasis, TextWidthBasis.longestLine);
+          expect(label.textHeightBehavior!.applyHeightToFirstAscent, false);
+          expect(label.locale, const Locale('fr'));
+          expect(label.semanticsLabel, 'Accessible tick');
+          expect(label.selectionColor, Colors.orange);
+        }
+        expect(tester.takeException(), isNull);
+      },
+    );
+  }
+
+  testWidgets('custom axis builder remains authoritative', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SizedBox(
+          width: 400,
+          height: 250,
+          child: LineChart(
+            series: [
+              LineSeries(
+                id: 's',
+                label: 'S',
+                points: [
+                  ChartPoint(id: 'a', x: 0, y: 0),
+                  ChartPoint(id: 'b', x: 1, y: 1),
+                ],
+              ),
+            ],
+            xAxis: ChartAxis.numeric(
+              min: 0,
+              max: 1,
+              interval: 1,
+              labelBuilder: (_, _) =>
+                  const Text('Custom', textAlign: TextAlign.left),
+            ),
+            style: LineChartStyler().axis(
+              ChartAxisStyler().label(
+                TextStyler().uppercase().textAlign(TextAlign.end),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    final labels = tester.widgetList<Text>(find.text('Custom')).toList();
+    expect(labels, isNotEmpty);
+    for (final label in labels) {
+      expect(label.textAlign, TextAlign.left);
+    }
+    expect(find.text('CUSTOM'), findsNothing);
+  });
+
+  testWidgets('axis labels retain text flow and typography', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SizedBox(
+          width: 400,
+          height: 250,
+          child: LineChart(
+            xAxis: ChartAxis.numeric(
+              min: 0,
+              max: 1,
+              interval: 1,
+              labelFormatter: (_) => 'Audit',
+            ),
+            series: [
+              LineSeries(
+                id: 's',
+                label: 'Series',
+                points: [
+                  ChartPoint(id: 'a', x: 0, y: 0),
+                  ChartPoint(id: 'b', x: 1, y: 1),
+                ],
+              ),
+            ],
+            style: LineChartStyler().axis(
+              ChartAxisStyler().label(
+                TextStyler()
+                    .fontFamily('AuditFont')
+                    .fontSize(17)
+                    .fontWeight(FontWeight.w300)
+                    .textAlign(TextAlign.end)
+                    .maxLines(2)
+                    .softWrap(false)
+                    .overflow(TextOverflow.fade),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    final labels = tester
+        .widgetList<RichText>(find.byType(RichText))
+        .where((w) => w.text.toPlainText() == 'Audit')
+        .toList();
+    expect(labels, isNotEmpty);
+    for (final label in labels) {
+      expect(label.text.style!.fontFamily, 'AuditFont');
+      expect(label.text.style!.fontSize, 17);
+      expect(label.text.style!.fontWeight, FontWeight.w300);
+      expect(label.textAlign, TextAlign.end);
+      expect(label.maxLines, 2);
+      expect(label.softWrap, false);
+      expect(label.overflow, TextOverflow.fade);
+    }
+  });
+}


### PR DESCRIPTION
#### Related issue

No linked issue; found during the property-forwarding audit.

### Description

Automatic line/bar axis labels now honor supported TextSpec properties instead of forwarding only TextStyle.

### Changes

- Render labels with StyledText; preserve default/common/specific precedence and custom label builders.
- Compose partial raw struts without losing leading distribution or diagnostic labels, or double-prefixing package fonts. Resolved modifier lists retain per-axis replacement semantics.
- Add six regression cases, including raw strut preservation, explicit overrides and custom builders.

**Review Checklist**

- [x] **Testing**: Six focused tests, full `dart run melos run gen:build`, `ci`, and `analyze`, plus formatting and `git diff --check` passed locally with Flutter 3.41.7. All five jobs in [GitHub CI](https://github.com/conceptadev/mix/actions/runs/34573498317) passed for `49b962b82ae6c65a7d1552494fe6274aeb434c75`.
- [ ] **Breaking Changes**: No API change. Previously ignored label settings now render and may require more reserved space.
- [x] **Documentation Updates**: Existing TextStyler contract restored; no new public API.
- [ ] **Website Updates**: Not required.

### Additional Information (optional)

Real Flutter captures, identical synthetic data and 800×480 viewport; requested end alignment, uppercase and 1.3× scaling:

![Before: label properties ignored](https://github.com/user-attachments/assets/4c92cb09-b7e0-4e60-a11d-d3b5368fd30b)
![After: label properties applied](https://github.com/user-attachments/assets/9b5d4451-658c-426d-b61e-3b4d2d916c0c)

The follow-up raw-strut capture is visually unchanged for the sampled fixture; regression assertions demonstrate property preservation. This is not a general chart-label fitting fix.
