### PR TITLE
ci: cancel superseded pull request runs

### DIFF
--- a/.github/workflows/title_validation.yml
+++ b/.github/workflows/title_validation.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   pull-requests: read
 
+concurrency:
+  group: pr-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
+
 jobs:
   main:
     timeout-minutes: 5


### PR DESCRIPTION
#### Related issue

No linked issue; CI maintenance.

### Description

New pushes currently leave superseded pull-request runs executing. Cancel older runs of each changed workflow for the same PR so runner time is spent on the latest commit. Other PRs and non-PR runs retain their existing behavior.

### Changes

- `.github/workflows/title_validation.yml`

**Review Checklist**

- [x] **Testing**: Workflow YAML and structural checks passed.
- [ ] **Testing**: Live cancellation verified after the base-branch workflow is updated.
- **Breaking Changes**: None.
- **Documentation Updates**: Not applicable; package behavior is unchanged.
- **Website Updates**: Not applicable.

### Additional Information

- YAML parsing and structural comparison passed: only `concurrency` changed.
- `git diff --no-index --check` found no whitespace errors.
- `actionlint -shellcheck= -pyflakes=` passed for every changed workflow.

Application suites were not run locally for this workflow-only patch. Keep this PR in draft until applicable CI completes. Live cancellation behavior remains to be checked by pushing again while a PR run is active; a `pull_request_target` workflow uses the base-branch definition until this change is merged.


## CI verification snapshot

All reported checks for commit `a4070d9b33cf0a5c71e9c6ece2612aa0874e101a` have completed successfully or were intentionally skipped, as of 2026-09-11T16:04:36+00:00. No failing or pending checks were reported.
