### PR TITLE
fix(mix_chart): preserve common item label typography

### DIFF
--- a/packages/mix_chart/lib/src/backend/fl_chart/fl_bar_chart_adapter.dart
+++ b/packages/mix_chart/lib/src/backend/fl_chart/fl_bar_chart_adapter.dart
@@ -100,7 +100,11 @@ final class _FlBarChartAdapterState extends State<FlBarChartAdapter> {
       label: fl.BarChartRodLabel(
         show: presentation.label != null,
         text: formatter(bar.toY),
-        style: presentation.label?.spec.style,
+        style:
+            widget.spec.bar?.spec.label?.spec.style?.merge(
+              presentation.label?.spec.style,
+            ) ??
+            presentation.label?.spec.style,
         angle: presentation.labelAngle ?? 0,
         offset: presentation.labelOffset ?? const Offset(0, 8),
       ),
@@ -130,7 +134,11 @@ final class _FlBarChartAdapterState extends State<FlBarChartAdapter> {
       gradient == null ? color : null,
       gradient: gradient,
       label: presentation.label == null ? null : segment.label,
-      labelStyle: presentation.label?.spec.style,
+      labelStyle:
+          widget.spec.segment?.spec.label?.spec.style?.merge(
+            presentation.label?.spec.style,
+          ) ??
+          presentation.label?.spec.style,
       borderSide: border,
     );
   }

