### PR TITLE
fix(mix_generator): avoid redundant widget field qualifiers

### DIFF
--- a/packages/mix_generator/CHANGELOG.md
+++ b/packages/mix_generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Avoid unnecessary `this` qualifiers in generated `@MixWidget` build methods while preserving forwarding for fields named `context`.
+
 ## 2.2.0-beta.3
 
  - **FEAT**: Emit a complete `$stylerFieldNames` inventory for generated

--- a/packages/mix_generator/lib/src/core/builders/mix_widget_builder.dart
+++ b/packages/mix_generator/lib/src/core/builders/mix_widget_builder.dart
@@ -112,7 +112,7 @@ class MixWidgetBuilder {
   /// Emits the `build` method that delegates to the styler's `call()`.
   void _writeBuildMethod(StringBuffer buffer) {
     buffer.writeln('  @override');
-    buffer.writeln('  Widget build(BuildContext context) {');
+    buffer.writeln('  Widget build(BuildContext _) {');
 
     final invocation = model.isFunctionFactory
         ? '${model.factoryReference}(${_factoryArgs()})'
@@ -156,12 +156,11 @@ class MixWidgetBuilder {
         '$targetTypeReference${model.typeParameterInvocation}'
         '$constructorSuffix';
     final args = [
-      for (final p in model.callParams.where((p) => p.isPositional))
-        'this.${p.name}',
-      if (model.stylerCallForwardsKey) 'key: this.key',
+      for (final p in model.callParams.where((p) => p.isPositional)) p.name,
+      if (model.stylerCallForwardsKey) 'key: key',
       'style: $styleInvocation',
       for (final p in model.callParams.where((p) => !p.isPositional))
-        '${p.name}: this.${p.name}',
+        '${p.name}: ${p.name}',
     ];
 
     buffer.writeln('    return $target(');
@@ -172,15 +171,15 @@ class MixWidgetBuilder {
   }
 
   /// Renders the comma-separated argument list passed to the factory function.
-  /// Positionals and named params are read through `this` so generated field
-  /// names cannot be shadowed by locals in `build`.
+  /// The unused build context is a wildcard, so fields named `context`
+  /// remain accessible without redundant `this` qualifiers.
   String _factoryArgs() {
     final positional = model.factoryParams
         .where((p) => p.isPositional)
-        .map((p) => 'this.${p.name}');
+        .map((p) => p.name);
     final named = model.factoryParams
         .where((p) => !p.isPositional)
-        .map((p) => '${p.name}: this.${p.name}');
+        .map((p) => '${p.name}: ${p.name}');
 
     return [...positional, ...named].join(', ');
   }
@@ -188,11 +187,10 @@ class MixWidgetBuilder {
   /// Renders the lines passed to `.call(...)`.
   List<String> _callArgs() {
     return [
-      for (final p in model.callParams.where((p) => p.isPositional))
-        'this.${p.name}',
-      if (model.stylerCallForwardsKey) 'key: this.key',
+      for (final p in model.callParams.where((p) => p.isPositional)) p.name,
+      if (model.stylerCallForwardsKey) 'key: key',
       for (final p in model.callParams.where((p) => !p.isPositional))
-        '${p.name}: this.${p.name}',
+        '${p.name}: ${p.name}',
     ];
   }
 

--- a/packages/mix_generator/test/core/builders/mix_widget_builder_test.dart
+++ b/packages/mix_generator/test/core/builders/mix_widget_builder_test.dart
@@ -1,9 +1,72 @@
+import 'dart:io';
+
 import 'package:mix_generator/src/core/builders/mix_widget_builder.dart';
 import 'package:mix_generator/src/core/models/mix_widget_model.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('MixWidgetBuilder', () {
+    test(
+      'generated build is lint-clean and preserves a context field',
+      () async {
+        final code = MixWidgetBuilder(
+          const MixWidgetModel(
+            widgetName: 'Demo',
+            factoryReference: 'demoStyle',
+            isFunctionFactory: true,
+            factoryParams: [
+              WidgetCallParam(
+                name: 'context',
+                typeCode: 'String',
+                isPositional: false,
+                isRequired: true,
+              ),
+            ],
+            callParams: [
+              WidgetCallParam(
+                name: 'label',
+                typeCode: 'String',
+                isPositional: false,
+                isRequired: true,
+              ),
+            ],
+            stylerCallForwardsKey: true,
+          ),
+        ).build();
+        final directory = Directory.systemTemp.createTempSync(
+          'mix-widget-lint-',
+        );
+        addTearDown(() => directory.deleteSync(recursive: true));
+        File(
+          '${directory.path}/analysis_options.yaml',
+        ).writeAsStringSync('linter:\n  rules:\n    unnecessary_this: true\n');
+        File('${directory.path}/example.dart').writeAsStringSync('''
+class Key { const Key(); }
+class BuildContext {}
+class Widget { const Widget({this.key}); final Key? key; }
+abstract class StatelessWidget extends Widget {
+  const StatelessWidget({super.key});
+  Widget build(BuildContext context);
+}
+class DemoStyle {
+  Widget call({Key? key, required String label}) => Widget(key: key);
+}
+DemoStyle demoStyle({required String context}) => DemoStyle();
+$code
+''');
+        final result = await Process.run(Platform.resolvedExecutable, [
+          'analyze',
+          '--fatal-infos',
+          directory.path,
+        ]);
+        expect(
+          result.exitCode,
+          0,
+          reason: '${result.stdout}\n${result.stderr}',
+        );
+      },
+    );
+
     test('variable-backed style with child + key', () {
       final builder = MixWidgetBuilder(
         const MixWidgetModel(
@@ -29,8 +92,8 @@ void main() {
       expect(code, contains('const Card({super.key, this.child});'));
       expect(code, contains('final Widget? child;'));
       expect(code, contains('return cardStyle.call('));
-      expect(code, contains('key: this.key,'));
-      expect(code, contains('child: this.child,'));
+      expect(code, contains('key: key,'));
+      expect(code, contains('child: child,'));
     });
 
     test('function-backed style threads factory args before call', () {
@@ -73,9 +136,7 @@ void main() {
       expect(code, contains('this.child'));
       expect(
         code,
-        contains(
-          'return badgeStyle(color: this.color, style: this.style).call(',
-        ),
+        contains('return badgeStyle(color: color, style: style).call('),
       );
     });
 
@@ -112,8 +173,8 @@ void main() {
         code,
         contains('const Label(this.text, {super.key, this.color});'),
       );
-      expect(code, contains('return labelStyle(color: this.color).call('));
-      expect(code, contains('      this.text,\n      key: this.key,'));
+      expect(code, contains('return labelStyle(color: color).call('));
+      expect(code, contains('      text,\n      key: key,'));
     });
 
     test('required call params surface required keyword', () {
@@ -154,8 +215,8 @@ void main() {
       expect(code, contains('required this.onPressed'));
       expect(code, contains('required this.child'));
       expect(code, contains('this.color = const Color(0xFF0000FF)'));
-      expect(code, contains('onPressed: this.onPressed,'));
-      expect(code, contains('child: this.child,'));
+      expect(code, contains('onPressed: onPressed,'));
+      expect(code, contains('child: child,'));
     });
 
     test('no Key? key on styler call → no key forwarding in build', () {
@@ -173,7 +234,7 @@ void main() {
       final code = builder.build();
 
       expect(code, contains('return keyLessStyle.call();'));
-      expect(code, isNot(contains('key: this.key')));
+      expect(code, isNot(contains('key: key')));
     });
 
     test('generic styler call emits generic widget and forwards type args', () {
@@ -202,7 +263,7 @@ void main() {
       expect(code, contains('required this.value'));
       expect(code, contains('final T value;'));
       expect(code, contains('return fortalRadioStyle().call<T>('));
-      expect(code, contains('value: this.value,'));
+      expect(code, contains('value: value,'));
     });
 
     test('generic styler call preserves bounds', () {
@@ -377,7 +438,7 @@ class Card extends StatelessWidget {
   const Card({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext _) {
     return cardStyle.call();
   }
 }

--- a/packages/mix_generator/test/integration/generator_smoke_test.dart
+++ b/packages/mix_generator/test/integration/generator_smoke_test.dart
@@ -758,8 +758,8 @@ final cardStyle = const BoxStyler();
             contains('const Card({super.key, this.child});'),
             contains('final Widget? child;'),
             contains('return cardStyle.call('),
-            contains('key: this.key'),
-            contains('child: this.child'),
+            contains('key: key'),
+            contains('child: child'),
           ]),
         );
       },
@@ -806,9 +806,9 @@ final legacyStyle = const BoxStyler();
           contains('class Legacy extends StatelessWidget'),
           contains('final String? label;'),
           contains('final Widget? child;'),
-          contains('key: this.key'),
-          contains('label: this.label'),
-          contains('child: this.child'),
+          contains('key: key'),
+          contains('label: label'),
+          contains('child: child'),
         ]),
       );
     });
@@ -854,9 +854,9 @@ final allStyle = const BoxStyler();
           contains('class All extends StatelessWidget'),
           contains('final String? label;'),
           contains('final Widget? child;'),
-          contains('key: this.key'),
-          contains('label: this.label'),
-          contains('child: this.child'),
+          contains('key: key'),
+          contains('label: label'),
+          contains('child: child'),
         ]),
       );
     });
