### PR TITLE
fix(mix_chart): honor pie tooltip fitting flags

### DIFF
--- a/packages/mix_chart/lib/src/backend/fl_chart/fl_chart_tooltip_overlay.dart
+++ b/packages/mix_chart/lib/src/backend/fl_chart/fl_chart_tooltip_overlay.dart
@@ -2,19 +2,21 @@ import 'package:flutter/widgets.dart';
 
 import '../../public/models/chart_hit.dart';
 
-/// Places a custom widget tooltip above a chart hit and keeps it in bounds.
+/// Places a widget tooltip above a chart hit, fitting each axis by default.
 Widget flWrapTooltipOverlay({
   required Widget child,
   required ChartHit? hit,
   required ChartTooltipBuilder? builder,
   double margin = 12,
+  bool fitHorizontally = true,
+  bool fitVertically = true,
 }) {
   if (hit == null || builder == null) return child;
 
   return Builder(
     builder: (context) => Stack(
       fit: .expand,
-      clipBehavior: .hardEdge,
+      clipBehavior: fitHorizontally && fitVertically ? .hardEdge : .none,
       children: [
         child,
         Positioned.fill(
@@ -22,6 +24,8 @@ Widget flWrapTooltipOverlay({
             delegate: _ChartTooltipLayoutDelegate(
               target: hit.localPosition,
               margin: margin,
+              fitHorizontally: fitHorizontally,
+              fitVertically: fitVertically,
             ),
             child: IgnorePointer(child: builder(context, hit)),
           ),
@@ -34,10 +38,14 @@ Widget flWrapTooltipOverlay({
 final class _ChartTooltipLayoutDelegate extends SingleChildLayoutDelegate {
   final Offset target;
   final double margin;
+  final bool fitHorizontally;
+  final bool fitVertically;
 
   const _ChartTooltipLayoutDelegate({
     required this.target,
     required this.margin,
+    required this.fitHorizontally,
+    required this.fitVertically,
   });
 
   @override
@@ -52,12 +60,15 @@ final class _ChartTooltipLayoutDelegate extends SingleChildLayoutDelegate {
     final maxTop = (size.height - childSize.height).clamp(0.0, double.infinity);
 
     return Offset(
-      preferredLeft.clamp(0.0, maxLeft),
-      preferredTop.clamp(0.0, maxTop),
+      fitHorizontally ? preferredLeft.clamp(0.0, maxLeft) : preferredLeft,
+      fitVertically ? preferredTop.clamp(0.0, maxTop) : preferredTop,
     );
   }
 
   @override
   bool shouldRelayout(_ChartTooltipLayoutDelegate oldDelegate) =>
-      target != oldDelegate.target || margin != oldDelegate.margin;
+      target != oldDelegate.target ||
+      margin != oldDelegate.margin ||
+      fitHorizontally != oldDelegate.fitHorizontally ||
+      fitVertically != oldDelegate.fitVertically;
 }

--- a/packages/mix_chart/lib/src/backend/fl_chart/fl_pie_chart_adapter.dart
+++ b/packages/mix_chart/lib/src/backend/fl_chart/fl_pie_chart_adapter.dart
@@ -241,6 +241,12 @@ final class _FlPieChartAdapterState extends State<FlPieChartAdapter> {
       hit: _tooltipHit,
       builder: widget.tooltipBuilder ?? _buildDefaultTooltip,
       margin: widget.spec.tooltip?.spec.margin ?? 12,
+      fitHorizontally:
+          widget.tooltipBuilder != null ||
+          (widget.spec.tooltip?.spec.fitHorizontally ?? true),
+      fitVertically:
+          widget.tooltipBuilder != null ||
+          (widget.spec.tooltip?.spec.fitVertically ?? true),
       child: chart,
     );
   }

--- a/packages/mix_chart/test/pie_tooltip_fit_test.dart
+++ b/packages/mix_chart/test/pie_tooltip_fit_test.dart
@@ -1,0 +1,145 @@
+import 'package:fl_chart/fl_chart.dart' as fl;
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mix_chart/mix_chart.dart';
+
+void main() {
+  for (final custom in [false, true]) {
+    testWidgets('pie default fitting and live updates custom=$custom', (
+      tester,
+    ) async {
+      final fitting = ValueNotifier<bool?>(null);
+      addTearDown(fitting.dispose);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Center(
+            child: SizedBox(
+              width: 240,
+              height: 240,
+              child: ValueListenableBuilder<bool?>(
+                valueListenable: fitting,
+                builder: (_, value, _) => PieChart(
+                  slices: [PieSlice(id: 'm', label: 'Mobile', value: 64)],
+                  tooltipBuilder: custom
+                      ? (_, _) => const SizedBox(
+                          key: ValueKey('custom-tooltip'),
+                          width: 80,
+                          height: 40,
+                        )
+                      : null,
+                  style: PieChartStyler().tooltip(
+                    value == null
+                        ? const ChartTooltipStyler.create()
+                        : ChartTooltipStyler()
+                              .fitHorizontally(value)
+                              .fitVertically(value),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      final backend = tester.widget<fl.PieChart>(find.byType(fl.PieChart));
+      final chart = tester.getRect(find.byType(fl.PieChart));
+      backend.data.pieTouchData.touchCallback!(
+        fl.FlPointerHoverEvent(const PointerHoverEvent(position: Offset(2, 2))),
+        fl.PieTouchResponse(
+          touchLocation: const Offset(2, 2),
+          touchedSection: fl.PieTouchedSection(
+            backend.data.sections.single,
+            0,
+            45,
+            60,
+          ),
+        ),
+      );
+      await tester.pump();
+      final tooltipFinder = custom
+          ? find.byKey(const ValueKey('custom-tooltip'))
+          : find.byWidgetPredicate(
+              (widget) =>
+                  widget is DecoratedBox &&
+                  widget.decoration is BoxDecoration &&
+                  (widget.decoration as BoxDecoration).color ==
+                      const Color(0xFF0F172A),
+            );
+      for (final value in [null, false, true]) {
+        fitting.value = value;
+        await tester.pump();
+        final tooltip = tester.getRect(tooltipFinder);
+        final fits = custom || value != false;
+        expect(
+          tooltip.left,
+          fits ? greaterThanOrEqualTo(chart.left) : lessThan(chart.left),
+        );
+        expect(
+          tooltip.top,
+          fits ? greaterThanOrEqualTo(chart.top) : lessThan(chart.top),
+        );
+      }
+    });
+  }
+
+  for (final horizontal in [true, false]) {
+    for (final vertical in [true, false]) {
+      testWidgets('pie fitting horizontal=$horizontal vertical=$vertical', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Center(
+              child: SizedBox(
+                width: 240,
+                height: 240,
+                child: PieChart(
+                  slices: [PieSlice(id: 'm', label: 'Mobile', value: 64)],
+                  style: PieChartStyler().tooltip(
+                    ChartTooltipStyler()
+                        .fitHorizontally(horizontal)
+                        .fitVertically(vertical),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+        final backend = tester.widget<fl.PieChart>(find.byType(fl.PieChart));
+        final chart = tester.getRect(find.byType(fl.PieChart));
+        backend.data.pieTouchData.touchCallback!(
+          fl.FlPointerHoverEvent(
+            const PointerHoverEvent(position: Offset(2, 2)),
+          ),
+          fl.PieTouchResponse(
+            touchLocation: const Offset(2, 2),
+            touchedSection: fl.PieTouchedSection(
+              backend.data.sections.single,
+              0,
+              45,
+              60,
+            ),
+          ),
+        );
+        await tester.pump();
+        final tooltip = tester.getRect(
+          find.byWidgetPredicate(
+            (widget) =>
+                widget is DecoratedBox &&
+                widget.decoration is BoxDecoration &&
+                (widget.decoration as BoxDecoration).color ==
+                    const Color(0xFF0F172A),
+          ),
+        );
+        expect(
+          tooltip.left,
+          horizontal ? greaterThanOrEqualTo(chart.left) : lessThan(chart.left),
+        );
+        expect(
+          tooltip.top,
+          vertical ? greaterThanOrEqualTo(chart.top) : lessThan(chart.top),
+        );
+      });
+    }
+  }
+}


### PR DESCRIPTION
#### Related issue

No linked issue.

### Description

Built-in pie tooltips ignored `fitHorizontally` and `fitVertically`, always clamping to the chart. Honor each existing flag independently, including changes while a tooltip is visible.

### Changes

- Forward built-in pie fitting flags to the existing overlay layout.
- Allow overflow painting when fitting is explicitly disabled; default fitting and custom-builder behavior remain unchanged.
- Add six regression cases for all flag combinations, omitted defaults, live updates and custom-builder containment.

**Review Checklist**

- [x] **Testing**: Chart-package tests and exact-head repository CI passed.
- [ ] **Breaking Changes**: No public API change. Explicit opt-outs now permit overlap with adjacent content.
- [x] **Documentation Updates**: Internal helper documentation updated; existing public flag descriptions already specify overflow correction.
- [ ] **Website Updates**: No website changes required.

### Additional Information (optional)

Validation:
- `fvm flutter test` in `packages/mix_chart` — 58 passed.
- `dcm analyze . --fatal-style --fatal-warnings` in that package — no issues; one no-rules context skipped.
- Targeted Dart analysis and `git diff --check` passed.
- Baseline flag matrix: three failures, one pass; corrected matrix passes.
- Local adversarial review supports keeping the correction.
- Exact-head CI run 34565143576 passed generation, schema inventories, Dart analysis, full tests, formatting, showcase-tool tests and release-dependency checks. Local full-generation success is not claimed; that local run was deferred for disk space.

Visual evidence: identical before/after Flutter render-boundary captures passed and were inspected. The opt-out capture intentionally demonstrates overlap, not a recommended default layout.

Before:
![Tooltip ignores disabled fitting flags](https://github.com/user-attachments/assets/2ded0d74-49d4-4741-9358-f83090dd5942)

After:
![Tooltip honors disabled fitting flags](https://github.com/user-attachments/assets/e018326f-12e1-4ace-8d77-0beb7e9eef6a)