--- a/packages/mix_chart/lib/src/backend/fl_chart/fl_pie_chart_adapter.dart
+++ b/packages/mix_chart/lib/src/backend/fl_chart/fl_pie_chart_adapter.dart
@@ -61,12 +61,15 @@ final class _FlPieChartAdapterState extends State<FlPieChartAdapter> {
           (presentation.radius ?? 80) +
           (selected ? (widget.spec.selectedSliceRadiusOffset ?? 8.0) : 0),
       showTitle: presentation.showLabel ?? true,
-      titleStyle: const TextStyle(
-        color: Colors.white,
-        fontSize: 12,
-        fontWeight: .w600,
-        height: 1.15,
-      ).merge(presentation.label?.spec.style),
+      titleStyle:
+          const TextStyle(
+                color: Colors.white,
+                fontSize: 12,
+                fontWeight: .w600,
+                height: 1.15,
+              )
+              .merge(widget.spec.slice?.spec.label?.spec.style)
+              .merge(presentation.label?.spec.style),
       title: '${slice.label}\n${formatter(slice.value)}',
       borderSide: presentation.border ?? .none,
       cornerRadius: presentation.cornerRadius ?? 0,

--- a/packages/mix_chart/test/item_label_composition_test.dart
+++ b/packages/mix_chart/test/item_label_composition_test.dart
@@ -1,0 +1,205 @@
+import 'package:fl_chart/fl_chart.dart' as fl;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mix/mix.dart';
+import 'package:mix_chart/mix_chart.dart';
+
+void main() {
+  for (final replace in [false, true]) {
+    testWidgets('explicit label typography wins replace=$replace', (
+      tester,
+    ) async {
+      final common = TextStyler().fontSize(24).fontWeight(FontWeight.w700);
+      final override = TextStyler()
+          .fontSize(17)
+          .color(Colors.red)
+          .inherit(!replace);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Column(
+            children: [
+              SizedBox(
+                width: 260,
+                height: 200,
+                child: PieChart(
+                  style: PieChartStyler().slice(PieSliceStyler().label(common)),
+                  slices: [
+                    PieSlice(
+                      id: 'p',
+                      label: 'Pie',
+                      value: 1,
+                      style: PieSliceStyler().label(override),
+                    ),
+                  ],
+                ),
+              ),
+              SizedBox(
+                width: 260,
+                height: 200,
+                child: BarChart(
+                  style: BarChartStyler()
+                      .bar(BarStyler().label(common))
+                      .segment(BarSegmentStyler().label(common)),
+                  groups: [
+                    BarGroup(
+                      id: 'g',
+                      label: 'Group',
+                      bars: [
+                        BarValue(
+                          id: 'b',
+                          label: 'Bar',
+                          toY: 4,
+                          style: BarStyler().label(override),
+                          segments: [
+                            BarSegment(
+                              id: 's',
+                              label: 'Segment',
+                              fromY: 0,
+                              toY: 4,
+                              style: BarSegmentStyler().label(override),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+      final pie = tester.widget<fl.PieChart>(find.byType(fl.PieChart));
+      final rod = tester
+          .widget<fl.BarChart>(find.byType(fl.BarChart))
+          .data
+          .barGroups
+          .single
+          .barRods
+          .single;
+      for (final text in [
+        pie.data.sections.single.titleStyle,
+        rod.label.style,
+        rod.rodStackItems.single.labelStyle,
+      ]) {
+        expect(text?.fontSize, 17);
+        expect(text?.color, Colors.red);
+        expect(text?.fontWeight, replace ? isNull : FontWeight.w700);
+        expect(text?.inherit, !replace);
+      }
+    });
+  }
+  testWidgets('per-slice color preserves common label typography', (
+    tester,
+  ) async {
+    final common = PieSliceStyler().label(
+      TextStyler().fontSize(24).fontWeight(FontWeight.w700),
+    );
+    final override = PieSliceStyler().label(TextStyler().color(Colors.red));
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SizedBox(
+          width: 320,
+          height: 280,
+          child: PieChart(
+            style: PieChartStyler().slice(common),
+            slices: [
+              PieSlice(id: 'base', label: 'Base', value: 1),
+              PieSlice(
+                id: 'override',
+                label: 'Override',
+                value: 1,
+                style: override,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    final context = tester.element(find.byType(fl.PieChart));
+    final composed = common
+        .merge(override)
+        .build(context)
+        .spec
+        .label!
+        .spec
+        .style!;
+    expect(composed.fontSize, 24);
+    expect(composed.fontWeight, FontWeight.w700);
+    expect(composed.color, Colors.red);
+    final sections = tester
+        .widget<fl.PieChart>(find.byType(fl.PieChart))
+        .data
+        .sections;
+    expect(sections.first.titleStyle?.fontSize, 24);
+    expect(sections.last.titleStyle?.color, Colors.red);
+    expect(sections.last.titleStyle?.fontSize, 24);
+    expect(sections.last.titleStyle?.fontWeight, FontWeight.w700);
+  });
+  for (final segment in [false, true]) {
+    testWidgets('item colors preserve common label fonts segment=$segment', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SizedBox(
+            width: 320,
+            height: 280,
+            child: BarChart(
+              style: BarChartStyler()
+                  .bar(
+                    BarStyler().label(
+                      TextStyler().fontSize(24).fontWeight(FontWeight.w700),
+                    ),
+                  )
+                  .segment(
+                    BarSegmentStyler().label(
+                      TextStyler().fontSize(22).fontWeight(FontWeight.w500),
+                    ),
+                  ),
+              groups: [
+                BarGroup(
+                  id: 'g',
+                  label: 'Group',
+                  bars: [
+                    BarValue(
+                      id: 'b',
+                      label: 'Bar',
+                      toY: 4,
+                      style: BarStyler().label(TextStyler().color(Colors.red)),
+                      segments: [
+                        BarSegment(
+                          id: 's',
+                          label: 'Segment',
+                          fromY: 0,
+                          toY: 4,
+                          style: BarSegmentStyler().label(
+                            TextStyler().color(Colors.blue),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+      final rod = tester
+          .widget<fl.BarChart>(find.byType(fl.BarChart))
+          .data
+          .barGroups
+          .single
+          .barRods
+          .single;
+      expect(rod.label.style?.color, Colors.red);
+      expect(rod.rodStackItems.single.labelStyle?.color, Colors.blue);
+      final text = segment
+          ? rod.rodStackItems.single.labelStyle
+          : rod.label.style;
+      expect(text?.fontSize, segment ? 22 : 24);
+      expect(text?.fontWeight, segment ? FontWeight.w500 : FontWeight.w700);
+    });
+  }
+}

--- a/packages/mix_chart/test/item_label_context_test.dart
+++ b/packages/mix_chart/test/item_label_context_test.dart
@@ -1,0 +1,135 @@
+import 'package:fl_chart/fl_chart.dart' as fl;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mix/mix.dart';
+import 'package:mix_chart/mix_chart.dart';
+
+void main() {
+  for (final raw in [false, true]) {
+    testWidgets('item typography updates with context raw=$raw', (
+      tester,
+    ) async {
+      final dark = ValueNotifier(false);
+      addTearDown(dark.dispose);
+      final common = TextStyler()
+          .fontSize(20)
+          .fontFamily('Common')
+          .letterSpacing(1.5)
+          .onDark(.fontSize(28));
+      final override = TextStyler()
+          .color(Colors.red)
+          .onDark(.color(Colors.blue));
+      const rawText = StyleSpec(
+        spec: TextSpec(
+          style: TextStyle(fontSize: 31, fontFamily: 'Raw', letterSpacing: 2),
+        ),
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ValueListenableBuilder<bool>(
+            valueListenable: dark,
+            builder: (_, value, _) => MediaQuery(
+              data: MediaQueryData(
+                platformBrightness: value ? Brightness.dark : Brightness.light,
+              ),
+              child: Column(
+                children: [
+                  SizedBox(
+                    width: 260,
+                    height: 200,
+                    child: PieChart(
+                      style: PieChartStyler().slice(
+                        PieSliceStyler().label(common),
+                      ),
+                      styleSpec: raw
+                          ? const StyleSpec(
+                              spec: PieChartSpec(
+                                slice: StyleSpec(
+                                  spec: PieSliceSpec(label: rawText),
+                                ),
+                              ),
+                            )
+                          : null,
+                      slices: [
+                        PieSlice(
+                          id: 'p',
+                          label: 'Pie',
+                          value: 1,
+                          style: PieSliceStyler().label(override),
+                        ),
+                      ],
+                    ),
+                  ),
+                  SizedBox(
+                    width: 260,
+                    height: 200,
+                    child: BarChart(
+                      style: BarChartStyler()
+                          .bar(BarStyler().label(common))
+                          .segment(BarSegmentStyler().label(common)),
+                      styleSpec: raw
+                          ? const StyleSpec(
+                              spec: BarChartSpec(
+                                bar: StyleSpec(spec: BarSpec(label: rawText)),
+                                segment: StyleSpec(
+                                  spec: BarSegmentSpec(label: rawText),
+                                ),
+                              ),
+                            )
+                          : null,
+                      groups: [
+                        BarGroup(
+                          id: 'g',
+                          label: 'Group',
+                          bars: [
+                            BarValue(
+                              id: 'b',
+                              label: 'Bar',
+                              toY: 4,
+                              style: BarStyler().label(override),
+                              segments: [
+                                BarSegment(
+                                  id: 's',
+                                  label: 'Segment',
+                                  fromY: 0,
+                                  toY: 4,
+                                  style: BarSegmentStyler().label(override),
+                                ),
+                              ],
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      for (final value in [false, true, false]) {
+        dark.value = value;
+        await tester.pump();
+        final pie = tester.widget<fl.PieChart>(find.byType(fl.PieChart));
+        final rod = tester
+            .widget<fl.BarChart>(find.byType(fl.BarChart))
+            .data
+            .barGroups
+            .single
+            .barRods
+            .single;
+        for (final text in [
+          pie.data.sections.single.titleStyle,
+          rod.label.style,
+          rod.rodStackItems.single.labelStyle,
+        ]) {
+          expect(text?.fontSize, raw ? 31 : (value ? 28 : 20));
+          expect(text?.fontFamily, raw ? 'Raw' : 'Common');
+          expect(text?.letterSpacing, raw ? 2 : 1.5);
+          expect(text?.color, value ? Colors.blue : Colors.red);
+        }
+      }
+    });
+  }
+}


### PR DESCRIPTION
#### Related issue

No linked issue.

### Description

Per-item label colors replaced common typography for pie slices, bars and stacked segments. Compose the common and item TextStyle values at the renderer boundary using Flutter merge semantics.

### Changes

- Preserve unspecified common typography while explicit item values and `inherit: false` still win.
- Keep visibility, content, geometry and public APIs unchanged.
- Add seven regressions covering partial/explicit overrides, replacement, raw specs and live context updates.

**Review Checklist**

- [x] **Testing**: Local generation, workspace tests and analysis passed; exact-head CI passed (run 34566307473).
- [ ] **Breaking Changes**: No API change; previously dropped common font settings now render.
- [ ] **Documentation Updates**: Existing presentation contracts apply; no new TextSpec layout/directive support.
- [ ] **Website Updates**: No website change required.

### Additional Information (optional)

- `melos run gen:build && melos run ci && melos run analyze` passed.
- Two context tests were added after the full test phase; all seven focused tests and final targeted Dart/DCM analysis passed afterward.
- Three independent baseline regressions failed before the fix.
- Adversarial review: KEEP, medium confidence.
- Before/after Flutter captures passed and were inspected. Exact-head CI also passed.

Before:
![Common label fonts dropped by item color overrides](https://github.com/user-attachments/assets/31beea18-b5b7-4a76-bf92-2a02e8c49b57)

After:
![Common typography preserved with item colors](https://github.com/user-attachments/assets/b7ab125d-745c-4b95-a72a-52d574666964)