@@ -901,9 +901,9 @@ final emptyStyle = const BoxStyler();
         outputMatcher: allOf([
           contains('class Empty extends StatelessWidget'),
           contains('const Empty({super.key});'),
-          contains('return emptyStyle.call(key: this.key);'),
+          contains('return emptyStyle.call(key: key);'),
           isNot(contains('final Widget? child;')),
-          isNot(contains('child: this.child')),
+          isNot(contains('child: child')),
         ]),
       );
     });
@@ -960,7 +960,7 @@ class _Stub extends StatelessWidget {
           outputMatcher: allOf([
             contains('class External extends StatelessWidget'),
             contains('final Widget child;'),
-            contains('return externalStyle.call(this.child);'),
+            contains('return externalStyle.call(child);'),
             isNot(contains('optional')),
             isNot(contains('hidden')),
             isNot(contains('final String? build;')),
@@ -1017,10 +1017,10 @@ BoxStyler badgeStyle({String? child, Color? color, BoxStyler? style}) =>
             contains('final String? label;'),
             isNot(contains('final Widget? child;')),
             contains('return badgeStyle('),
-            contains('child: this.child'),
-            contains('color: this.color'),
-            contains('style: this.style'),
-            contains('label: this.label'),
+            contains('child: child'),
+            contains('color: color'),
+            contains('style: style'),
+            contains('label: label'),
           ]),
         );
       },
