### PR TITLE
fix(mix_chart): forward tooltip text presentation

### DIFF
--- a/packages/mix_chart/lib/src/backend/fl_chart/fl_bar_chart_adapter.dart
+++ b/packages/mix_chart/lib/src/backend/fl_chart/fl_bar_chart_adapter.dart
@@ -164,6 +164,8 @@ final class _FlBarChartAdapterState extends State<FlBarChartAdapter> {
           return fl.BarTooltipItem(
             '${group.label} · ${bar.label}\n${formatter(rod.toY)}',
             textStyle,
+            textAlign: tooltip?.text?.spec.textAlign ?? .center,
+            textDirection: tooltip?.text?.spec.textDirection ?? .ltr,
           );
         },
         getTooltipColor: (_) =>

--- a/packages/mix_chart/lib/src/backend/fl_chart/fl_line_chart_adapter.dart
+++ b/packages/mix_chart/lib/src/backend/fl_chart/fl_line_chart_adapter.dart
@@ -169,6 +169,8 @@ final class _FlLineChartAdapterState extends State<FlLineChartAdapter> {
               return fl.LineTooltipItem(
                 '${series.label}\n${formatter(spot.y)}',
                 textStyle,
+                textAlign: tooltip?.text?.spec.textAlign ?? .center,
+                textDirection: tooltip?.text?.spec.textDirection ?? .ltr,
               );
             })
             .toList(growable: false),

--- a/packages/mix_chart/lib/src/backend/fl_chart/fl_pie_chart_adapter.dart
+++ b/packages/mix_chart/lib/src/backend/fl_chart/fl_pie_chart_adapter.dart
@@ -1,5 +1,6 @@
 import 'package:fl_chart/fl_chart.dart' as fl;
 import 'package:flutter/material.dart';
+import 'package:mix/mix.dart';
 
 import '../../public/models/chart_config.dart';
 import '../../public/models/chart_hit.dart';
@@ -86,6 +87,7 @@ final class _FlPieChartAdapterState extends State<FlPieChartAdapter> {
     final slice = widget.slices[sliceIndex];
     final formatter = widget.valueFormatter ?? (double value) => '$value';
     final borderSide = tooltip?.border ?? .none;
+    final text = tooltip?.text ?? const StyleSpec(spec: TextSpec());
 
     return ConstrainedBox(
       constraints: BoxConstraints(maxWidth: tooltip?.maxWidth ?? 180),
@@ -98,13 +100,17 @@ final class _FlPieChartAdapterState extends State<FlPieChartAdapter> {
         child: Padding(
           padding:
               tooltip?.padding ?? const .symmetric(vertical: 9, horizontal: 12),
-          child: Text(
+          child: StyledText(
             '${slice.label}\n${formatter(slice.value)}',
-            style: const TextStyle(
-              color: Colors.white,
-              fontSize: 12,
-              fontWeight: .w600,
-            ).merge(tooltip?.text?.spec.style),
+            styleSpec: text.copyWith(
+              spec: text.spec.copyWith(
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 12,
+                  fontWeight: .w600,
+                ).merge(text.spec.style),
+              ),
+            ),
           ),
         ),
       ),

--- a/packages/mix_chart/test/cartesian_tooltip_text_test.dart
+++ b/packages/mix_chart/test/cartesian_tooltip_text_test.dart
@@ -1,0 +1,81 @@
+import 'package:fl_chart/fl_chart.dart' as fl;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mix/mix.dart';
+import 'package:mix_chart/mix_chart.dart';
+
+void main() {
+  for (final isBar in [false, true]) {
+    for (final styled in [false, true]) {
+      testWidgets('tooltip alignment/direction on bar=$isBar styled=$styled', (
+        tester,
+      ) async {
+        final tooltip = styled
+            ? ChartTooltipStyler().text(
+                TextStyler()
+                    .fontSize(19)
+                    .textAlign(TextAlign.end)
+                    .textDirection(TextDirection.rtl),
+              )
+            : const ChartTooltipStyler.create();
+        await tester.pumpWidget(
+          MaterialApp(
+            home: SizedBox(
+              width: 320,
+              height: 200,
+              child: isBar
+                  ? BarChart(
+                      groups: [
+                        BarGroup(
+                          id: 'g',
+                          label: 'Group',
+                          bars: [BarValue(id: 'b', label: 'Bar', toY: 12)],
+                        ),
+                      ],
+                      style: BarChartStyler().tooltip(tooltip),
+                    )
+                  : LineChart(
+                      series: [
+                        LineSeries(
+                          id: 's',
+                          label: 'Series',
+                          points: [ChartPoint(id: 'p', x: 0, y: 12)],
+                        ),
+                      ],
+                      style: LineChartStyler().tooltip(tooltip),
+                    ),
+            ),
+          ),
+        );
+        if (isBar) {
+          final chart = tester.widget<fl.BarChart>(find.byType(fl.BarChart));
+          final group = chart.data.barGroups.single;
+          final item = chart.data.barTouchData.touchTooltipData.getTooltipItem(
+            group,
+            0,
+            group.barRods.single,
+            0,
+          )!;
+          expect(item.textStyle.fontSize, styled ? 19 : 12);
+          expect(item.textAlign, styled ? TextAlign.end : TextAlign.center);
+          expect(
+            item.textDirection,
+            styled ? TextDirection.rtl : TextDirection.ltr,
+          );
+        } else {
+          final chart = tester.widget<fl.LineChart>(find.byType(fl.LineChart));
+          final series = chart.data.lineBarsData.single;
+          final item = chart.data.lineTouchData.touchTooltipData
+              .getTooltipItems([fl.LineBarSpot(series, 0, series.spots.single)])
+              .single!;
+          expect(item.textStyle.fontSize, styled ? 19 : 12);
+          expect(item.textAlign, styled ? TextAlign.end : TextAlign.center);
+          expect(
+            item.textDirection,
+            styled ? TextDirection.rtl : TextDirection.ltr,
+          );
+        }
+      });
+    }
+  }
+}

--- a/packages/mix_chart/test/pie_tooltip_text_test.dart
+++ b/packages/mix_chart/test/pie_tooltip_text_test.dart
@@ -1,0 +1,84 @@
+import 'package:fl_chart/fl_chart.dart' as fl;
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mix/mix.dart';
+import 'package:mix_chart/mix_chart.dart';
+
+void main() {
+  for (final mode in ['defaults', 'styled', 'custom']) {
+    testWidgets('pie tooltip text: $mode', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SizedBox(
+            width: 240,
+            height: 240,
+            child: PieChart(
+              slices: [PieSlice(id: 'mobile', label: 'Mobile', value: 64)],
+              tooltipBuilder: mode == 'custom'
+                  ? (_, _) => const Text(
+                      'Custom',
+                      style: TextStyle(fontSize: 9),
+                      maxLines: 2,
+                    )
+                  : null,
+              style: mode == 'defaults'
+                  ? const PieChartStyler.create()
+                  : PieChartStyler().tooltip(
+                      ChartTooltipStyler().text(
+                        TextStyler()
+                            .fontSize(17)
+                            .textAlign(TextAlign.end)
+                            .maxLines(1)
+                            .overflow(TextOverflow.ellipsis),
+                      ),
+                    ),
+            ),
+          ),
+        ),
+      );
+      final backend = tester.widget<fl.PieChart>(find.byType(fl.PieChart));
+      backend.data.pieTouchData.touchCallback!(
+        fl.FlPointerHoverEvent(
+          const PointerHoverEvent(position: Offset(120, 60)),
+        ),
+        fl.PieTouchResponse(
+          touchLocation: const Offset(120, 60),
+          touchedSection: fl.PieTouchedSection(
+            backend.data.sections.single,
+            0,
+            45,
+            60,
+          ),
+        ),
+      );
+      await tester.pump();
+      final rich = tester.widget<RichText>(
+        find.descendant(
+          of: find.text(mode == 'custom' ? 'Custom' : 'Mobile\n64.0'),
+          matching: find.byType(RichText),
+        ),
+      );
+      expect(
+        rich.text.style?.fontSize,
+        mode == 'custom'
+            ? 9
+            : mode == 'defaults'
+            ? 12
+            : 17,
+      );
+      if (mode == 'styled') {
+        expect(rich.textAlign, TextAlign.end);
+        expect(rich.maxLines, 1);
+        expect(rich.overflow, TextOverflow.ellipsis);
+      } else if (mode == 'defaults') {
+        expect(rich.text.style?.color, Colors.white);
+        expect(rich.text.style?.fontWeight, FontWeight.w600);
+        expect(rich.maxLines, isNull);
+      } else {
+        expect(rich.maxLines, 2);
+        expect(find.text('Mobile\n64.0'), findsNothing);
+      }
+    });
+  }
+}


