### PR TITLE
chore(mix_chart): prepare 0.0.1-beta.3

### DIFF
--- a/packages/mix_chart/CHANGELOG.md
+++ b/packages/mix_chart/CHANGELOG.md
@@ -1,21 +1,24 @@
+## 0.0.1-beta.3
+
+- Fix axis labels ignoring supported text settings.
+- Fix pie tooltip text styling and line/bar tooltip alignment and direction.
+- Honor pie tooltip fitting flags; disabling fitting allows overflow.
+- Preserve shared label typography when individual items override text styles.
+
+Corrected text settings may require more label space; clipping is not generally
+resolved. Dependency and SDK minimums are unchanged.
+
 ## 0.0.1-beta.2
 
-- Regenerates chart Stylers with source-field metadata and requires the Mix
-  release that defines the metadata contract.
+- Add source-field metadata to generated Stylers; require Mix 2.2.0-beta.5.
 
 ## 0.0.1-beta.1
 
-- Adds `PieChartStyler.selectedSliceRadiusOffset` to customize or disable the
-  selected-slice expansion while preserving the existing 8-pixel default.
+- Add `PieChartStyler.selectedSliceRadiusOffset` to control selection expansion
+  (default: 8 pixels).
 
 ## 0.0.1-beta.0
 
-- Introduces Mix-owned `LineChart`, `BarChart`, and `PieChart` widgets.
-- Adds backend-neutral data, axis, viewport, interaction, tooltip, animation,
-  selection, and accessibility contracts.
-- Adds generated Specs and fluent Stylers for line/area, grouped/stacked/
-  floating bar, and pie/donut presentation.
-- Keeps `fl_chart` behind a private adapter boundary; consumers use no renderer
-  types.
-- Adds a polished gallery, interactive playground, dashboard, screenshots,
-  release wiring, and publish-readiness verification.
+- Introduce Mix-styled line/area, grouped/stacked/floating bar, and pie/donut charts.
+- Add axes, tooltips, selection, animation, and accessibility support.
+- Add a gallery, interactive playground, and dashboard example.

--- a/packages/mix_chart/pubspec.yaml
+++ b/packages/mix_chart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mix_chart
 description: Type-safe Flutter chart widgets styled with Mix.
-version: 0.0.1-beta.2
+version: 0.0.1-beta.3
 homepage: https://github.com/btwld/mix
 repository: https://github.com/btwld/mix/tree/main/packages/mix_chart
 

--- a/packages/mix_chart/test/publish_contract_test.dart
+++ b/packages/mix_chart/test/publish_contract_test.dart
@@ -10,9 +10,9 @@ void main() {
     expect(pubspec, contains(RegExp(r'^name: mix_chart$', multiLine: true)));
     expect(
       pubspec,
-      contains(RegExp(r'^version: 0\.0\.1-beta\.2$', multiLine: true)),
+      contains(RegExp(r'^version: 0\.0\.1-beta\.3$', multiLine: true)),
     );
-    expect(changelog, startsWith('## 0.0.1-beta.2\n'));
+    expect(changelog, startsWith('## 0.0.1-beta.3\n'));
     expect(
       pubspec,
       isNot(contains('publish_to: none')),


### PR DESCRIPTION
#### Related issue

Release of the merged chart fixes in #1045–#1048.

### Description

Prepare `mix_chart 0.0.1-beta.3` with corrected axis-label and tooltip text handling, pie tooltip fitting, and shared label typography.

### Changes

- Bump only `mix_chart` and its release-contract test.
- Keep changelog entries concise, including the label-space caveat.
- Leave dependency and SDK minimums unchanged.

**Review Checklist**

- [x] **Testing**: Repository generation, tests, schema inventories, Dart analysis and DCM passed locally on Flutter 3.41.7. Chart tests (78), gallery tests (5), and chart analysis also passed against published Mix 2.2.0-beta.5.
- [ ] **Breaking Changes**: No new API changes; previously ignored text settings may require more label space.
- [x] **Documentation Updates**: Changelog updated.
- [ ] **Website Updates**: Not needed for this package-only release.

### Release

After final-head CI passes and this PR merges, publish through the existing `mix_chart-v0.0.1-beta.3` tag workflow. No core Mix or Remix release is included. A clean-checkout release verification passed all 78 chart tests against published Mix and `dart pub publish --dry-run` with zero warnings. Publication will repeat the workflow's mandatory dry-run.