@@ -1235,9 +1235,9 @@ final genericCallStyle = const GenericCallStyler();
           contains('final Widget? child;'),
           isNot(contains('final T? value;')),
           contains('return genericCallStyle.call<T>('),
-          contains('key: this.key'),
-          contains('child: this.child'),
-          isNot(contains('value: this.value')),
+          contains('key: key'),
+          contains('child: child'),
+          isNot(contains('value: value')),
         ]),
       );
     });
@@ -1302,10 +1302,10 @@ RadioStyler fortalRadioStyle({Variant variant = Variant.surface}) =>
             contains('final T value;'),
             contains('final List<T> values;'),
             contains('return fortalRadioStyle('),
-            contains('variant: this.variant'),
+            contains('variant: variant'),
             contains('.call<T>('),
-            contains('value: this.value'),
-            contains('values: this.values'),
+            contains('value: value'),
+            contains('values: values'),
           ]),
         );
       },
@@ -1348,7 +1348,7 @@ final typedStyle = const TypedStyler();
           contains('required this.child'),
           contains('final T child;'),
           contains('return typedStyle.call<T>('),
-          contains('child: this.child'),
+          contains('child: child'),
         ]),
       );
     });
@@ -1395,9 +1395,9 @@ TextStyler labelStyle({Color? color}) => const TextStyler();
           contains('this.text'),
           contains('final String text;'),
           contains('final Color? color;'),
-          contains('return labelStyle(color: this.color).call('),
+          contains('return labelStyle(color: color).call('),
           contains('this.text'),
-          contains('key: this.key'),
+          contains('key: key'),
         ]),
       );
     });
@@ -1449,13 +1449,13 @@ ButtonStyler primaryButtonStyle({Color color = const Color(0xFF0000FF)}) =>
           contains('required this.onPressed'),
           contains('required this.child'),
           contains('this.color = const Color(0xFF0000FF)'),
-          // Formatter may wrap `primaryButtonStyle(color: this.color)` across
+          // Formatter may wrap `primaryButtonStyle(color: color)` across
           // lines; assert the call invocation without whitespace.
           contains('primaryButtonStyle('),