### PR DESCRIPTION
#### Related issue

No linked issue; found during the component property-forwarding audit.

### Description

Built-in chart tooltips discarded supported text presentation. Pie tooltips now use the existing StyledText renderer; line/bar tooltip items receive text alignment and direction.

### Changes

- Preserve pie tooltip text layout, directives and StyleSpec metadata while retaining the existing fallback font.
- Forward line/bar alignment and direction with unchanged center/LTR defaults.
- Protect omitted settings, explicit overrides and custom pie tooltip precedence with seven regression cases.
- No new public API or renderer. Cartesian painter tooltips still do not support every widget-only TextSpec property.

**Review Checklist**

- [x] **Testing**: Seven new regression cases and six existing interaction cases passed.
- [ ] **Breaking Changes**: No intentional API break; previously ignored explicit settings now apply.
- [x] **Documentation Updates**: Existing text-presentation contract is unchanged; backend scope is stated here.
- [ ] **Website Updates**: No website change needed.

### Additional Information (optional)

Validation:
- Generation passed without generated-file changes.
- Full Flutter package suite passed.
- All Dart suites passed sequentially after an initial disk-space failure.
- Schema inventory, Dart analysis and DCM analysis passed.
- Final focused tooltip and interaction run: 13 tests passed.
- Original regression cases failed before the fix.

Exact-head GitHub CI passed at `72f6ecf87a2b517caaa13f70536b79e06d6956d4`.

### Visual evidence

Identical 800×480 synthetic Flutter fixture requesting uppercase text and a single line with ellipsis. This deliberately tests caller settings, not recommended tooltip content design.

Before:
![Pie tooltip ignores text layout](https://github.com/user-attachments/assets/b77c0d68-2e57-4c00-9ecb-fdc62a486728)

After:
![Pie tooltip honors text layout](https://github.com/user-attachments/assets/6b2c6e8f-ab88-45fd-9bf7-0cb8ff705928)