-          contains('color: this.color'),
+          contains('color: color'),
           contains('.call('),
-          contains('onPressed: this.onPressed'),
-          contains('child: this.child'),
+          contains('onPressed: onPressed'),
+          contains('child: child'),
         ]),
       );
     });
@@ -1503,8 +1503,8 @@ final keyLessStyle = const BoxStyler();
             contains('class KeyLess extends StatelessWidget'),
             contains('const KeyLess({super.key, this.child});'),
             contains('return keyLessStyle.call('),
-            contains('child: this.child'),
-            isNot(contains('key: this.key')),
+            contains('child: child'),
+            isNot(contains('key: key')),
           ]),
         );
       },
@@ -1551,10 +1551,8 @@ final cardStyle = const BoxStyler();
       );
     });
 
-    test(
-      'BuildContext param named context forwards from this.context',
-      () async {
-        const source = r'''
+    test('BuildContext field named context is not shadowed by build', () async {
+      const source = r'''
 library widget_case;
 
 import 'package:flutter/widgets.dart';
@@ -1580,32 +1578,29 @@ class _Stub extends StatelessWidget {
 BoxStyler contextualStyle({BuildContext? context}) => const BoxStyler();
 ''';
 
-        await expectGeneratorOutputResolves(
-          builder: partBuilder(const MixWidgetGenerator()),
-          sources: {
-            ...mixAnnotationsSources,
-            ...widgetStub,
-            'mix|lib/src/core/style.dart': styleStub,
-            'mix_generator|lib/widget_case.dart': source,
-          },
-          inputAsset: 'mix_generator|lib/widget_case.dart',
-          outputAsset: 'mix_generator|lib/widget_case.g.dart',
-          outputMatcher: allOf([
-            contains('class Contextual extends StatelessWidget'),
-            contains('final BuildContext? context;'),
-            contains('return contextualStyle('),
-            contains('context: this.context'),
-            contains('key: this.key'),
-            contains('child: this.child'),
-          ]),
-        );
-      },
-    );
+      await expectGeneratorOutputResolves(
+        builder: partBuilder(const MixWidgetGenerator()),
+        sources: {
+          ...mixAnnotationsSources,
+          ...widgetStub,
+          'mix|lib/src/core/style.dart': styleStub,
+          'mix_generator|lib/widget_case.dart': source,
+        },
+        inputAsset: 'mix_generator|lib/widget_case.dart',
+        outputAsset: 'mix_generator|lib/widget_case.g.dart',
+        outputMatcher: allOf([
+          contains('class Contextual extends StatelessWidget'),
+          contains('final BuildContext? context;'),
+          contains('return contextualStyle('),
+          contains('context: context'),
+          contains('key: key'),
+          contains('child: child'),
+        ]),
+      );
+    });
 
-    test(
-      'function-backed style resolves with this-qualified factory and call args',
-      () async {
-        const source = r'''
+    test('function-backed style forwards factory and call fields', () async {
+      const source = r'''
 library widget_case;
 
 import 'package:flutter/widgets.dart';
@@ -1631,26 +1626,25 @@ class _Stub extends StatelessWidget {
 BoxStyler chipStyle(Color color, {BoxStyler? style}) => const BoxStyler();
 ''';
 
-        await expectGeneratorOutputResolves(
-          builder: partBuilder(const MixWidgetGenerator()),
-          sources: {
-            ...mixAnnotationsSources,
-            ...widgetStub,
-            'mix|lib/src/core/style.dart': styleStub,
-            'mix_generator|lib/widget_case.dart': source,
-          },
-          inputAsset: 'mix_generator|lib/widget_case.dart',
-          outputAsset: 'mix_generator|lib/widget_case.g.dart',
-          outputMatcher: allOf([
-            contains('class Chip extends StatelessWidget'),
-            contains('return chipStyle('),
-            contains('this.color'),
-            contains('style: this.style'),
-            contains('key: this.key'),
-            contains('child: this.child'),
-          ]),
-        );
-      },
-    );
+      await expectGeneratorOutputResolves(
+        builder: partBuilder(const MixWidgetGenerator()),
+        sources: {
+          ...mixAnnotationsSources,
+          ...widgetStub,
+          'mix|lib/src/core/style.dart': styleStub,
+          'mix_generator|lib/widget_case.dart': source,
+        },
+        inputAsset: 'mix_generator|lib/widget_case.dart',
+        outputAsset: 'mix_generator|lib/widget_case.g.dart',
+        outputMatcher: allOf([
+          contains('class Chip extends StatelessWidget'),
+          contains('return chipStyle('),
+          contains('this.color'),
+          contains('style: style'),
+          contains('key: key'),
+          contains('child: child'),
+        ]),
+      );
+    });
   });
 }

--- a/packages/mix_generator/test/integration/mix_widget_spec_styler_test.dart
+++ b/packages/mix_generator/test/integration/mix_widget_spec_styler_test.dart
@@ -257,9 +257,7 @@ ButtonStyler buttonStyle({Color? color}) => ButtonStyler(color: color);
           contains('final Widget? child;'),
           // build() delegates through the factory to the styler call().
           contains('buttonStyle('),
-          contains(
-            '.call(key: this.key, label: this.label, child: this.child)',
-          ),
+          contains('.call(key: key, label: label, child: child)'),
         ]),
       );
     });
@@ -319,8 +317,8 @@ final ButtonStyler cardStyle = ButtonStyler(color: Color(0xFF000000));
         outputMatcher: allOf([
           contains('class Card extends StatelessWidget {'),
           contains(
-            'cardStyle.call(key: this.key, label: this.label, '
-            'child: this.child)',
+            'cardStyle.call(key: key, label: label, '
+            'child: child)',
           ),
         ]),
       );
@@ -481,13 +479,13 @@ ButtonStyler fortalButtonStyler({
           isNot(contains('final Style<ButtonSpec> style;')),
           isNot(contains('final StyleSpec<ButtonSpec>? styleSpec;')),
           contains('return PlainButton('),
-          contains('key: this.key,'),
+          contains('key: key,'),
           contains(
-            'style: fortalButtonStyler(variant: this.variant, '
-            'size: this.size),',
+            'style: fortalButtonStyler(variant: variant, '
+            'size: size),',
           ),
-          contains('label: this.label,'),
-          contains('child: this.child,'),
+          contains('label: label,'),
+          contains('child: child,'),
           isNot(contains('.call(')),
         ]),
       );
@@ -540,7 +538,7 @@ RadioStyler fortalRadioStyler() => RadioStyler();
           contains('final T value;'),
           contains('return PlainRadio<T>('),
           contains('style: fortalRadioStyler(),'),
-          contains('value: this.value,'),
+          contains('value: value'),
         ]),
       );
     });

--- a/packages/mix_generator/test/integration/mix_widget_variant_constructor_test.dart
+++ b/packages/mix_generator/test/integration/mix_widget_variant_constructor_test.dart
@@ -167,8 +167,8 @@ ButtonStyler buttonStyle({
             contains('const Button.solid('),
             contains('const Button.ghost('),
             isNot(contains('final Widget? child;')),
-            isNot(contains('child: this.child')),
-            contains('label: this.label'),
+            isNot(contains('child: child')),
+            contains('label: label'),
           ]),
         );
       },


### PR DESCRIPTION
#### Related issue

Follow-up to the generator lint workaround used by Remix; no linked issue.

### Description

Generated `@MixWidget` build methods trigger `unnecessary_this` warnings when consumers analyze generated code. Forward widget fields without redundant qualifiers and use an unnamed build context so a field named `context` still reaches the target correctly. Constructor field formals and the generated public API are unchanged.

### Changes

- Update factory, call, and direct widget-constructor forwarding.
- Add an analyzer regression test that fails on the original warnings and verifies a `context` field is not shadowed.
- Update expected generated output and add an unreleased changelog entry.

### Validation

- `dart test` in `packages/mix_generator`: 378 tests passed.
- `melos run gen:build`: passed; checked-in generated output remains current.
- `melos run ci`: all Flutter and Dart package tests passed.
- `melos run analyze`: schema inventories, Dart analysis, and DCM passed.
- Changed Dart files formatted; `git diff --check` passed.

**Review Checklist**

- [x] **Testing**: Unit, integration, and analyzer regression coverage passed.
- [ ] **Breaking Changes**: No public API changes.
- [x] **Documentation Updates**: Generator documentation and changelog updated.
- [ ] **Website Updates**: No website changes needed.
